### PR TITLE
chore(tests): add tests to help prevent accidental changes to the output CSS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,15 @@
 'use strict';
 
-let { configs } = require('@nullvoxpopuli/eslint-configs');
+const { configs } = require('@nullvoxpopuli/eslint-configs');
+const { nodeMTS } = require('@nullvoxpopuli/eslint-configs/configs/node');
 
-module.exports = configs.nodeCJS();
+/**
+ * TODO: convert this library to ESM,
+ *     then we can "just" use configs.nodeTS()
+ */
+const config = configs.nodeCJS();
+
+module.exports = {
+  ...config,
+  overrides: [...config.overrides, ...nodeMTS],
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ env:
 
 jobs:
   tests:
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
-    name: Base Tests
+    name: Tests
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -23,15 +22,13 @@ jobs:
       - uses: volta-cli/action@v1
 
       - run: yarn install
-      - run: |
-          echo "No tests yet"
-          exit 1
+      - run: yarn test
 
   publish:
     name: Release
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-    needs: [tests, try-scenarios, floating-dependencies]
+    needs: [tests]
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /dist/
 /toucan.css
 /index.css
+/coverage/
+yarn-error.log

--- a/lib/build-preview.mjs
+++ b/lib/build-preview.mjs
@@ -1,10 +1,13 @@
 'use strict';
 
-const path = require('path');
-const fs = require('fs').promises;
-const fse = require('fs-extra');
-const execa = require('execa');
-const { stripIndent } = require('common-tags');
+import path from 'path';
+import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+import fse from 'fs-extra';
+import { execa } from 'execa';
+import { stripIndent } from 'common-tags';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const root = path.join(__dirname, '..');
 const targetDir = path.join(root, 'dist');

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
   "scripts": {
     "start": "yarn build && npx http-server ./dist",
     "build": "npm-run-all clean build:cdn build:alias build:preview",
-    "build:preview": "node ./lib/build-preview.js",
+    "build:preview": "node ./lib/build-preview.mjs",
     "build:cdn": "NODE_ENV=production tailwind build -i ./lib/index.css -o ./index.css -c ./lib/tailwind.config.cdn.js",
     "clean": "rm -f ./toucan.css ./index.css",
     "build:alias": "cp index.css toucan.css",
     "figma:export-styles": "figma-export use-config",
+    "test": "yarn vitest --coverage --run",
     "lint:fix": "yarn lint:js --fix",
     "lint:js": "eslint ."
   },
@@ -32,15 +33,19 @@
     "@nullvoxpopuli/eslint-configs": "2.2.16",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.1",
+    "@types/fs-extra": "^9.0.13",
     "autoprefixer": "^10.3.4",
+    "c8": "^7.11.2",
     "common-tags": "^1.8.2",
     "eslint": "^7.32.0",
-    "execa": "^5.1.1",
+    "execa": "^6.1.0",
     "fs-extra": "^10.1.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.3.6",
     "semantic-release": "^17.4.7",
-    "tailwind-config-viewer": "^1.7.0"
+    "tailwind-config-viewer": "^1.7.0",
+    "typescript": "^4.6.4",
+    "vitest": "0.12.4"
   },
   "engines": {
     "node": ">=14.15.0"
@@ -60,7 +65,7 @@
     ]
   },
   "volta": {
-    "node": "14.17.6",
+    "node": "16.15.0",
     "yarn": "1.22.11",
     "npm": "8.9.0"
   }

--- a/tests/-setup.ts
+++ b/tests/-setup.ts
@@ -1,0 +1,11 @@
+import { execa } from 'execa';
+
+// https://vitest.dev/config/#globalsetup
+// setup + teardown is a vitest convention for global setup files
+
+export async function setup() {
+  await execa('yarn', ['build'], { preferLocal: true });
+}
+
+// export async function teardown() {
+// }

--- a/tests/__snapshots__/cdn.test.ts.snap
+++ b/tests/__snapshots__/cdn.test.ts.snap
@@ -1,0 +1,38954 @@
+// Vitest Snapshot v1
+
+exports[`CDN > does not change unexpectedly 1`] = `
+"/*! tailwindcss v2.2.19 | MIT License | https://tailwindcss.com */
+
+/*! modern-normalize v1.1.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
+
+/*
+Document
+========
+*/
+
+/**
+Use a better box model (opinionated).
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
+
+/**
+Use a more readable tab size (opinionated).
+*/
+
+html {
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+     tab-size: 4;
+}
+
+/**
+1. Correct the line height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+*/
+
+html {
+  line-height: 1.15;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+}
+
+/*
+Sections
+========
+*/
+
+/**
+Remove the margin in all browsers.
+*/
+
+body {
+  margin: 0;
+}
+
+/**
+Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+*/
+
+body {
+  font-family:
+		system-ui,
+		-apple-system, /* Firefox supports this but not yet \`system-ui\` */
+		'Segoe UI',
+		Roboto,
+		Helvetica,
+		Arial,
+		sans-serif,
+		'Apple Color Emoji',
+		'Segoe UI Emoji';
+}
+
+/*
+Grouping content
+================
+*/
+
+/**
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+*/
+
+hr {
+  height: 0;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+}
+
+/*
+Text-level semantics
+====================
+*/
+
+/**
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr[title] {
+  -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
+}
+
+/**
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the odd 'em' font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family:
+		ui-monospace,
+		SFMono-Regular,
+		Consolas,
+		'Liberation Mono',
+		Menlo,
+		monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
+}
+
+/**
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/**
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+Tabular data
+============
+*/
+
+/**
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+*/
+
+table {
+  text-indent: 0;
+  /* 1 */
+  border-color: inherit;
+  /* 2 */
+}
+
+/*
+Forms
+=====
+*/
+
+/**
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  line-height: 1.15;
+  /* 1 */
+  margin: 0;
+  /* 2 */
+}
+
+/**
+Remove the inheritance of text transform in Edge and Firefox.
+1. Remove the inheritance of text transform in Firefox.
+*/
+
+button,
+select {
+  /* 1 */
+  text-transform: none;
+}
+
+/**
+Correct the inability to style clickable types in iOS and Safari.
+*/
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+}
+
+/**
+Remove the inner border and padding in Firefox.
+*/
+
+::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+Restore the focus styles unset by the previous rule.
+*/
+
+:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+Remove the additional ':invalid' styles in Firefox.
+See: https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737
+*/
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/**
+Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+*/
+
+legend {
+  padding: 0;
+}
+
+/**
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
+}
+
+/**
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to 'inherit' in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+}
+
+/*
+Interactive
+===========
+*/
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/**
+ * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * A thin layer on top of normalize.css that provides a starting point more
+ * suitable for web applications.
+ */
+
+/**
+ * Removes the default spacing and border for appropriate elements.
+ */
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+button {
+  background-color: transparent;
+  background-image: none;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+ol,
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/**
+ * Tailwind custom reset styles
+ */
+
+/**
+ * 1. Use the user's configured \`sans\` font-family (with Tailwind's default
+ *    sans-serif font stack as a fallback) as a sane default.
+ * 2. Use Tailwind's default \\"normal\\" line-height so the user isn't forced
+ *    to override it to ensure consistency even when using the default theme.
+ */
+
+html {
+  font-family: Calibre, sans-serif;
+  /* 1 */
+  line-height: 1.5;
+  /* 2 */
+}
+
+/**
+ * Inherit font-family and line-height from \`html\` so users can set them as
+ * a class directly on the \`html\` element.
+ */
+
+body {
+  font-family: inherit;
+  line-height: inherit;
+}
+
+/**
+ * 1. Prevent padding and border from affecting element width.
+ *
+ *    We used to set this in the html element and inherit from
+ *    the parent element for everything else. This caused issues
+ *    in shadow-dom-enhanced elements like <details> where the content
+ *    is wrapped by a div with box-sizing set to \`content-box\`.
+ *
+ *    https://github.com/mozdevs/cssremedy/issues/4
+ *
+ *
+ * 2. Allow adding a border to an element by just adding a border-width.
+ *
+ *    By default, the way the browser specifies that an element should have no
+ *    border is by setting it's border-style to \`none\` in the user-agent
+ *    stylesheet.
+ *
+ *    In order to easily add borders to elements by just setting the \`border-width\`
+ *    property, we change the default border-style for all elements to \`solid\`, and
+ *    use border-width to hide them instead. This way our \`border\` utilities only
+ *    need to set the \`border-width\` property instead of the entire \`border\`
+ *    shorthand, making our border utilities much more straightforward to compose.
+ *
+ *    https://github.com/tailwindcss/tailwindcss/pull/116
+ */
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  /* 1 */
+  border-width: 0;
+  /* 2 */
+  border-style: solid;
+  /* 2 */
+  border-color: currentColor;
+  /* 2 */
+}
+
+/*
+ * Ensure horizontal rules are visible by default
+ */
+
+hr {
+  border-top-width: 1px;
+}
+
+/**
+ * Undo the \`border-style: none\` reset that Normalize applies to images so that
+ * our \`border-{width}\` utilities have the expected effect.
+ *
+ * The Normalize reset is unnecessary for us since we default the border-width
+ * to 0 on all elements.
+ *
+ * https://github.com/tailwindcss/tailwindcss/issues/362
+ */
+
+img {
+  border-style: solid;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input::-moz-placeholder, textarea::-moz-placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+input:-ms-input-placeholder, textarea:-ms-input-placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+button,
+[role=\\"button\\"] {
+  cursor: pointer;
+}
+
+/**
+ * Override legacy focus reset from Normalize with modern Firefox focus styles.
+ *
+ * This is actually an improvement over the new defaults in Firefox in our testing,
+ * as it triggers the better focus styles even for links, which still use a dotted
+ * outline in Firefox by default.
+ */
+
+:-moz-focusring {
+  outline: auto;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/**
+ * Reset links to optimize for opt-in styling instead of
+ * opt-out.
+ */
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/**
+ * Reset form element properties that are easy to forget to
+ * style explicitly so you don't inadvertently introduce
+ * styles that deviate from your design system. These styles
+ * supplement a partial reset that is already applied by
+ * normalize.css.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  padding: 0;
+  line-height: inherit;
+  color: inherit;
+}
+
+/**
+ * Use the configured 'mono' font family for elements that
+ * are expected to be rendered with a monospace font, falling
+ * back to the system monospace stack if there is no configured
+ * 'mono' font family.
+ */
+
+pre,
+code,
+kbd,
+samp {
+  font-family: Monaco, monospace;
+}
+
+/**
+ * 1. Make replaced elements \`display: block\` by default as that's
+ *    the behavior you want almost all of the time. Inspired by
+ *    CSS Remedy, with \`svg\` added as well.
+ *
+ *    https://github.com/mozdevs/cssremedy/issues/14
+ * 
+ * 2. Add \`vertical-align: middle\` to align replaced elements more
+ *    sensibly by default when overriding \`display\` by adding a
+ *    utility like \`inline\`.
+ *
+ *    This can trigger a poorly considered linting error in some
+ *    tools but is included by design.
+ * 
+ *    https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210
+ */
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+  /* 1 */
+  vertical-align: middle;
+  /* 2 */
+}
+
+/**
+ * Constrain images and videos to the parent width and preserve
+ * their intrinsic aspect ratio.
+ *
+ * https://github.com/mozdevs/cssremedy/issues/14
+ */
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/**
+ * Ensure the default browser behavior of the \`hidden\` attribute.
+ */
+
+[hidden] {
+  display: none;
+}
+
+*, ::before, ::after {
+  border-color: currentColor;
+}
+
+.theme-dark {
+  --basement: #131217;
+  --blue: #1c9cfe;
+  --body-and-labels: #a6acb0;
+  --brand: #d31912;
+  --code-base-64: #e96e9d;
+  --code-bg: #232326;
+  --code-outline: #1c1c21;
+  --code-text: #9dc1fd;
+  --critical: #f64147;
+  --destructive-hover: #fa9497;
+  --destructive-idle: #1e1d20;
+  --destructive-pressed: #f9585d;
+  --disabled: #77798f;
+  --disc-operations: #db62f9;
+  --dns-requests: #8556fe;
+  --focus: #6688ff;
+  --graph-1: #4cd7f5;
+  --graph-10: #b7b7b7;
+  --graph-11: #efefef;
+  --graph-2: #8280ff;
+  --graph-3: #c179f6;
+  --graph-4: #ffc6c6;
+  --graph-5: #ef91b3;
+  --graph-6: #f69667;
+  --graph-7: #9cefae;
+  --graph-8: #fcdc5c;
+  --graph-9: #a06e6e;
+  --graph-disabled: #505265;
+  --ground-floor: #27262c;
+  --high: #f77d40;
+  --informational: #9dc1fd;
+  --lines-dark: #09090c;
+  --lines-light: #14141a;
+  --low: #cef2ce;
+  --medium: #ffcc00;
+  --mezzanine: #212121;
+  --nav-text-and-icons: #fafafa;
+  --nav-text-secondary: #a6acb0;
+  --network-operations: #fb5093;
+  --normal-hover: #63646e;
+  --normal-idle: #4e4f5a;
+  --normal-pressed: #3d3d48;
+  --overlay-0\\\\.5: #00000021;
+  --overlay-1: #00000040;
+  --overlay-2: #00000099;
+  --positive: #06e5b7;
+  --primary-hover: #e1ecfe;
+  --primary-idle: #c8dcfe;
+  --primary-pressed: #7d9bff;
+  --process-operations: #629cfb;
+  --purple: #b15af2;
+  --registry-operations: #5d63fe;
+  --selected: #7d9bff1a;
+  --surface-2xl: #3d3c40;
+  --surface-base: #26252a;
+  --surface-inner: #17161a;
+  --surface-lg: #343337;
+  --surface-md: #2d2c31;
+  --surface-xl: #38373c;
+  --text-and-icons: #fafafa;
+  --titles-and-attributes: #e2e2e4;
+}
+
+.theme-light {
+  --basement: #ebebeb;
+  --blue: #2469f0;
+  --body-and-labels: #767676;
+  --brand: #d31c12;
+  --code-base-64: #a8154e;
+  --code-bg: #ffffff;
+  --code-outline: #e5e5e5;
+  --code-text: #0b54c1;
+  --critical: #e9181f;
+  --destructive-hover: #f47479;
+  --destructive-idle: #ffffff;
+  --destructive-pressed: #e8121a;
+  --disabled: #949494;
+  --disc-operations: #b308dd;
+  --dns-requests: #4902fd;
+  --focus: #039eba;
+  --graph-1: #0f99a1;
+  --graph-10: #7478a1;
+  --graph-11: #3b364a;
+  --graph-2: #1c3cae;
+  --graph-3: #6b30ab;
+  --graph-4: #961574;
+  --graph-5: #ce4789;
+  --graph-6: #bf4815;
+  --graph-7: #946613;
+  --graph-8: #2e5c0e;
+  --graph-9: #684444;
+  --graph-disabled: #d3d3d3;
+  --ground-floor: #ffffff;
+  --high: #ff7e00;
+  --informational: #5082d2;
+  --lines-dark: #d9d9d9;
+  --lines-light: #eeeeee;
+  --low: #649f64;
+  --medium: #edb000;
+  --mezzanine: #242424;
+  --nav-text-and-icons: #fafafa;
+  --nav-text-secondary: #adadad;
+  --network-operations: #c70f57;
+  --normal-hover: #e8e8e8;
+  --normal-idle: #e0e0e0;
+  --normal-pressed: #adadad;
+  --overlay-0\\\\.5: #00000008;
+  --overlay-1: #0000000d;
+  --overlay-2: #00000026;
+  --positive: #1b8e67;
+  --primary-hover: #168093;
+  --primary-idle: #036678;
+  --primary-pressed: #025564;
+  --process-operations: #1055c6;
+  --purple: #8532c2;
+  --registry-operations: #0108c6;
+  --selected: #036d801a;
+  --surface-2xl: #ffffff;
+  --surface-base: #ffffff;
+  --surface-inner: #ededed;
+  --surface-lg: #ffffff;
+  --surface-md: #ffffff;
+  --surface-xl: #ffffff;
+  --text-and-icons: #202020;
+  --titles-and-attributes: #3d3d3d;
+}
+
+.theme-light .theme-mezzanine {
+  --blue: #1c9cfe;
+  --body-and-labels: #a6acb0;
+  --code-base-64: #e96e9d;
+  --code-text: #9dc1fd;
+  --critical: #f64147;
+  --destructive-hover: #fa9497;
+  --destructive-idle: #1e1d20;
+  --destructive-pressed: #f9585d;
+  --disabled: #77798f;
+  --disc-operations: #db62f9;
+  --dns-requests: #8556fe;
+  --focus: #039eba;
+  --ground-floor: #27262c;
+  --high: #f77d40;
+  --informational: #9dc1fd;
+  --lines-dark: #09090c;
+  --lines-light: #14141a;
+  --low: #cef2ce;
+  --medium: #ffcc00;
+  --mezzanine: #212121;
+  --network-operations: #fb5093;
+  --normal-hover: #5b5b5b;
+  --normal-idle: #454545;
+  --normal-pressed: #3a3a3a;
+  --overlay-1: #00000040;
+  --overlay-2: #00000099;
+  --positive: #06e5b7;
+  --primary-hover: #e9fbfb;
+  --primary-idle: #c9f8fd;
+  --primary-pressed: #039eba;
+  --process-operations: #629cfb;
+  --purple: #b15af2;
+  --registry-operations: #5d63fe;
+  --selected: #039eba1a;
+  --surface-2xl: #3c3c3c;
+  --surface-base: #252525;
+  --surface-inner: #1a1a1a;
+  --surface-lg: #333333;
+  --surface-md: #2c2c2c;
+  --surface-xl: #373737;
+  --text-and-icons: #fafafa;
+  --titles-and-attributes: #e2e2e4;
+}
+
+.theme-dark {
+  --elevation-2xl: 0px 25px 50px 0px rgba(0, 0, 0, 0.62);
+  --elevation-base: 0px 1px 2px 0px rgba(0, 0, 0, 0.46), 0px 1px 3px 0px rgba(0, 0, 0, 0.1);
+  --elevation-inner-lg: inset 0px 2px 4px 0px rgba(0, 0, 0, 0.36);
+  --elevation-inner-md: inset 0px 1px 2px 0px rgba(0, 0, 0, 0.25);
+  --elevation-lg: 0px 10px 15px 0px rgba(0, 0, 0, 0.3), 0px 4px 6px 0px rgba(0, 0, 0, 0.15);
+  --elevation-md: 0px 2px 4px 0px rgba(0, 0, 0, 0.33), 0px 4px 6px 0px rgba(0, 0, 0, 0.1);
+  --elevation-xl: 0px 20px 25px 0px rgba(0, 0, 0, 0.3), 0px 10px 10px 0px rgba(0, 0, 0, 0.12);
+}
+
+.theme-light {
+  --elevation-2xl: 0px 0px 7px 0px rgba(0, 0, 0, 0.08), 0px 25px 50px 0px rgba(0, 0, 0, 0.15);
+  --elevation-base: 0px 0px 1px 0px rgba(0, 0, 0, 0.07), 0px 1px 2px 0px rgba(0, 0, 0, 0.15);
+  --elevation-inner-lg: inset 0px 2px 5px 0px rgba(0, 0, 0, 0.09);
+  --elevation-inner-md: inset 0px 2px 4px 0px rgba(0, 0, 0, 0.08);
+  --elevation-lg: 0px 10px 15px 0px rgba(0, 0, 0, 0.08), 0px 0px 3px 0px rgba(0, 0, 0, 0.07);
+  --elevation-md: 0px 0px 4px 0px rgba(0, 0, 0, 0.06), 0px 3px 6px 0px rgba(0, 0, 0, 0.1);
+  --elevation-xl: 0px 20px 25px 0px rgba(0, 0, 0, 0.08), 0px 0px 4px 0px rgba(0, 0, 0, 0.08);
+}
+
+.theme-light .theme-mezzanine {
+  --elevation-2xl: 0px 25px 50px 0px rgba(0, 0, 0, 0.2);
+  --elevation-base: 0px 1px 2px 0px rgba(0, 0, 0, 0.06), 0px 1px 3px 0px rgba(0, 0, 0, 0.1);
+  --elevation-inner-lg: inset 0px 2px 5px 0px rgba(0, 0, 0, 0.09);
+  --elevation-inner-md: inset 0px 2px 4px 0px rgba(0, 0, 0, 0.08);
+  --elevation-lg: 0px 10px 15px 0px rgba(0, 0, 0, 0.1), 0px 4px 6px 0px rgba(0, 0, 0, 0.05);
+  --elevation-md: 0px 2px 4px 0px rgba(0, 0, 0, 0.06), 0px 4px 6px 0px rgba(0, 0, 0, 0.1);
+  --elevation-xl: 0px 20px 25px 0px rgba(0, 0, 0, 0.1), 0px 10px 10px 0px rgba(0, 0, 0, 0.04);
+}
+
+.container {
+  width: 100%;
+}
+
+@media (min-width: 1120px) {
+  .container {
+    max-width: 1120px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
+.focusable {
+  --tw-ring-color: var(--ground-floor);
+  --tw-ring-inset: inset;
+  --tw-ring-offset-width: 2px;
+  --tw-ring-offset-color: var(--focus);
+}
+
+.focusable:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focusable:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focusable-destructive {
+  --tw-ring-offset-color: var(--destructive-pressed);
+}
+
+.focusable-outer {
+  --tw-ring-offset-color: var(--ground-floor);
+  --tw-ring-offset-width: 1px;
+  --tw-ring-color: var(--focus);
+}
+
+.focusable-outer:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focusable-outer:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.interactive-normal {
+  background-color: var(--normal-idle);
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  color: var(--text-and-icons);
+}
+
+.interactive-normal:not(.interactive-disabled):hover {
+  background-color: var(--normal-hover);
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-normal:not(.interactive-disabled):focus-visible {
+  background-color: var(--normal-hover);
+}
+
+.interactive-normal:not(.interactive-disabled):active {
+  background-color: var(--normal-pressed);
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-primary {
+  background-color: var(--primary-idle);
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  color: var(--ground-floor);
+}
+
+.interactive-primary:not(.interactive-disabled):focus-visible {
+  background-color: var(--primary-hover);
+}
+
+.interactive-primary:not(.interactive-disabled):hover {
+  background-color: var(--primary-hover);
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-primary:not(.interactive-disabled):active {
+  background-color: var(--primary-pressed);
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-destructive {
+  background-color: var(--destructive-idle);
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  color: var(--destructive-pressed);
+}
+
+.interactive-destructive:not(.interactive-disabled):focus-visible {
+  background-color: var(--destructive-hover);
+  color: var(--ground-floor);
+}
+
+.interactive-destructive:not(.interactive-disabled):hover {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  background-color: var(--destructive-hover);
+  color: var(--ground-floor);
+}
+
+.interactive-destructive:not(.interactive-disabled):active {
+  background-color: var(--destructive-pressed);
+  color: var(--ground-floor);
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-link {
+  background-color: transparent;
+  color: var(--primary-idle);
+}
+
+.interactive-link:not(.interactive-disabled):hover {
+  --tw-bg-opacity: 0;
+  color: var(--primary-hover);
+}
+
+.interactive-link:not(.interactive-disabled):active {
+  color: var(--primary-pressed);
+}
+
+.interactive-quiet {
+  background-color: transparent;
+  color: var(--text-and-icons);
+}
+
+.interactive-quiet:not(.interactive-disabled):focus-visible {
+  background-color: var(--normal-hover);
+}
+
+.interactive-quiet:not(.interactive-disabled):hover {
+  background-color: var(--normal-hover);
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-quiet:not(.interactive-disabled):active {
+  background-color: var(--normal-pressed);
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-disabled {
+  background-color: var(--overlay-1);
+  cursor: default;
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  color: var(--disabled);
+}
+
+.interactive-quiet.interactive-disabled {
+  background-color: transparent;
+}
+
+.textbox {
+  background-color: var(--overlay-1);
+  border-radius: var(--border-radius);
+  box-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  color: var(--titles-and-attributes);
+  display: block;
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: var(--space-1) var(--space-2);
+  width: 100%;
+}
+
+.textbox:focus {
+  box-shadow: inset 0 0 0 2px var(--focus);;
+  outline: 0;
+}
+
+.textbox::-moz-placeholder {
+  color: var(--disabled);
+}
+
+.textbox:-ms-input-placeholder {
+  color: var(--disabled);
+}
+
+.textbox::placeholder {
+  color: var(--disabled);
+}
+
+.textarea {
+  background-color: var(--overlay-1);
+  border-radius: var(--border-radius);
+  box-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  color: var(--titles-and-attributes);
+  display: block;
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: var(--space-1) var(--space-2);
+  width: 100%;
+}
+
+.textarea:focus {
+  box-shadow: inset 0 0 0 2px var(--focus);;
+  outline: 0;
+}
+
+.textarea::-moz-placeholder {
+  color: var(--disabled);
+}
+
+.textarea:-ms-input-placeholder {
+  color: var(--disabled);
+}
+
+.textarea::placeholder {
+  color: var(--disabled);
+}
+
+.textarea {
+  min-height: 150px;
+  resize: vertical;
+}
+
+.type-4xl {
+  font-size: 3rem;
+  line-height: 3.25rem;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
+.type-3xl {
+  font-size: 2.5rem;
+  line-height: 3rem;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
+.type-2xl {
+  font-size: 2rem;
+  line-height: 2.5rem;
+  font-weight: 500;
+}
+
+.type-xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 500;
+  text-rendering: geometricPrecision;
+}
+
+.type-lg {
+  font-size: 1.25rem;
+  line-height: 2rem;
+}
+
+.type-lg-medium {
+  font-size: 1.25rem;
+  line-height: 2rem;
+  font-weight: 500;
+}
+
+.type-lg-tight-medium {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  font-weight: 500;
+  text-rendering: geometricPrecision;
+}
+
+.type-md {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.type-md-medium {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 500;
+}
+
+.type-md-underline {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  text-decoration: underline;
+}
+
+.type-md-tight {
+  font-size: 1rem;
+  line-height: 1.25rem;
+}
+
+.type-md-tight-medium {
+  font-size: 1rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  text-rendering: geometricPrecision;
+}
+
+.type-md-tight-underline {
+  font-size: 1rem;
+  line-height: 1.25rem;
+  text-decoration: underline;
+}
+
+.type-sm-mono {
+  font-size: .875rem;
+  line-height: 1.5rem;
+  font-family: Monaco, monospace;
+}
+
+.type-sm-mono-tight {
+  font-size: .875rem;
+  font-family: Monaco, monospace;
+  line-height: 1.25rem;
+}
+
+.type-sm-mono-underline {
+  font-size: .875rem;
+  line-height: 1.5rem;
+  font-family: Monaco, monospace;
+  text-decoration: underline;
+}
+
+.type-xs {
+  font-size: .75rem;
+  line-height: 1.25rem;
+}
+
+.type-xs-tight {
+  font-size: .75rem;
+  line-height: 1rem;
+}
+
+.type-xs-tight-underline {
+  font-size: .75rem;
+  line-height: 1rem;
+  text-decoration: underline;
+}
+
+.type-xs-mono {
+  font-size: .75rem;
+  line-height: 1.5rem;
+  font-family: Monaco, monospace;
+}
+
+.type-xxs-mono {
+  font-size: .5625rem;
+  line-height: 1rem;
+  font-family: Monaco, monospace;
+}
+
+.geometric-precision-text {
+  text-rendering: geometricPrecision;
+}
+
+:root {
+  --space-0: 0px;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-7: 1.75rem;
+  --space-8: 2rem;
+  --space-9: 2.25rem;
+  --space-10: 2.5rem;
+  --space-11: 2.75rem;
+  --space-12: 3rem;
+  --space-14: 3.5rem;
+  --space-16: 4rem;
+  --space-20: 5rem;
+  --space-24: 6rem;
+  --space-28: 7rem;
+  --space-32: 8rem;
+  --space-36: 9rem;
+  --space-40: 10rem;
+  --space-44: 11rem;
+  --space-48: 12rem;
+  --space-52: 13rem;
+  --space-56: 14rem;
+  --space-60: 15rem;
+  --space-64: 16rem;
+  --space-72: 18rem;
+  --space-80: 20rem;
+  --space-96: 24rem;
+  --space-px: 1px;
+  --space-0.5: 0.125rem;
+  --space-1.5: 0.375rem;
+  --space-2.5: 0.625rem;
+  --space-3.5: 0.875rem;
+  --space--0: 0px;
+  --space--1: -0.25rem;
+  --space--2: -0.5rem;
+  --space--3: -0.75rem;
+  --space--4: -1rem;
+  --space--5: -1.25rem;
+  --space--6: -1.5rem;
+  --space--7: -1.75rem;
+  --space--8: -2rem;
+  --space--9: -2.25rem;
+  --space--10: -2.5rem;
+  --space--11: -2.75rem;
+  --space--12: -3rem;
+  --space--14: -3.5rem;
+  --space--16: -4rem;
+  --space--20: -5rem;
+  --space--24: -6rem;
+  --space--28: -7rem;
+  --space--32: -8rem;
+  --space--36: -9rem;
+  --space--40: -10rem;
+  --space--44: -11rem;
+  --space--48: -12rem;
+  --space--52: -13rem;
+  --space--56: -14rem;
+  --space--60: -15rem;
+  --space--64: -16rem;
+  --space--72: -18rem;
+  --space--80: -20rem;
+  --space--96: -24rem;
+  --space--px: -1px;
+  --space--0.5: -0.125rem;
+  --space--1.5: -0.375rem;
+  --space--2.5: -0.625rem;
+  --space--3.5: -0.875rem;
+  --side-nav-width-collapsed: 122px;
+  --side-nav-width-expanded: 247px;
+  --tab-list-height: 40px;
+  --tab-height: 40px;
+  --tab-border-radius: 8px;
+  --process-offset-top: 40px;
+  --default-animation-duration: 125ms;
+  --default-animation-timing-function: ease-out;
+  --default-animation-settings: var(--default-animation-duration) var(--default-animation-timing-function);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.not-sr-only {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
+.focus\\\\:sr-only:focus {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.focus\\\\:not-sr-only:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
+.pointer-events-none {
+  pointer-events: none;
+}
+
+.pointer-events-auto {
+  pointer-events: auto;
+}
+
+.disabled\\\\:pointer-events-none:disabled {
+  pointer-events: none;
+}
+
+.disabled\\\\:pointer-events-auto:disabled {
+  pointer-events: auto;
+}
+
+.visible {
+  visibility: visible;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.static {
+  position: static;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.sticky {
+  position: -webkit-sticky;
+  position: sticky;
+}
+
+.hover\\\\:static:hover {
+  position: static;
+}
+
+.hover\\\\:fixed:hover {
+  position: fixed;
+}
+
+.hover\\\\:absolute:hover {
+  position: absolute;
+}
+
+.hover\\\\:relative:hover {
+  position: relative;
+}
+
+.hover\\\\:sticky:hover {
+  position: -webkit-sticky;
+  position: sticky;
+}
+
+.inset-0 {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.inset-1 {
+  top: 0.25rem;
+  right: 0.25rem;
+  bottom: 0.25rem;
+  left: 0.25rem;
+}
+
+.inset-2 {
+  top: 0.5rem;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  left: 0.5rem;
+}
+
+.inset-3 {
+  top: 0.75rem;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  left: 0.75rem;
+}
+
+.inset-4 {
+  top: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+}
+
+.inset-5 {
+  top: 1.25rem;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  left: 1.25rem;
+}
+
+.inset-6 {
+  top: 1.5rem;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  left: 1.5rem;
+}
+
+.inset-7 {
+  top: 1.75rem;
+  right: 1.75rem;
+  bottom: 1.75rem;
+  left: 1.75rem;
+}
+
+.inset-8 {
+  top: 2rem;
+  right: 2rem;
+  bottom: 2rem;
+  left: 2rem;
+}
+
+.inset-9 {
+  top: 2.25rem;
+  right: 2.25rem;
+  bottom: 2.25rem;
+  left: 2.25rem;
+}
+
+.inset-10 {
+  top: 2.5rem;
+  right: 2.5rem;
+  bottom: 2.5rem;
+  left: 2.5rem;
+}
+
+.inset-11 {
+  top: 2.75rem;
+  right: 2.75rem;
+  bottom: 2.75rem;
+  left: 2.75rem;
+}
+
+.inset-12 {
+  top: 3rem;
+  right: 3rem;
+  bottom: 3rem;
+  left: 3rem;
+}
+
+.inset-14 {
+  top: 3.5rem;
+  right: 3.5rem;
+  bottom: 3.5rem;
+  left: 3.5rem;
+}
+
+.inset-16 {
+  top: 4rem;
+  right: 4rem;
+  bottom: 4rem;
+  left: 4rem;
+}
+
+.inset-20 {
+  top: 5rem;
+  right: 5rem;
+  bottom: 5rem;
+  left: 5rem;
+}
+
+.inset-24 {
+  top: 6rem;
+  right: 6rem;
+  bottom: 6rem;
+  left: 6rem;
+}
+
+.inset-28 {
+  top: 7rem;
+  right: 7rem;
+  bottom: 7rem;
+  left: 7rem;
+}
+
+.inset-32 {
+  top: 8rem;
+  right: 8rem;
+  bottom: 8rem;
+  left: 8rem;
+}
+
+.inset-36 {
+  top: 9rem;
+  right: 9rem;
+  bottom: 9rem;
+  left: 9rem;
+}
+
+.inset-40 {
+  top: 10rem;
+  right: 10rem;
+  bottom: 10rem;
+  left: 10rem;
+}
+
+.inset-44 {
+  top: 11rem;
+  right: 11rem;
+  bottom: 11rem;
+  left: 11rem;
+}
+
+.inset-48 {
+  top: 12rem;
+  right: 12rem;
+  bottom: 12rem;
+  left: 12rem;
+}
+
+.inset-52 {
+  top: 13rem;
+  right: 13rem;
+  bottom: 13rem;
+  left: 13rem;
+}
+
+.inset-56 {
+  top: 14rem;
+  right: 14rem;
+  bottom: 14rem;
+  left: 14rem;
+}
+
+.inset-60 {
+  top: 15rem;
+  right: 15rem;
+  bottom: 15rem;
+  left: 15rem;
+}
+
+.inset-64 {
+  top: 16rem;
+  right: 16rem;
+  bottom: 16rem;
+  left: 16rem;
+}
+
+.inset-72 {
+  top: 18rem;
+  right: 18rem;
+  bottom: 18rem;
+  left: 18rem;
+}
+
+.inset-80 {
+  top: 20rem;
+  right: 20rem;
+  bottom: 20rem;
+  left: 20rem;
+}
+
+.inset-96 {
+  top: 24rem;
+  right: 24rem;
+  bottom: 24rem;
+  left: 24rem;
+}
+
+.inset-auto {
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+}
+
+.inset-px {
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  left: 1px;
+}
+
+.inset-0\\\\.5 {
+  top: 0.125rem;
+  right: 0.125rem;
+  bottom: 0.125rem;
+  left: 0.125rem;
+}
+
+.inset-1\\\\.5 {
+  top: 0.375rem;
+  right: 0.375rem;
+  bottom: 0.375rem;
+  left: 0.375rem;
+}
+
+.inset-2\\\\.5 {
+  top: 0.625rem;
+  right: 0.625rem;
+  bottom: 0.625rem;
+  left: 0.625rem;
+}
+
+.inset-3\\\\.5 {
+  top: 0.875rem;
+  right: 0.875rem;
+  bottom: 0.875rem;
+  left: 0.875rem;
+}
+
+.-inset-0 {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.-inset-1 {
+  top: -0.25rem;
+  right: -0.25rem;
+  bottom: -0.25rem;
+  left: -0.25rem;
+}
+
+.-inset-2 {
+  top: -0.5rem;
+  right: -0.5rem;
+  bottom: -0.5rem;
+  left: -0.5rem;
+}
+
+.-inset-3 {
+  top: -0.75rem;
+  right: -0.75rem;
+  bottom: -0.75rem;
+  left: -0.75rem;
+}
+
+.-inset-4 {
+  top: -1rem;
+  right: -1rem;
+  bottom: -1rem;
+  left: -1rem;
+}
+
+.-inset-5 {
+  top: -1.25rem;
+  right: -1.25rem;
+  bottom: -1.25rem;
+  left: -1.25rem;
+}
+
+.-inset-6 {
+  top: -1.5rem;
+  right: -1.5rem;
+  bottom: -1.5rem;
+  left: -1.5rem;
+}
+
+.-inset-7 {
+  top: -1.75rem;
+  right: -1.75rem;
+  bottom: -1.75rem;
+  left: -1.75rem;
+}
+
+.-inset-8 {
+  top: -2rem;
+  right: -2rem;
+  bottom: -2rem;
+  left: -2rem;
+}
+
+.-inset-9 {
+  top: -2.25rem;
+  right: -2.25rem;
+  bottom: -2.25rem;
+  left: -2.25rem;
+}
+
+.-inset-10 {
+  top: -2.5rem;
+  right: -2.5rem;
+  bottom: -2.5rem;
+  left: -2.5rem;
+}
+
+.-inset-11 {
+  top: -2.75rem;
+  right: -2.75rem;
+  bottom: -2.75rem;
+  left: -2.75rem;
+}
+
+.-inset-12 {
+  top: -3rem;
+  right: -3rem;
+  bottom: -3rem;
+  left: -3rem;
+}
+
+.-inset-14 {
+  top: -3.5rem;
+  right: -3.5rem;
+  bottom: -3.5rem;
+  left: -3.5rem;
+}
+
+.-inset-16 {
+  top: -4rem;
+  right: -4rem;
+  bottom: -4rem;
+  left: -4rem;
+}
+
+.-inset-20 {
+  top: -5rem;
+  right: -5rem;
+  bottom: -5rem;
+  left: -5rem;
+}
+
+.-inset-24 {
+  top: -6rem;
+  right: -6rem;
+  bottom: -6rem;
+  left: -6rem;
+}
+
+.-inset-28 {
+  top: -7rem;
+  right: -7rem;
+  bottom: -7rem;
+  left: -7rem;
+}
+
+.-inset-32 {
+  top: -8rem;
+  right: -8rem;
+  bottom: -8rem;
+  left: -8rem;
+}
+
+.-inset-36 {
+  top: -9rem;
+  right: -9rem;
+  bottom: -9rem;
+  left: -9rem;
+}
+
+.-inset-40 {
+  top: -10rem;
+  right: -10rem;
+  bottom: -10rem;
+  left: -10rem;
+}
+
+.-inset-44 {
+  top: -11rem;
+  right: -11rem;
+  bottom: -11rem;
+  left: -11rem;
+}
+
+.-inset-48 {
+  top: -12rem;
+  right: -12rem;
+  bottom: -12rem;
+  left: -12rem;
+}
+
+.-inset-52 {
+  top: -13rem;
+  right: -13rem;
+  bottom: -13rem;
+  left: -13rem;
+}
+
+.-inset-56 {
+  top: -14rem;
+  right: -14rem;
+  bottom: -14rem;
+  left: -14rem;
+}
+
+.-inset-60 {
+  top: -15rem;
+  right: -15rem;
+  bottom: -15rem;
+  left: -15rem;
+}
+
+.-inset-64 {
+  top: -16rem;
+  right: -16rem;
+  bottom: -16rem;
+  left: -16rem;
+}
+
+.-inset-72 {
+  top: -18rem;
+  right: -18rem;
+  bottom: -18rem;
+  left: -18rem;
+}
+
+.-inset-80 {
+  top: -20rem;
+  right: -20rem;
+  bottom: -20rem;
+  left: -20rem;
+}
+
+.-inset-96 {
+  top: -24rem;
+  right: -24rem;
+  bottom: -24rem;
+  left: -24rem;
+}
+
+.-inset-px {
+  top: -1px;
+  right: -1px;
+  bottom: -1px;
+  left: -1px;
+}
+
+.-inset-0\\\\.5 {
+  top: -0.125rem;
+  right: -0.125rem;
+  bottom: -0.125rem;
+  left: -0.125rem;
+}
+
+.-inset-1\\\\.5 {
+  top: -0.375rem;
+  right: -0.375rem;
+  bottom: -0.375rem;
+  left: -0.375rem;
+}
+
+.-inset-2\\\\.5 {
+  top: -0.625rem;
+  right: -0.625rem;
+  bottom: -0.625rem;
+  left: -0.625rem;
+}
+
+.-inset-3\\\\.5 {
+  top: -0.875rem;
+  right: -0.875rem;
+  bottom: -0.875rem;
+  left: -0.875rem;
+}
+
+.inset-1\\\\/2 {
+  top: 50%;
+  right: 50%;
+  bottom: 50%;
+  left: 50%;
+}
+
+.inset-1\\\\/3 {
+  top: 33.333333%;
+  right: 33.333333%;
+  bottom: 33.333333%;
+  left: 33.333333%;
+}
+
+.inset-2\\\\/3 {
+  top: 66.666667%;
+  right: 66.666667%;
+  bottom: 66.666667%;
+  left: 66.666667%;
+}
+
+.inset-1\\\\/4 {
+  top: 25%;
+  right: 25%;
+  bottom: 25%;
+  left: 25%;
+}
+
+.inset-2\\\\/4 {
+  top: 50%;
+  right: 50%;
+  bottom: 50%;
+  left: 50%;
+}
+
+.inset-3\\\\/4 {
+  top: 75%;
+  right: 75%;
+  bottom: 75%;
+  left: 75%;
+}
+
+.inset-full {
+  top: 100%;
+  right: 100%;
+  bottom: 100%;
+  left: 100%;
+}
+
+.-inset-1\\\\/2 {
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+}
+
+.-inset-1\\\\/3 {
+  top: -33.333333%;
+  right: -33.333333%;
+  bottom: -33.333333%;
+  left: -33.333333%;
+}
+
+.-inset-2\\\\/3 {
+  top: -66.666667%;
+  right: -66.666667%;
+  bottom: -66.666667%;
+  left: -66.666667%;
+}
+
+.-inset-1\\\\/4 {
+  top: -25%;
+  right: -25%;
+  bottom: -25%;
+  left: -25%;
+}
+
+.-inset-2\\\\/4 {
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+}
+
+.-inset-3\\\\/4 {
+  top: -75%;
+  right: -75%;
+  bottom: -75%;
+  left: -75%;
+}
+
+.-inset-full {
+  top: -100%;
+  right: -100%;
+  bottom: -100%;
+  left: -100%;
+}
+
+.focus\\\\:inset-0:focus {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.focus\\\\:inset-1:focus {
+  top: 0.25rem;
+  right: 0.25rem;
+  bottom: 0.25rem;
+  left: 0.25rem;
+}
+
+.focus\\\\:inset-2:focus {
+  top: 0.5rem;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  left: 0.5rem;
+}
+
+.focus\\\\:inset-3:focus {
+  top: 0.75rem;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  left: 0.75rem;
+}
+
+.focus\\\\:inset-4:focus {
+  top: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+}
+
+.focus\\\\:inset-5:focus {
+  top: 1.25rem;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  left: 1.25rem;
+}
+
+.focus\\\\:inset-6:focus {
+  top: 1.5rem;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  left: 1.5rem;
+}
+
+.focus\\\\:inset-7:focus {
+  top: 1.75rem;
+  right: 1.75rem;
+  bottom: 1.75rem;
+  left: 1.75rem;
+}
+
+.focus\\\\:inset-8:focus {
+  top: 2rem;
+  right: 2rem;
+  bottom: 2rem;
+  left: 2rem;
+}
+
+.focus\\\\:inset-9:focus {
+  top: 2.25rem;
+  right: 2.25rem;
+  bottom: 2.25rem;
+  left: 2.25rem;
+}
+
+.focus\\\\:inset-10:focus {
+  top: 2.5rem;
+  right: 2.5rem;
+  bottom: 2.5rem;
+  left: 2.5rem;
+}
+
+.focus\\\\:inset-11:focus {
+  top: 2.75rem;
+  right: 2.75rem;
+  bottom: 2.75rem;
+  left: 2.75rem;
+}
+
+.focus\\\\:inset-12:focus {
+  top: 3rem;
+  right: 3rem;
+  bottom: 3rem;
+  left: 3rem;
+}
+
+.focus\\\\:inset-14:focus {
+  top: 3.5rem;
+  right: 3.5rem;
+  bottom: 3.5rem;
+  left: 3.5rem;
+}
+
+.focus\\\\:inset-16:focus {
+  top: 4rem;
+  right: 4rem;
+  bottom: 4rem;
+  left: 4rem;
+}
+
+.focus\\\\:inset-20:focus {
+  top: 5rem;
+  right: 5rem;
+  bottom: 5rem;
+  left: 5rem;
+}
+
+.focus\\\\:inset-24:focus {
+  top: 6rem;
+  right: 6rem;
+  bottom: 6rem;
+  left: 6rem;
+}
+
+.focus\\\\:inset-28:focus {
+  top: 7rem;
+  right: 7rem;
+  bottom: 7rem;
+  left: 7rem;
+}
+
+.focus\\\\:inset-32:focus {
+  top: 8rem;
+  right: 8rem;
+  bottom: 8rem;
+  left: 8rem;
+}
+
+.focus\\\\:inset-36:focus {
+  top: 9rem;
+  right: 9rem;
+  bottom: 9rem;
+  left: 9rem;
+}
+
+.focus\\\\:inset-40:focus {
+  top: 10rem;
+  right: 10rem;
+  bottom: 10rem;
+  left: 10rem;
+}
+
+.focus\\\\:inset-44:focus {
+  top: 11rem;
+  right: 11rem;
+  bottom: 11rem;
+  left: 11rem;
+}
+
+.focus\\\\:inset-48:focus {
+  top: 12rem;
+  right: 12rem;
+  bottom: 12rem;
+  left: 12rem;
+}
+
+.focus\\\\:inset-52:focus {
+  top: 13rem;
+  right: 13rem;
+  bottom: 13rem;
+  left: 13rem;
+}
+
+.focus\\\\:inset-56:focus {
+  top: 14rem;
+  right: 14rem;
+  bottom: 14rem;
+  left: 14rem;
+}
+
+.focus\\\\:inset-60:focus {
+  top: 15rem;
+  right: 15rem;
+  bottom: 15rem;
+  left: 15rem;
+}
+
+.focus\\\\:inset-64:focus {
+  top: 16rem;
+  right: 16rem;
+  bottom: 16rem;
+  left: 16rem;
+}
+
+.focus\\\\:inset-72:focus {
+  top: 18rem;
+  right: 18rem;
+  bottom: 18rem;
+  left: 18rem;
+}
+
+.focus\\\\:inset-80:focus {
+  top: 20rem;
+  right: 20rem;
+  bottom: 20rem;
+  left: 20rem;
+}
+
+.focus\\\\:inset-96:focus {
+  top: 24rem;
+  right: 24rem;
+  bottom: 24rem;
+  left: 24rem;
+}
+
+.focus\\\\:inset-auto:focus {
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+}
+
+.focus\\\\:inset-px:focus {
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  left: 1px;
+}
+
+.focus\\\\:inset-0\\\\.5:focus {
+  top: 0.125rem;
+  right: 0.125rem;
+  bottom: 0.125rem;
+  left: 0.125rem;
+}
+
+.focus\\\\:inset-1\\\\.5:focus {
+  top: 0.375rem;
+  right: 0.375rem;
+  bottom: 0.375rem;
+  left: 0.375rem;
+}
+
+.focus\\\\:inset-2\\\\.5:focus {
+  top: 0.625rem;
+  right: 0.625rem;
+  bottom: 0.625rem;
+  left: 0.625rem;
+}
+
+.focus\\\\:inset-3\\\\.5:focus {
+  top: 0.875rem;
+  right: 0.875rem;
+  bottom: 0.875rem;
+  left: 0.875rem;
+}
+
+.focus\\\\:-inset-0:focus {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.focus\\\\:-inset-1:focus {
+  top: -0.25rem;
+  right: -0.25rem;
+  bottom: -0.25rem;
+  left: -0.25rem;
+}
+
+.focus\\\\:-inset-2:focus {
+  top: -0.5rem;
+  right: -0.5rem;
+  bottom: -0.5rem;
+  left: -0.5rem;
+}
+
+.focus\\\\:-inset-3:focus {
+  top: -0.75rem;
+  right: -0.75rem;
+  bottom: -0.75rem;
+  left: -0.75rem;
+}
+
+.focus\\\\:-inset-4:focus {
+  top: -1rem;
+  right: -1rem;
+  bottom: -1rem;
+  left: -1rem;
+}
+
+.focus\\\\:-inset-5:focus {
+  top: -1.25rem;
+  right: -1.25rem;
+  bottom: -1.25rem;
+  left: -1.25rem;
+}
+
+.focus\\\\:-inset-6:focus {
+  top: -1.5rem;
+  right: -1.5rem;
+  bottom: -1.5rem;
+  left: -1.5rem;
+}
+
+.focus\\\\:-inset-7:focus {
+  top: -1.75rem;
+  right: -1.75rem;
+  bottom: -1.75rem;
+  left: -1.75rem;
+}
+
+.focus\\\\:-inset-8:focus {
+  top: -2rem;
+  right: -2rem;
+  bottom: -2rem;
+  left: -2rem;
+}
+
+.focus\\\\:-inset-9:focus {
+  top: -2.25rem;
+  right: -2.25rem;
+  bottom: -2.25rem;
+  left: -2.25rem;
+}
+
+.focus\\\\:-inset-10:focus {
+  top: -2.5rem;
+  right: -2.5rem;
+  bottom: -2.5rem;
+  left: -2.5rem;
+}
+
+.focus\\\\:-inset-11:focus {
+  top: -2.75rem;
+  right: -2.75rem;
+  bottom: -2.75rem;
+  left: -2.75rem;
+}
+
+.focus\\\\:-inset-12:focus {
+  top: -3rem;
+  right: -3rem;
+  bottom: -3rem;
+  left: -3rem;
+}
+
+.focus\\\\:-inset-14:focus {
+  top: -3.5rem;
+  right: -3.5rem;
+  bottom: -3.5rem;
+  left: -3.5rem;
+}
+
+.focus\\\\:-inset-16:focus {
+  top: -4rem;
+  right: -4rem;
+  bottom: -4rem;
+  left: -4rem;
+}
+
+.focus\\\\:-inset-20:focus {
+  top: -5rem;
+  right: -5rem;
+  bottom: -5rem;
+  left: -5rem;
+}
+
+.focus\\\\:-inset-24:focus {
+  top: -6rem;
+  right: -6rem;
+  bottom: -6rem;
+  left: -6rem;
+}
+
+.focus\\\\:-inset-28:focus {
+  top: -7rem;
+  right: -7rem;
+  bottom: -7rem;
+  left: -7rem;
+}
+
+.focus\\\\:-inset-32:focus {
+  top: -8rem;
+  right: -8rem;
+  bottom: -8rem;
+  left: -8rem;
+}
+
+.focus\\\\:-inset-36:focus {
+  top: -9rem;
+  right: -9rem;
+  bottom: -9rem;
+  left: -9rem;
+}
+
+.focus\\\\:-inset-40:focus {
+  top: -10rem;
+  right: -10rem;
+  bottom: -10rem;
+  left: -10rem;
+}
+
+.focus\\\\:-inset-44:focus {
+  top: -11rem;
+  right: -11rem;
+  bottom: -11rem;
+  left: -11rem;
+}
+
+.focus\\\\:-inset-48:focus {
+  top: -12rem;
+  right: -12rem;
+  bottom: -12rem;
+  left: -12rem;
+}
+
+.focus\\\\:-inset-52:focus {
+  top: -13rem;
+  right: -13rem;
+  bottom: -13rem;
+  left: -13rem;
+}
+
+.focus\\\\:-inset-56:focus {
+  top: -14rem;
+  right: -14rem;
+  bottom: -14rem;
+  left: -14rem;
+}
+
+.focus\\\\:-inset-60:focus {
+  top: -15rem;
+  right: -15rem;
+  bottom: -15rem;
+  left: -15rem;
+}
+
+.focus\\\\:-inset-64:focus {
+  top: -16rem;
+  right: -16rem;
+  bottom: -16rem;
+  left: -16rem;
+}
+
+.focus\\\\:-inset-72:focus {
+  top: -18rem;
+  right: -18rem;
+  bottom: -18rem;
+  left: -18rem;
+}
+
+.focus\\\\:-inset-80:focus {
+  top: -20rem;
+  right: -20rem;
+  bottom: -20rem;
+  left: -20rem;
+}
+
+.focus\\\\:-inset-96:focus {
+  top: -24rem;
+  right: -24rem;
+  bottom: -24rem;
+  left: -24rem;
+}
+
+.focus\\\\:-inset-px:focus {
+  top: -1px;
+  right: -1px;
+  bottom: -1px;
+  left: -1px;
+}
+
+.focus\\\\:-inset-0\\\\.5:focus {
+  top: -0.125rem;
+  right: -0.125rem;
+  bottom: -0.125rem;
+  left: -0.125rem;
+}
+
+.focus\\\\:-inset-1\\\\.5:focus {
+  top: -0.375rem;
+  right: -0.375rem;
+  bottom: -0.375rem;
+  left: -0.375rem;
+}
+
+.focus\\\\:-inset-2\\\\.5:focus {
+  top: -0.625rem;
+  right: -0.625rem;
+  bottom: -0.625rem;
+  left: -0.625rem;
+}
+
+.focus\\\\:-inset-3\\\\.5:focus {
+  top: -0.875rem;
+  right: -0.875rem;
+  bottom: -0.875rem;
+  left: -0.875rem;
+}
+
+.focus\\\\:inset-1\\\\/2:focus {
+  top: 50%;
+  right: 50%;
+  bottom: 50%;
+  left: 50%;
+}
+
+.focus\\\\:inset-1\\\\/3:focus {
+  top: 33.333333%;
+  right: 33.333333%;
+  bottom: 33.333333%;
+  left: 33.333333%;
+}
+
+.focus\\\\:inset-2\\\\/3:focus {
+  top: 66.666667%;
+  right: 66.666667%;
+  bottom: 66.666667%;
+  left: 66.666667%;
+}
+
+.focus\\\\:inset-1\\\\/4:focus {
+  top: 25%;
+  right: 25%;
+  bottom: 25%;
+  left: 25%;
+}
+
+.focus\\\\:inset-2\\\\/4:focus {
+  top: 50%;
+  right: 50%;
+  bottom: 50%;
+  left: 50%;
+}
+
+.focus\\\\:inset-3\\\\/4:focus {
+  top: 75%;
+  right: 75%;
+  bottom: 75%;
+  left: 75%;
+}
+
+.focus\\\\:inset-full:focus {
+  top: 100%;
+  right: 100%;
+  bottom: 100%;
+  left: 100%;
+}
+
+.focus\\\\:-inset-1\\\\/2:focus {
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+}
+
+.focus\\\\:-inset-1\\\\/3:focus {
+  top: -33.333333%;
+  right: -33.333333%;
+  bottom: -33.333333%;
+  left: -33.333333%;
+}
+
+.focus\\\\:-inset-2\\\\/3:focus {
+  top: -66.666667%;
+  right: -66.666667%;
+  bottom: -66.666667%;
+  left: -66.666667%;
+}
+
+.focus\\\\:-inset-1\\\\/4:focus {
+  top: -25%;
+  right: -25%;
+  bottom: -25%;
+  left: -25%;
+}
+
+.focus\\\\:-inset-2\\\\/4:focus {
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+}
+
+.focus\\\\:-inset-3\\\\/4:focus {
+  top: -75%;
+  right: -75%;
+  bottom: -75%;
+  left: -75%;
+}
+
+.focus\\\\:-inset-full:focus {
+  top: -100%;
+  right: -100%;
+  bottom: -100%;
+  left: -100%;
+}
+
+.inset-x-0 {
+  left: 0px;
+  right: 0px;
+}
+
+.inset-x-1 {
+  left: 0.25rem;
+  right: 0.25rem;
+}
+
+.inset-x-2 {
+  left: 0.5rem;
+  right: 0.5rem;
+}
+
+.inset-x-3 {
+  left: 0.75rem;
+  right: 0.75rem;
+}
+
+.inset-x-4 {
+  left: 1rem;
+  right: 1rem;
+}
+
+.inset-x-5 {
+  left: 1.25rem;
+  right: 1.25rem;
+}
+
+.inset-x-6 {
+  left: 1.5rem;
+  right: 1.5rem;
+}
+
+.inset-x-7 {
+  left: 1.75rem;
+  right: 1.75rem;
+}
+
+.inset-x-8 {
+  left: 2rem;
+  right: 2rem;
+}
+
+.inset-x-9 {
+  left: 2.25rem;
+  right: 2.25rem;
+}
+
+.inset-x-10 {
+  left: 2.5rem;
+  right: 2.5rem;
+}
+
+.inset-x-11 {
+  left: 2.75rem;
+  right: 2.75rem;
+}
+
+.inset-x-12 {
+  left: 3rem;
+  right: 3rem;
+}
+
+.inset-x-14 {
+  left: 3.5rem;
+  right: 3.5rem;
+}
+
+.inset-x-16 {
+  left: 4rem;
+  right: 4rem;
+}
+
+.inset-x-20 {
+  left: 5rem;
+  right: 5rem;
+}
+
+.inset-x-24 {
+  left: 6rem;
+  right: 6rem;
+}
+
+.inset-x-28 {
+  left: 7rem;
+  right: 7rem;
+}
+
+.inset-x-32 {
+  left: 8rem;
+  right: 8rem;
+}
+
+.inset-x-36 {
+  left: 9rem;
+  right: 9rem;
+}
+
+.inset-x-40 {
+  left: 10rem;
+  right: 10rem;
+}
+
+.inset-x-44 {
+  left: 11rem;
+  right: 11rem;
+}
+
+.inset-x-48 {
+  left: 12rem;
+  right: 12rem;
+}
+
+.inset-x-52 {
+  left: 13rem;
+  right: 13rem;
+}
+
+.inset-x-56 {
+  left: 14rem;
+  right: 14rem;
+}
+
+.inset-x-60 {
+  left: 15rem;
+  right: 15rem;
+}
+
+.inset-x-64 {
+  left: 16rem;
+  right: 16rem;
+}
+
+.inset-x-72 {
+  left: 18rem;
+  right: 18rem;
+}
+
+.inset-x-80 {
+  left: 20rem;
+  right: 20rem;
+}
+
+.inset-x-96 {
+  left: 24rem;
+  right: 24rem;
+}
+
+.inset-x-auto {
+  left: auto;
+  right: auto;
+}
+
+.inset-x-px {
+  left: 1px;
+  right: 1px;
+}
+
+.inset-x-0\\\\.5 {
+  left: 0.125rem;
+  right: 0.125rem;
+}
+
+.inset-x-1\\\\.5 {
+  left: 0.375rem;
+  right: 0.375rem;
+}
+
+.inset-x-2\\\\.5 {
+  left: 0.625rem;
+  right: 0.625rem;
+}
+
+.inset-x-3\\\\.5 {
+  left: 0.875rem;
+  right: 0.875rem;
+}
+
+.-inset-x-0 {
+  left: 0px;
+  right: 0px;
+}
+
+.-inset-x-1 {
+  left: -0.25rem;
+  right: -0.25rem;
+}
+
+.-inset-x-2 {
+  left: -0.5rem;
+  right: -0.5rem;
+}
+
+.-inset-x-3 {
+  left: -0.75rem;
+  right: -0.75rem;
+}
+
+.-inset-x-4 {
+  left: -1rem;
+  right: -1rem;
+}
+
+.-inset-x-5 {
+  left: -1.25rem;
+  right: -1.25rem;
+}
+
+.-inset-x-6 {
+  left: -1.5rem;
+  right: -1.5rem;
+}
+
+.-inset-x-7 {
+  left: -1.75rem;
+  right: -1.75rem;
+}
+
+.-inset-x-8 {
+  left: -2rem;
+  right: -2rem;
+}
+
+.-inset-x-9 {
+  left: -2.25rem;
+  right: -2.25rem;
+}
+
+.-inset-x-10 {
+  left: -2.5rem;
+  right: -2.5rem;
+}
+
+.-inset-x-11 {
+  left: -2.75rem;
+  right: -2.75rem;
+}
+
+.-inset-x-12 {
+  left: -3rem;
+  right: -3rem;
+}
+
+.-inset-x-14 {
+  left: -3.5rem;
+  right: -3.5rem;
+}
+
+.-inset-x-16 {
+  left: -4rem;
+  right: -4rem;
+}
+
+.-inset-x-20 {
+  left: -5rem;
+  right: -5rem;
+}
+
+.-inset-x-24 {
+  left: -6rem;
+  right: -6rem;
+}
+
+.-inset-x-28 {
+  left: -7rem;
+  right: -7rem;
+}
+
+.-inset-x-32 {
+  left: -8rem;
+  right: -8rem;
+}
+
+.-inset-x-36 {
+  left: -9rem;
+  right: -9rem;
+}
+
+.-inset-x-40 {
+  left: -10rem;
+  right: -10rem;
+}
+
+.-inset-x-44 {
+  left: -11rem;
+  right: -11rem;
+}
+
+.-inset-x-48 {
+  left: -12rem;
+  right: -12rem;
+}
+
+.-inset-x-52 {
+  left: -13rem;
+  right: -13rem;
+}
+
+.-inset-x-56 {
+  left: -14rem;
+  right: -14rem;
+}
+
+.-inset-x-60 {
+  left: -15rem;
+  right: -15rem;
+}
+
+.-inset-x-64 {
+  left: -16rem;
+  right: -16rem;
+}
+
+.-inset-x-72 {
+  left: -18rem;
+  right: -18rem;
+}
+
+.-inset-x-80 {
+  left: -20rem;
+  right: -20rem;
+}
+
+.-inset-x-96 {
+  left: -24rem;
+  right: -24rem;
+}
+
+.-inset-x-px {
+  left: -1px;
+  right: -1px;
+}
+
+.-inset-x-0\\\\.5 {
+  left: -0.125rem;
+  right: -0.125rem;
+}
+
+.-inset-x-1\\\\.5 {
+  left: -0.375rem;
+  right: -0.375rem;
+}
+
+.-inset-x-2\\\\.5 {
+  left: -0.625rem;
+  right: -0.625rem;
+}
+
+.-inset-x-3\\\\.5 {
+  left: -0.875rem;
+  right: -0.875rem;
+}
+
+.inset-x-1\\\\/2 {
+  left: 50%;
+  right: 50%;
+}
+
+.inset-x-1\\\\/3 {
+  left: 33.333333%;
+  right: 33.333333%;
+}
+
+.inset-x-2\\\\/3 {
+  left: 66.666667%;
+  right: 66.666667%;
+}
+
+.inset-x-1\\\\/4 {
+  left: 25%;
+  right: 25%;
+}
+
+.inset-x-2\\\\/4 {
+  left: 50%;
+  right: 50%;
+}
+
+.inset-x-3\\\\/4 {
+  left: 75%;
+  right: 75%;
+}
+
+.inset-x-full {
+  left: 100%;
+  right: 100%;
+}
+
+.-inset-x-1\\\\/2 {
+  left: -50%;
+  right: -50%;
+}
+
+.-inset-x-1\\\\/3 {
+  left: -33.333333%;
+  right: -33.333333%;
+}
+
+.-inset-x-2\\\\/3 {
+  left: -66.666667%;
+  right: -66.666667%;
+}
+
+.-inset-x-1\\\\/4 {
+  left: -25%;
+  right: -25%;
+}
+
+.-inset-x-2\\\\/4 {
+  left: -50%;
+  right: -50%;
+}
+
+.-inset-x-3\\\\/4 {
+  left: -75%;
+  right: -75%;
+}
+
+.-inset-x-full {
+  left: -100%;
+  right: -100%;
+}
+
+.inset-y-0 {
+  top: 0px;
+  bottom: 0px;
+}
+
+.inset-y-1 {
+  top: 0.25rem;
+  bottom: 0.25rem;
+}
+
+.inset-y-2 {
+  top: 0.5rem;
+  bottom: 0.5rem;
+}
+
+.inset-y-3 {
+  top: 0.75rem;
+  bottom: 0.75rem;
+}
+
+.inset-y-4 {
+  top: 1rem;
+  bottom: 1rem;
+}
+
+.inset-y-5 {
+  top: 1.25rem;
+  bottom: 1.25rem;
+}
+
+.inset-y-6 {
+  top: 1.5rem;
+  bottom: 1.5rem;
+}
+
+.inset-y-7 {
+  top: 1.75rem;
+  bottom: 1.75rem;
+}
+
+.inset-y-8 {
+  top: 2rem;
+  bottom: 2rem;
+}
+
+.inset-y-9 {
+  top: 2.25rem;
+  bottom: 2.25rem;
+}
+
+.inset-y-10 {
+  top: 2.5rem;
+  bottom: 2.5rem;
+}
+
+.inset-y-11 {
+  top: 2.75rem;
+  bottom: 2.75rem;
+}
+
+.inset-y-12 {
+  top: 3rem;
+  bottom: 3rem;
+}
+
+.inset-y-14 {
+  top: 3.5rem;
+  bottom: 3.5rem;
+}
+
+.inset-y-16 {
+  top: 4rem;
+  bottom: 4rem;
+}
+
+.inset-y-20 {
+  top: 5rem;
+  bottom: 5rem;
+}
+
+.inset-y-24 {
+  top: 6rem;
+  bottom: 6rem;
+}
+
+.inset-y-28 {
+  top: 7rem;
+  bottom: 7rem;
+}
+
+.inset-y-32 {
+  top: 8rem;
+  bottom: 8rem;
+}
+
+.inset-y-36 {
+  top: 9rem;
+  bottom: 9rem;
+}
+
+.inset-y-40 {
+  top: 10rem;
+  bottom: 10rem;
+}
+
+.inset-y-44 {
+  top: 11rem;
+  bottom: 11rem;
+}
+
+.inset-y-48 {
+  top: 12rem;
+  bottom: 12rem;
+}
+
+.inset-y-52 {
+  top: 13rem;
+  bottom: 13rem;
+}
+
+.inset-y-56 {
+  top: 14rem;
+  bottom: 14rem;
+}
+
+.inset-y-60 {
+  top: 15rem;
+  bottom: 15rem;
+}
+
+.inset-y-64 {
+  top: 16rem;
+  bottom: 16rem;
+}
+
+.inset-y-72 {
+  top: 18rem;
+  bottom: 18rem;
+}
+
+.inset-y-80 {
+  top: 20rem;
+  bottom: 20rem;
+}
+
+.inset-y-96 {
+  top: 24rem;
+  bottom: 24rem;
+}
+
+.inset-y-auto {
+  top: auto;
+  bottom: auto;
+}
+
+.inset-y-px {
+  top: 1px;
+  bottom: 1px;
+}
+
+.inset-y-0\\\\.5 {
+  top: 0.125rem;
+  bottom: 0.125rem;
+}
+
+.inset-y-1\\\\.5 {
+  top: 0.375rem;
+  bottom: 0.375rem;
+}
+
+.inset-y-2\\\\.5 {
+  top: 0.625rem;
+  bottom: 0.625rem;
+}
+
+.inset-y-3\\\\.5 {
+  top: 0.875rem;
+  bottom: 0.875rem;
+}
+
+.-inset-y-0 {
+  top: 0px;
+  bottom: 0px;
+}
+
+.-inset-y-1 {
+  top: -0.25rem;
+  bottom: -0.25rem;
+}
+
+.-inset-y-2 {
+  top: -0.5rem;
+  bottom: -0.5rem;
+}
+
+.-inset-y-3 {
+  top: -0.75rem;
+  bottom: -0.75rem;
+}
+
+.-inset-y-4 {
+  top: -1rem;
+  bottom: -1rem;
+}
+
+.-inset-y-5 {
+  top: -1.25rem;
+  bottom: -1.25rem;
+}
+
+.-inset-y-6 {
+  top: -1.5rem;
+  bottom: -1.5rem;
+}
+
+.-inset-y-7 {
+  top: -1.75rem;
+  bottom: -1.75rem;
+}
+
+.-inset-y-8 {
+  top: -2rem;
+  bottom: -2rem;
+}
+
+.-inset-y-9 {
+  top: -2.25rem;
+  bottom: -2.25rem;
+}
+
+.-inset-y-10 {
+  top: -2.5rem;
+  bottom: -2.5rem;
+}
+
+.-inset-y-11 {
+  top: -2.75rem;
+  bottom: -2.75rem;
+}
+
+.-inset-y-12 {
+  top: -3rem;
+  bottom: -3rem;
+}
+
+.-inset-y-14 {
+  top: -3.5rem;
+  bottom: -3.5rem;
+}
+
+.-inset-y-16 {
+  top: -4rem;
+  bottom: -4rem;
+}
+
+.-inset-y-20 {
+  top: -5rem;
+  bottom: -5rem;
+}
+
+.-inset-y-24 {
+  top: -6rem;
+  bottom: -6rem;
+}
+
+.-inset-y-28 {
+  top: -7rem;
+  bottom: -7rem;
+}
+
+.-inset-y-32 {
+  top: -8rem;
+  bottom: -8rem;
+}
+
+.-inset-y-36 {
+  top: -9rem;
+  bottom: -9rem;
+}
+
+.-inset-y-40 {
+  top: -10rem;
+  bottom: -10rem;
+}
+
+.-inset-y-44 {
+  top: -11rem;
+  bottom: -11rem;
+}
+
+.-inset-y-48 {
+  top: -12rem;
+  bottom: -12rem;
+}
+
+.-inset-y-52 {
+  top: -13rem;
+  bottom: -13rem;
+}
+
+.-inset-y-56 {
+  top: -14rem;
+  bottom: -14rem;
+}
+
+.-inset-y-60 {
+  top: -15rem;
+  bottom: -15rem;
+}
+
+.-inset-y-64 {
+  top: -16rem;
+  bottom: -16rem;
+}
+
+.-inset-y-72 {
+  top: -18rem;
+  bottom: -18rem;
+}
+
+.-inset-y-80 {
+  top: -20rem;
+  bottom: -20rem;
+}
+
+.-inset-y-96 {
+  top: -24rem;
+  bottom: -24rem;
+}
+
+.-inset-y-px {
+  top: -1px;
+  bottom: -1px;
+}
+
+.-inset-y-0\\\\.5 {
+  top: -0.125rem;
+  bottom: -0.125rem;
+}
+
+.-inset-y-1\\\\.5 {
+  top: -0.375rem;
+  bottom: -0.375rem;
+}
+
+.-inset-y-2\\\\.5 {
+  top: -0.625rem;
+  bottom: -0.625rem;
+}
+
+.-inset-y-3\\\\.5 {
+  top: -0.875rem;
+  bottom: -0.875rem;
+}
+
+.inset-y-1\\\\/2 {
+  top: 50%;
+  bottom: 50%;
+}
+
+.inset-y-1\\\\/3 {
+  top: 33.333333%;
+  bottom: 33.333333%;
+}
+
+.inset-y-2\\\\/3 {
+  top: 66.666667%;
+  bottom: 66.666667%;
+}
+
+.inset-y-1\\\\/4 {
+  top: 25%;
+  bottom: 25%;
+}
+
+.inset-y-2\\\\/4 {
+  top: 50%;
+  bottom: 50%;
+}
+
+.inset-y-3\\\\/4 {
+  top: 75%;
+  bottom: 75%;
+}
+
+.inset-y-full {
+  top: 100%;
+  bottom: 100%;
+}
+
+.-inset-y-1\\\\/2 {
+  top: -50%;
+  bottom: -50%;
+}
+
+.-inset-y-1\\\\/3 {
+  top: -33.333333%;
+  bottom: -33.333333%;
+}
+
+.-inset-y-2\\\\/3 {
+  top: -66.666667%;
+  bottom: -66.666667%;
+}
+
+.-inset-y-1\\\\/4 {
+  top: -25%;
+  bottom: -25%;
+}
+
+.-inset-y-2\\\\/4 {
+  top: -50%;
+  bottom: -50%;
+}
+
+.-inset-y-3\\\\/4 {
+  top: -75%;
+  bottom: -75%;
+}
+
+.-inset-y-full {
+  top: -100%;
+  bottom: -100%;
+}
+
+.focus\\\\:inset-x-0:focus {
+  left: 0px;
+  right: 0px;
+}
+
+.focus\\\\:inset-x-1:focus {
+  left: 0.25rem;
+  right: 0.25rem;
+}
+
+.focus\\\\:inset-x-2:focus {
+  left: 0.5rem;
+  right: 0.5rem;
+}
+
+.focus\\\\:inset-x-3:focus {
+  left: 0.75rem;
+  right: 0.75rem;
+}
+
+.focus\\\\:inset-x-4:focus {
+  left: 1rem;
+  right: 1rem;
+}
+
+.focus\\\\:inset-x-5:focus {
+  left: 1.25rem;
+  right: 1.25rem;
+}
+
+.focus\\\\:inset-x-6:focus {
+  left: 1.5rem;
+  right: 1.5rem;
+}
+
+.focus\\\\:inset-x-7:focus {
+  left: 1.75rem;
+  right: 1.75rem;
+}
+
+.focus\\\\:inset-x-8:focus {
+  left: 2rem;
+  right: 2rem;
+}
+
+.focus\\\\:inset-x-9:focus {
+  left: 2.25rem;
+  right: 2.25rem;
+}
+
+.focus\\\\:inset-x-10:focus {
+  left: 2.5rem;
+  right: 2.5rem;
+}
+
+.focus\\\\:inset-x-11:focus {
+  left: 2.75rem;
+  right: 2.75rem;
+}
+
+.focus\\\\:inset-x-12:focus {
+  left: 3rem;
+  right: 3rem;
+}
+
+.focus\\\\:inset-x-14:focus {
+  left: 3.5rem;
+  right: 3.5rem;
+}
+
+.focus\\\\:inset-x-16:focus {
+  left: 4rem;
+  right: 4rem;
+}
+
+.focus\\\\:inset-x-20:focus {
+  left: 5rem;
+  right: 5rem;
+}
+
+.focus\\\\:inset-x-24:focus {
+  left: 6rem;
+  right: 6rem;
+}
+
+.focus\\\\:inset-x-28:focus {
+  left: 7rem;
+  right: 7rem;
+}
+
+.focus\\\\:inset-x-32:focus {
+  left: 8rem;
+  right: 8rem;
+}
+
+.focus\\\\:inset-x-36:focus {
+  left: 9rem;
+  right: 9rem;
+}
+
+.focus\\\\:inset-x-40:focus {
+  left: 10rem;
+  right: 10rem;
+}
+
+.focus\\\\:inset-x-44:focus {
+  left: 11rem;
+  right: 11rem;
+}
+
+.focus\\\\:inset-x-48:focus {
+  left: 12rem;
+  right: 12rem;
+}
+
+.focus\\\\:inset-x-52:focus {
+  left: 13rem;
+  right: 13rem;
+}
+
+.focus\\\\:inset-x-56:focus {
+  left: 14rem;
+  right: 14rem;
+}
+
+.focus\\\\:inset-x-60:focus {
+  left: 15rem;
+  right: 15rem;
+}
+
+.focus\\\\:inset-x-64:focus {
+  left: 16rem;
+  right: 16rem;
+}
+
+.focus\\\\:inset-x-72:focus {
+  left: 18rem;
+  right: 18rem;
+}
+
+.focus\\\\:inset-x-80:focus {
+  left: 20rem;
+  right: 20rem;
+}
+
+.focus\\\\:inset-x-96:focus {
+  left: 24rem;
+  right: 24rem;
+}
+
+.focus\\\\:inset-x-auto:focus {
+  left: auto;
+  right: auto;
+}
+
+.focus\\\\:inset-x-px:focus {
+  left: 1px;
+  right: 1px;
+}
+
+.focus\\\\:inset-x-0\\\\.5:focus {
+  left: 0.125rem;
+  right: 0.125rem;
+}
+
+.focus\\\\:inset-x-1\\\\.5:focus {
+  left: 0.375rem;
+  right: 0.375rem;
+}
+
+.focus\\\\:inset-x-2\\\\.5:focus {
+  left: 0.625rem;
+  right: 0.625rem;
+}
+
+.focus\\\\:inset-x-3\\\\.5:focus {
+  left: 0.875rem;
+  right: 0.875rem;
+}
+
+.focus\\\\:-inset-x-0:focus {
+  left: 0px;
+  right: 0px;
+}
+
+.focus\\\\:-inset-x-1:focus {
+  left: -0.25rem;
+  right: -0.25rem;
+}
+
+.focus\\\\:-inset-x-2:focus {
+  left: -0.5rem;
+  right: -0.5rem;
+}
+
+.focus\\\\:-inset-x-3:focus {
+  left: -0.75rem;
+  right: -0.75rem;
+}
+
+.focus\\\\:-inset-x-4:focus {
+  left: -1rem;
+  right: -1rem;
+}
+
+.focus\\\\:-inset-x-5:focus {
+  left: -1.25rem;
+  right: -1.25rem;
+}
+
+.focus\\\\:-inset-x-6:focus {
+  left: -1.5rem;
+  right: -1.5rem;
+}
+
+.focus\\\\:-inset-x-7:focus {
+  left: -1.75rem;
+  right: -1.75rem;
+}
+
+.focus\\\\:-inset-x-8:focus {
+  left: -2rem;
+  right: -2rem;
+}
+
+.focus\\\\:-inset-x-9:focus {
+  left: -2.25rem;
+  right: -2.25rem;
+}
+
+.focus\\\\:-inset-x-10:focus {
+  left: -2.5rem;
+  right: -2.5rem;
+}
+
+.focus\\\\:-inset-x-11:focus {
+  left: -2.75rem;
+  right: -2.75rem;
+}
+
+.focus\\\\:-inset-x-12:focus {
+  left: -3rem;
+  right: -3rem;
+}
+
+.focus\\\\:-inset-x-14:focus {
+  left: -3.5rem;
+  right: -3.5rem;
+}
+
+.focus\\\\:-inset-x-16:focus {
+  left: -4rem;
+  right: -4rem;
+}
+
+.focus\\\\:-inset-x-20:focus {
+  left: -5rem;
+  right: -5rem;
+}
+
+.focus\\\\:-inset-x-24:focus {
+  left: -6rem;
+  right: -6rem;
+}
+
+.focus\\\\:-inset-x-28:focus {
+  left: -7rem;
+  right: -7rem;
+}
+
+.focus\\\\:-inset-x-32:focus {
+  left: -8rem;
+  right: -8rem;
+}
+
+.focus\\\\:-inset-x-36:focus {
+  left: -9rem;
+  right: -9rem;
+}
+
+.focus\\\\:-inset-x-40:focus {
+  left: -10rem;
+  right: -10rem;
+}
+
+.focus\\\\:-inset-x-44:focus {
+  left: -11rem;
+  right: -11rem;
+}
+
+.focus\\\\:-inset-x-48:focus {
+  left: -12rem;
+  right: -12rem;
+}
+
+.focus\\\\:-inset-x-52:focus {
+  left: -13rem;
+  right: -13rem;
+}
+
+.focus\\\\:-inset-x-56:focus {
+  left: -14rem;
+  right: -14rem;
+}
+
+.focus\\\\:-inset-x-60:focus {
+  left: -15rem;
+  right: -15rem;
+}
+
+.focus\\\\:-inset-x-64:focus {
+  left: -16rem;
+  right: -16rem;
+}
+
+.focus\\\\:-inset-x-72:focus {
+  left: -18rem;
+  right: -18rem;
+}
+
+.focus\\\\:-inset-x-80:focus {
+  left: -20rem;
+  right: -20rem;
+}
+
+.focus\\\\:-inset-x-96:focus {
+  left: -24rem;
+  right: -24rem;
+}
+
+.focus\\\\:-inset-x-px:focus {
+  left: -1px;
+  right: -1px;
+}
+
+.focus\\\\:-inset-x-0\\\\.5:focus {
+  left: -0.125rem;
+  right: -0.125rem;
+}
+
+.focus\\\\:-inset-x-1\\\\.5:focus {
+  left: -0.375rem;
+  right: -0.375rem;
+}
+
+.focus\\\\:-inset-x-2\\\\.5:focus {
+  left: -0.625rem;
+  right: -0.625rem;
+}
+
+.focus\\\\:-inset-x-3\\\\.5:focus {
+  left: -0.875rem;
+  right: -0.875rem;
+}
+
+.focus\\\\:inset-x-1\\\\/2:focus {
+  left: 50%;
+  right: 50%;
+}
+
+.focus\\\\:inset-x-1\\\\/3:focus {
+  left: 33.333333%;
+  right: 33.333333%;
+}
+
+.focus\\\\:inset-x-2\\\\/3:focus {
+  left: 66.666667%;
+  right: 66.666667%;
+}
+
+.focus\\\\:inset-x-1\\\\/4:focus {
+  left: 25%;
+  right: 25%;
+}
+
+.focus\\\\:inset-x-2\\\\/4:focus {
+  left: 50%;
+  right: 50%;
+}
+
+.focus\\\\:inset-x-3\\\\/4:focus {
+  left: 75%;
+  right: 75%;
+}
+
+.focus\\\\:inset-x-full:focus {
+  left: 100%;
+  right: 100%;
+}
+
+.focus\\\\:-inset-x-1\\\\/2:focus {
+  left: -50%;
+  right: -50%;
+}
+
+.focus\\\\:-inset-x-1\\\\/3:focus {
+  left: -33.333333%;
+  right: -33.333333%;
+}
+
+.focus\\\\:-inset-x-2\\\\/3:focus {
+  left: -66.666667%;
+  right: -66.666667%;
+}
+
+.focus\\\\:-inset-x-1\\\\/4:focus {
+  left: -25%;
+  right: -25%;
+}
+
+.focus\\\\:-inset-x-2\\\\/4:focus {
+  left: -50%;
+  right: -50%;
+}
+
+.focus\\\\:-inset-x-3\\\\/4:focus {
+  left: -75%;
+  right: -75%;
+}
+
+.focus\\\\:-inset-x-full:focus {
+  left: -100%;
+  right: -100%;
+}
+
+.focus\\\\:inset-y-0:focus {
+  top: 0px;
+  bottom: 0px;
+}
+
+.focus\\\\:inset-y-1:focus {
+  top: 0.25rem;
+  bottom: 0.25rem;
+}
+
+.focus\\\\:inset-y-2:focus {
+  top: 0.5rem;
+  bottom: 0.5rem;
+}
+
+.focus\\\\:inset-y-3:focus {
+  top: 0.75rem;
+  bottom: 0.75rem;
+}
+
+.focus\\\\:inset-y-4:focus {
+  top: 1rem;
+  bottom: 1rem;
+}
+
+.focus\\\\:inset-y-5:focus {
+  top: 1.25rem;
+  bottom: 1.25rem;
+}
+
+.focus\\\\:inset-y-6:focus {
+  top: 1.5rem;
+  bottom: 1.5rem;
+}
+
+.focus\\\\:inset-y-7:focus {
+  top: 1.75rem;
+  bottom: 1.75rem;
+}
+
+.focus\\\\:inset-y-8:focus {
+  top: 2rem;
+  bottom: 2rem;
+}
+
+.focus\\\\:inset-y-9:focus {
+  top: 2.25rem;
+  bottom: 2.25rem;
+}
+
+.focus\\\\:inset-y-10:focus {
+  top: 2.5rem;
+  bottom: 2.5rem;
+}
+
+.focus\\\\:inset-y-11:focus {
+  top: 2.75rem;
+  bottom: 2.75rem;
+}
+
+.focus\\\\:inset-y-12:focus {
+  top: 3rem;
+  bottom: 3rem;
+}
+
+.focus\\\\:inset-y-14:focus {
+  top: 3.5rem;
+  bottom: 3.5rem;
+}
+
+.focus\\\\:inset-y-16:focus {
+  top: 4rem;
+  bottom: 4rem;
+}
+
+.focus\\\\:inset-y-20:focus {
+  top: 5rem;
+  bottom: 5rem;
+}
+
+.focus\\\\:inset-y-24:focus {
+  top: 6rem;
+  bottom: 6rem;
+}
+
+.focus\\\\:inset-y-28:focus {
+  top: 7rem;
+  bottom: 7rem;
+}
+
+.focus\\\\:inset-y-32:focus {
+  top: 8rem;
+  bottom: 8rem;
+}
+
+.focus\\\\:inset-y-36:focus {
+  top: 9rem;
+  bottom: 9rem;
+}
+
+.focus\\\\:inset-y-40:focus {
+  top: 10rem;
+  bottom: 10rem;
+}
+
+.focus\\\\:inset-y-44:focus {
+  top: 11rem;
+  bottom: 11rem;
+}
+
+.focus\\\\:inset-y-48:focus {
+  top: 12rem;
+  bottom: 12rem;
+}
+
+.focus\\\\:inset-y-52:focus {
+  top: 13rem;
+  bottom: 13rem;
+}
+
+.focus\\\\:inset-y-56:focus {
+  top: 14rem;
+  bottom: 14rem;
+}
+
+.focus\\\\:inset-y-60:focus {
+  top: 15rem;
+  bottom: 15rem;
+}
+
+.focus\\\\:inset-y-64:focus {
+  top: 16rem;
+  bottom: 16rem;
+}
+
+.focus\\\\:inset-y-72:focus {
+  top: 18rem;
+  bottom: 18rem;
+}
+
+.focus\\\\:inset-y-80:focus {
+  top: 20rem;
+  bottom: 20rem;
+}
+
+.focus\\\\:inset-y-96:focus {
+  top: 24rem;
+  bottom: 24rem;
+}
+
+.focus\\\\:inset-y-auto:focus {
+  top: auto;
+  bottom: auto;
+}
+
+.focus\\\\:inset-y-px:focus {
+  top: 1px;
+  bottom: 1px;
+}
+
+.focus\\\\:inset-y-0\\\\.5:focus {
+  top: 0.125rem;
+  bottom: 0.125rem;
+}
+
+.focus\\\\:inset-y-1\\\\.5:focus {
+  top: 0.375rem;
+  bottom: 0.375rem;
+}
+
+.focus\\\\:inset-y-2\\\\.5:focus {
+  top: 0.625rem;
+  bottom: 0.625rem;
+}
+
+.focus\\\\:inset-y-3\\\\.5:focus {
+  top: 0.875rem;
+  bottom: 0.875rem;
+}
+
+.focus\\\\:-inset-y-0:focus {
+  top: 0px;
+  bottom: 0px;
+}
+
+.focus\\\\:-inset-y-1:focus {
+  top: -0.25rem;
+  bottom: -0.25rem;
+}
+
+.focus\\\\:-inset-y-2:focus {
+  top: -0.5rem;
+  bottom: -0.5rem;
+}
+
+.focus\\\\:-inset-y-3:focus {
+  top: -0.75rem;
+  bottom: -0.75rem;
+}
+
+.focus\\\\:-inset-y-4:focus {
+  top: -1rem;
+  bottom: -1rem;
+}
+
+.focus\\\\:-inset-y-5:focus {
+  top: -1.25rem;
+  bottom: -1.25rem;
+}
+
+.focus\\\\:-inset-y-6:focus {
+  top: -1.5rem;
+  bottom: -1.5rem;
+}
+
+.focus\\\\:-inset-y-7:focus {
+  top: -1.75rem;
+  bottom: -1.75rem;
+}
+
+.focus\\\\:-inset-y-8:focus {
+  top: -2rem;
+  bottom: -2rem;
+}
+
+.focus\\\\:-inset-y-9:focus {
+  top: -2.25rem;
+  bottom: -2.25rem;
+}
+
+.focus\\\\:-inset-y-10:focus {
+  top: -2.5rem;
+  bottom: -2.5rem;
+}
+
+.focus\\\\:-inset-y-11:focus {
+  top: -2.75rem;
+  bottom: -2.75rem;
+}
+
+.focus\\\\:-inset-y-12:focus {
+  top: -3rem;
+  bottom: -3rem;
+}
+
+.focus\\\\:-inset-y-14:focus {
+  top: -3.5rem;
+  bottom: -3.5rem;
+}
+
+.focus\\\\:-inset-y-16:focus {
+  top: -4rem;
+  bottom: -4rem;
+}
+
+.focus\\\\:-inset-y-20:focus {
+  top: -5rem;
+  bottom: -5rem;
+}
+
+.focus\\\\:-inset-y-24:focus {
+  top: -6rem;
+  bottom: -6rem;
+}
+
+.focus\\\\:-inset-y-28:focus {
+  top: -7rem;
+  bottom: -7rem;
+}
+
+.focus\\\\:-inset-y-32:focus {
+  top: -8rem;
+  bottom: -8rem;
+}
+
+.focus\\\\:-inset-y-36:focus {
+  top: -9rem;
+  bottom: -9rem;
+}
+
+.focus\\\\:-inset-y-40:focus {
+  top: -10rem;
+  bottom: -10rem;
+}
+
+.focus\\\\:-inset-y-44:focus {
+  top: -11rem;
+  bottom: -11rem;
+}
+
+.focus\\\\:-inset-y-48:focus {
+  top: -12rem;
+  bottom: -12rem;
+}
+
+.focus\\\\:-inset-y-52:focus {
+  top: -13rem;
+  bottom: -13rem;
+}
+
+.focus\\\\:-inset-y-56:focus {
+  top: -14rem;
+  bottom: -14rem;
+}
+
+.focus\\\\:-inset-y-60:focus {
+  top: -15rem;
+  bottom: -15rem;
+}
+
+.focus\\\\:-inset-y-64:focus {
+  top: -16rem;
+  bottom: -16rem;
+}
+
+.focus\\\\:-inset-y-72:focus {
+  top: -18rem;
+  bottom: -18rem;
+}
+
+.focus\\\\:-inset-y-80:focus {
+  top: -20rem;
+  bottom: -20rem;
+}
+
+.focus\\\\:-inset-y-96:focus {
+  top: -24rem;
+  bottom: -24rem;
+}
+
+.focus\\\\:-inset-y-px:focus {
+  top: -1px;
+  bottom: -1px;
+}
+
+.focus\\\\:-inset-y-0\\\\.5:focus {
+  top: -0.125rem;
+  bottom: -0.125rem;
+}
+
+.focus\\\\:-inset-y-1\\\\.5:focus {
+  top: -0.375rem;
+  bottom: -0.375rem;
+}
+
+.focus\\\\:-inset-y-2\\\\.5:focus {
+  top: -0.625rem;
+  bottom: -0.625rem;
+}
+
+.focus\\\\:-inset-y-3\\\\.5:focus {
+  top: -0.875rem;
+  bottom: -0.875rem;
+}
+
+.focus\\\\:inset-y-1\\\\/2:focus {
+  top: 50%;
+  bottom: 50%;
+}
+
+.focus\\\\:inset-y-1\\\\/3:focus {
+  top: 33.333333%;
+  bottom: 33.333333%;
+}
+
+.focus\\\\:inset-y-2\\\\/3:focus {
+  top: 66.666667%;
+  bottom: 66.666667%;
+}
+
+.focus\\\\:inset-y-1\\\\/4:focus {
+  top: 25%;
+  bottom: 25%;
+}
+
+.focus\\\\:inset-y-2\\\\/4:focus {
+  top: 50%;
+  bottom: 50%;
+}
+
+.focus\\\\:inset-y-3\\\\/4:focus {
+  top: 75%;
+  bottom: 75%;
+}
+
+.focus\\\\:inset-y-full:focus {
+  top: 100%;
+  bottom: 100%;
+}
+
+.focus\\\\:-inset-y-1\\\\/2:focus {
+  top: -50%;
+  bottom: -50%;
+}
+
+.focus\\\\:-inset-y-1\\\\/3:focus {
+  top: -33.333333%;
+  bottom: -33.333333%;
+}
+
+.focus\\\\:-inset-y-2\\\\/3:focus {
+  top: -66.666667%;
+  bottom: -66.666667%;
+}
+
+.focus\\\\:-inset-y-1\\\\/4:focus {
+  top: -25%;
+  bottom: -25%;
+}
+
+.focus\\\\:-inset-y-2\\\\/4:focus {
+  top: -50%;
+  bottom: -50%;
+}
+
+.focus\\\\:-inset-y-3\\\\/4:focus {
+  top: -75%;
+  bottom: -75%;
+}
+
+.focus\\\\:-inset-y-full:focus {
+  top: -100%;
+  bottom: -100%;
+}
+
+.top-0 {
+  top: 0px;
+}
+
+.top-1 {
+  top: 0.25rem;
+}
+
+.top-2 {
+  top: 0.5rem;
+}
+
+.top-3 {
+  top: 0.75rem;
+}
+
+.top-4 {
+  top: 1rem;
+}
+
+.top-5 {
+  top: 1.25rem;
+}
+
+.top-6 {
+  top: 1.5rem;
+}
+
+.top-7 {
+  top: 1.75rem;
+}
+
+.top-8 {
+  top: 2rem;
+}
+
+.top-9 {
+  top: 2.25rem;
+}
+
+.top-10 {
+  top: 2.5rem;
+}
+
+.top-11 {
+  top: 2.75rem;
+}
+
+.top-12 {
+  top: 3rem;
+}
+
+.top-14 {
+  top: 3.5rem;
+}
+
+.top-16 {
+  top: 4rem;
+}
+
+.top-20 {
+  top: 5rem;
+}
+
+.top-24 {
+  top: 6rem;
+}
+
+.top-28 {
+  top: 7rem;
+}
+
+.top-32 {
+  top: 8rem;
+}
+
+.top-36 {
+  top: 9rem;
+}
+
+.top-40 {
+  top: 10rem;
+}
+
+.top-44 {
+  top: 11rem;
+}
+
+.top-48 {
+  top: 12rem;
+}
+
+.top-52 {
+  top: 13rem;
+}
+
+.top-56 {
+  top: 14rem;
+}
+
+.top-60 {
+  top: 15rem;
+}
+
+.top-64 {
+  top: 16rem;
+}
+
+.top-72 {
+  top: 18rem;
+}
+
+.top-80 {
+  top: 20rem;
+}
+
+.top-96 {
+  top: 24rem;
+}
+
+.top-auto {
+  top: auto;
+}
+
+.top-px {
+  top: 1px;
+}
+
+.top-0\\\\.5 {
+  top: 0.125rem;
+}
+
+.top-1\\\\.5 {
+  top: 0.375rem;
+}
+
+.top-2\\\\.5 {
+  top: 0.625rem;
+}
+
+.top-3\\\\.5 {
+  top: 0.875rem;
+}
+
+.-top-0 {
+  top: 0px;
+}
+
+.-top-1 {
+  top: -0.25rem;
+}
+
+.-top-2 {
+  top: -0.5rem;
+}
+
+.-top-3 {
+  top: -0.75rem;
+}
+
+.-top-4 {
+  top: -1rem;
+}
+
+.-top-5 {
+  top: -1.25rem;
+}
+
+.-top-6 {
+  top: -1.5rem;
+}
+
+.-top-7 {
+  top: -1.75rem;
+}
+
+.-top-8 {
+  top: -2rem;
+}
+
+.-top-9 {
+  top: -2.25rem;
+}
+
+.-top-10 {
+  top: -2.5rem;
+}
+
+.-top-11 {
+  top: -2.75rem;
+}
+
+.-top-12 {
+  top: -3rem;
+}
+
+.-top-14 {
+  top: -3.5rem;
+}
+
+.-top-16 {
+  top: -4rem;
+}
+
+.-top-20 {
+  top: -5rem;
+}
+
+.-top-24 {
+  top: -6rem;
+}
+
+.-top-28 {
+  top: -7rem;
+}
+
+.-top-32 {
+  top: -8rem;
+}
+
+.-top-36 {
+  top: -9rem;
+}
+
+.-top-40 {
+  top: -10rem;
+}
+
+.-top-44 {
+  top: -11rem;
+}
+
+.-top-48 {
+  top: -12rem;
+}
+
+.-top-52 {
+  top: -13rem;
+}
+
+.-top-56 {
+  top: -14rem;
+}
+
+.-top-60 {
+  top: -15rem;
+}
+
+.-top-64 {
+  top: -16rem;
+}
+
+.-top-72 {
+  top: -18rem;
+}
+
+.-top-80 {
+  top: -20rem;
+}
+
+.-top-96 {
+  top: -24rem;
+}
+
+.-top-px {
+  top: -1px;
+}
+
+.-top-0\\\\.5 {
+  top: -0.125rem;
+}
+
+.-top-1\\\\.5 {
+  top: -0.375rem;
+}
+
+.-top-2\\\\.5 {
+  top: -0.625rem;
+}
+
+.-top-3\\\\.5 {
+  top: -0.875rem;
+}
+
+.top-1\\\\/2 {
+  top: 50%;
+}
+
+.top-1\\\\/3 {
+  top: 33.333333%;
+}
+
+.top-2\\\\/3 {
+  top: 66.666667%;
+}
+
+.top-1\\\\/4 {
+  top: 25%;
+}
+
+.top-2\\\\/4 {
+  top: 50%;
+}
+
+.top-3\\\\/4 {
+  top: 75%;
+}
+
+.top-full {
+  top: 100%;
+}
+
+.-top-1\\\\/2 {
+  top: -50%;
+}
+
+.-top-1\\\\/3 {
+  top: -33.333333%;
+}
+
+.-top-2\\\\/3 {
+  top: -66.666667%;
+}
+
+.-top-1\\\\/4 {
+  top: -25%;
+}
+
+.-top-2\\\\/4 {
+  top: -50%;
+}
+
+.-top-3\\\\/4 {
+  top: -75%;
+}
+
+.-top-full {
+  top: -100%;
+}
+
+.right-0 {
+  right: 0px;
+}
+
+.right-1 {
+  right: 0.25rem;
+}
+
+.right-2 {
+  right: 0.5rem;
+}
+
+.right-3 {
+  right: 0.75rem;
+}
+
+.right-4 {
+  right: 1rem;
+}
+
+.right-5 {
+  right: 1.25rem;
+}
+
+.right-6 {
+  right: 1.5rem;
+}
+
+.right-7 {
+  right: 1.75rem;
+}
+
+.right-8 {
+  right: 2rem;
+}
+
+.right-9 {
+  right: 2.25rem;
+}
+
+.right-10 {
+  right: 2.5rem;
+}
+
+.right-11 {
+  right: 2.75rem;
+}
+
+.right-12 {
+  right: 3rem;
+}
+
+.right-14 {
+  right: 3.5rem;
+}
+
+.right-16 {
+  right: 4rem;
+}
+
+.right-20 {
+  right: 5rem;
+}
+
+.right-24 {
+  right: 6rem;
+}
+
+.right-28 {
+  right: 7rem;
+}
+
+.right-32 {
+  right: 8rem;
+}
+
+.right-36 {
+  right: 9rem;
+}
+
+.right-40 {
+  right: 10rem;
+}
+
+.right-44 {
+  right: 11rem;
+}
+
+.right-48 {
+  right: 12rem;
+}
+
+.right-52 {
+  right: 13rem;
+}
+
+.right-56 {
+  right: 14rem;
+}
+
+.right-60 {
+  right: 15rem;
+}
+
+.right-64 {
+  right: 16rem;
+}
+
+.right-72 {
+  right: 18rem;
+}
+
+.right-80 {
+  right: 20rem;
+}
+
+.right-96 {
+  right: 24rem;
+}
+
+.right-auto {
+  right: auto;
+}
+
+.right-px {
+  right: 1px;
+}
+
+.right-0\\\\.5 {
+  right: 0.125rem;
+}
+
+.right-1\\\\.5 {
+  right: 0.375rem;
+}
+
+.right-2\\\\.5 {
+  right: 0.625rem;
+}
+
+.right-3\\\\.5 {
+  right: 0.875rem;
+}
+
+.-right-0 {
+  right: 0px;
+}
+
+.-right-1 {
+  right: -0.25rem;
+}
+
+.-right-2 {
+  right: -0.5rem;
+}
+
+.-right-3 {
+  right: -0.75rem;
+}
+
+.-right-4 {
+  right: -1rem;
+}
+
+.-right-5 {
+  right: -1.25rem;
+}
+
+.-right-6 {
+  right: -1.5rem;
+}
+
+.-right-7 {
+  right: -1.75rem;
+}
+
+.-right-8 {
+  right: -2rem;
+}
+
+.-right-9 {
+  right: -2.25rem;
+}
+
+.-right-10 {
+  right: -2.5rem;
+}
+
+.-right-11 {
+  right: -2.75rem;
+}
+
+.-right-12 {
+  right: -3rem;
+}
+
+.-right-14 {
+  right: -3.5rem;
+}
+
+.-right-16 {
+  right: -4rem;
+}
+
+.-right-20 {
+  right: -5rem;
+}
+
+.-right-24 {
+  right: -6rem;
+}
+
+.-right-28 {
+  right: -7rem;
+}
+
+.-right-32 {
+  right: -8rem;
+}
+
+.-right-36 {
+  right: -9rem;
+}
+
+.-right-40 {
+  right: -10rem;
+}
+
+.-right-44 {
+  right: -11rem;
+}
+
+.-right-48 {
+  right: -12rem;
+}
+
+.-right-52 {
+  right: -13rem;
+}
+
+.-right-56 {
+  right: -14rem;
+}
+
+.-right-60 {
+  right: -15rem;
+}
+
+.-right-64 {
+  right: -16rem;
+}
+
+.-right-72 {
+  right: -18rem;
+}
+
+.-right-80 {
+  right: -20rem;
+}
+
+.-right-96 {
+  right: -24rem;
+}
+
+.-right-px {
+  right: -1px;
+}
+
+.-right-0\\\\.5 {
+  right: -0.125rem;
+}
+
+.-right-1\\\\.5 {
+  right: -0.375rem;
+}
+
+.-right-2\\\\.5 {
+  right: -0.625rem;
+}
+
+.-right-3\\\\.5 {
+  right: -0.875rem;
+}
+
+.right-1\\\\/2 {
+  right: 50%;
+}
+
+.right-1\\\\/3 {
+  right: 33.333333%;
+}
+
+.right-2\\\\/3 {
+  right: 66.666667%;
+}
+
+.right-1\\\\/4 {
+  right: 25%;
+}
+
+.right-2\\\\/4 {
+  right: 50%;
+}
+
+.right-3\\\\/4 {
+  right: 75%;
+}
+
+.right-full {
+  right: 100%;
+}
+
+.-right-1\\\\/2 {
+  right: -50%;
+}
+
+.-right-1\\\\/3 {
+  right: -33.333333%;
+}
+
+.-right-2\\\\/3 {
+  right: -66.666667%;
+}
+
+.-right-1\\\\/4 {
+  right: -25%;
+}
+
+.-right-2\\\\/4 {
+  right: -50%;
+}
+
+.-right-3\\\\/4 {
+  right: -75%;
+}
+
+.-right-full {
+  right: -100%;
+}
+
+.bottom-0 {
+  bottom: 0px;
+}
+
+.bottom-1 {
+  bottom: 0.25rem;
+}
+
+.bottom-2 {
+  bottom: 0.5rem;
+}
+
+.bottom-3 {
+  bottom: 0.75rem;
+}
+
+.bottom-4 {
+  bottom: 1rem;
+}
+
+.bottom-5 {
+  bottom: 1.25rem;
+}
+
+.bottom-6 {
+  bottom: 1.5rem;
+}
+
+.bottom-7 {
+  bottom: 1.75rem;
+}
+
+.bottom-8 {
+  bottom: 2rem;
+}
+
+.bottom-9 {
+  bottom: 2.25rem;
+}
+
+.bottom-10 {
+  bottom: 2.5rem;
+}
+
+.bottom-11 {
+  bottom: 2.75rem;
+}
+
+.bottom-12 {
+  bottom: 3rem;
+}
+
+.bottom-14 {
+  bottom: 3.5rem;
+}
+
+.bottom-16 {
+  bottom: 4rem;
+}
+
+.bottom-20 {
+  bottom: 5rem;
+}
+
+.bottom-24 {
+  bottom: 6rem;
+}
+
+.bottom-28 {
+  bottom: 7rem;
+}
+
+.bottom-32 {
+  bottom: 8rem;
+}
+
+.bottom-36 {
+  bottom: 9rem;
+}
+
+.bottom-40 {
+  bottom: 10rem;
+}
+
+.bottom-44 {
+  bottom: 11rem;
+}
+
+.bottom-48 {
+  bottom: 12rem;
+}
+
+.bottom-52 {
+  bottom: 13rem;
+}
+
+.bottom-56 {
+  bottom: 14rem;
+}
+
+.bottom-60 {
+  bottom: 15rem;
+}
+
+.bottom-64 {
+  bottom: 16rem;
+}
+
+.bottom-72 {
+  bottom: 18rem;
+}
+
+.bottom-80 {
+  bottom: 20rem;
+}
+
+.bottom-96 {
+  bottom: 24rem;
+}
+
+.bottom-auto {
+  bottom: auto;
+}
+
+.bottom-px {
+  bottom: 1px;
+}
+
+.bottom-0\\\\.5 {
+  bottom: 0.125rem;
+}
+
+.bottom-1\\\\.5 {
+  bottom: 0.375rem;
+}
+
+.bottom-2\\\\.5 {
+  bottom: 0.625rem;
+}
+
+.bottom-3\\\\.5 {
+  bottom: 0.875rem;
+}
+
+.-bottom-0 {
+  bottom: 0px;
+}
+
+.-bottom-1 {
+  bottom: -0.25rem;
+}
+
+.-bottom-2 {
+  bottom: -0.5rem;
+}
+
+.-bottom-3 {
+  bottom: -0.75rem;
+}
+
+.-bottom-4 {
+  bottom: -1rem;
+}
+
+.-bottom-5 {
+  bottom: -1.25rem;
+}
+
+.-bottom-6 {
+  bottom: -1.5rem;
+}
+
+.-bottom-7 {
+  bottom: -1.75rem;
+}
+
+.-bottom-8 {
+  bottom: -2rem;
+}
+
+.-bottom-9 {
+  bottom: -2.25rem;
+}
+
+.-bottom-10 {
+  bottom: -2.5rem;
+}
+
+.-bottom-11 {
+  bottom: -2.75rem;
+}
+
+.-bottom-12 {
+  bottom: -3rem;
+}
+
+.-bottom-14 {
+  bottom: -3.5rem;
+}
+
+.-bottom-16 {
+  bottom: -4rem;
+}
+
+.-bottom-20 {
+  bottom: -5rem;
+}
+
+.-bottom-24 {
+  bottom: -6rem;
+}
+
+.-bottom-28 {
+  bottom: -7rem;
+}
+
+.-bottom-32 {
+  bottom: -8rem;
+}
+
+.-bottom-36 {
+  bottom: -9rem;
+}
+
+.-bottom-40 {
+  bottom: -10rem;
+}
+
+.-bottom-44 {
+  bottom: -11rem;
+}
+
+.-bottom-48 {
+  bottom: -12rem;
+}
+
+.-bottom-52 {
+  bottom: -13rem;
+}
+
+.-bottom-56 {
+  bottom: -14rem;
+}
+
+.-bottom-60 {
+  bottom: -15rem;
+}
+
+.-bottom-64 {
+  bottom: -16rem;
+}
+
+.-bottom-72 {
+  bottom: -18rem;
+}
+
+.-bottom-80 {
+  bottom: -20rem;
+}
+
+.-bottom-96 {
+  bottom: -24rem;
+}
+
+.-bottom-px {
+  bottom: -1px;
+}
+
+.-bottom-0\\\\.5 {
+  bottom: -0.125rem;
+}
+
+.-bottom-1\\\\.5 {
+  bottom: -0.375rem;
+}
+
+.-bottom-2\\\\.5 {
+  bottom: -0.625rem;
+}
+
+.-bottom-3\\\\.5 {
+  bottom: -0.875rem;
+}
+
+.bottom-1\\\\/2 {
+  bottom: 50%;
+}
+
+.bottom-1\\\\/3 {
+  bottom: 33.333333%;
+}
+
+.bottom-2\\\\/3 {
+  bottom: 66.666667%;
+}
+
+.bottom-1\\\\/4 {
+  bottom: 25%;
+}
+
+.bottom-2\\\\/4 {
+  bottom: 50%;
+}
+
+.bottom-3\\\\/4 {
+  bottom: 75%;
+}
+
+.bottom-full {
+  bottom: 100%;
+}
+
+.-bottom-1\\\\/2 {
+  bottom: -50%;
+}
+
+.-bottom-1\\\\/3 {
+  bottom: -33.333333%;
+}
+
+.-bottom-2\\\\/3 {
+  bottom: -66.666667%;
+}
+
+.-bottom-1\\\\/4 {
+  bottom: -25%;
+}
+
+.-bottom-2\\\\/4 {
+  bottom: -50%;
+}
+
+.-bottom-3\\\\/4 {
+  bottom: -75%;
+}
+
+.-bottom-full {
+  bottom: -100%;
+}
+
+.left-0 {
+  left: 0px;
+}
+
+.left-1 {
+  left: 0.25rem;
+}
+
+.left-2 {
+  left: 0.5rem;
+}
+
+.left-3 {
+  left: 0.75rem;
+}
+
+.left-4 {
+  left: 1rem;
+}
+
+.left-5 {
+  left: 1.25rem;
+}
+
+.left-6 {
+  left: 1.5rem;
+}
+
+.left-7 {
+  left: 1.75rem;
+}
+
+.left-8 {
+  left: 2rem;
+}
+
+.left-9 {
+  left: 2.25rem;
+}
+
+.left-10 {
+  left: 2.5rem;
+}
+
+.left-11 {
+  left: 2.75rem;
+}
+
+.left-12 {
+  left: 3rem;
+}
+
+.left-14 {
+  left: 3.5rem;
+}
+
+.left-16 {
+  left: 4rem;
+}
+
+.left-20 {
+  left: 5rem;
+}
+
+.left-24 {
+  left: 6rem;
+}
+
+.left-28 {
+  left: 7rem;
+}
+
+.left-32 {
+  left: 8rem;
+}
+
+.left-36 {
+  left: 9rem;
+}
+
+.left-40 {
+  left: 10rem;
+}
+
+.left-44 {
+  left: 11rem;
+}
+
+.left-48 {
+  left: 12rem;
+}
+
+.left-52 {
+  left: 13rem;
+}
+
+.left-56 {
+  left: 14rem;
+}
+
+.left-60 {
+  left: 15rem;
+}
+
+.left-64 {
+  left: 16rem;
+}
+
+.left-72 {
+  left: 18rem;
+}
+
+.left-80 {
+  left: 20rem;
+}
+
+.left-96 {
+  left: 24rem;
+}
+
+.left-auto {
+  left: auto;
+}
+
+.left-px {
+  left: 1px;
+}
+
+.left-0\\\\.5 {
+  left: 0.125rem;
+}
+
+.left-1\\\\.5 {
+  left: 0.375rem;
+}
+
+.left-2\\\\.5 {
+  left: 0.625rem;
+}
+
+.left-3\\\\.5 {
+  left: 0.875rem;
+}
+
+.-left-0 {
+  left: 0px;
+}
+
+.-left-1 {
+  left: -0.25rem;
+}
+
+.-left-2 {
+  left: -0.5rem;
+}
+
+.-left-3 {
+  left: -0.75rem;
+}
+
+.-left-4 {
+  left: -1rem;
+}
+
+.-left-5 {
+  left: -1.25rem;
+}
+
+.-left-6 {
+  left: -1.5rem;
+}
+
+.-left-7 {
+  left: -1.75rem;
+}
+
+.-left-8 {
+  left: -2rem;
+}
+
+.-left-9 {
+  left: -2.25rem;
+}
+
+.-left-10 {
+  left: -2.5rem;
+}
+
+.-left-11 {
+  left: -2.75rem;
+}
+
+.-left-12 {
+  left: -3rem;
+}
+
+.-left-14 {
+  left: -3.5rem;
+}
+
+.-left-16 {
+  left: -4rem;
+}
+
+.-left-20 {
+  left: -5rem;
+}
+
+.-left-24 {
+  left: -6rem;
+}
+
+.-left-28 {
+  left: -7rem;
+}
+
+.-left-32 {
+  left: -8rem;
+}
+
+.-left-36 {
+  left: -9rem;
+}
+
+.-left-40 {
+  left: -10rem;
+}
+
+.-left-44 {
+  left: -11rem;
+}
+
+.-left-48 {
+  left: -12rem;
+}
+
+.-left-52 {
+  left: -13rem;
+}
+
+.-left-56 {
+  left: -14rem;
+}
+
+.-left-60 {
+  left: -15rem;
+}
+
+.-left-64 {
+  left: -16rem;
+}
+
+.-left-72 {
+  left: -18rem;
+}
+
+.-left-80 {
+  left: -20rem;
+}
+
+.-left-96 {
+  left: -24rem;
+}
+
+.-left-px {
+  left: -1px;
+}
+
+.-left-0\\\\.5 {
+  left: -0.125rem;
+}
+
+.-left-1\\\\.5 {
+  left: -0.375rem;
+}
+
+.-left-2\\\\.5 {
+  left: -0.625rem;
+}
+
+.-left-3\\\\.5 {
+  left: -0.875rem;
+}
+
+.left-1\\\\/2 {
+  left: 50%;
+}
+
+.left-1\\\\/3 {
+  left: 33.333333%;
+}
+
+.left-2\\\\/3 {
+  left: 66.666667%;
+}
+
+.left-1\\\\/4 {
+  left: 25%;
+}
+
+.left-2\\\\/4 {
+  left: 50%;
+}
+
+.left-3\\\\/4 {
+  left: 75%;
+}
+
+.left-full {
+  left: 100%;
+}
+
+.-left-1\\\\/2 {
+  left: -50%;
+}
+
+.-left-1\\\\/3 {
+  left: -33.333333%;
+}
+
+.-left-2\\\\/3 {
+  left: -66.666667%;
+}
+
+.-left-1\\\\/4 {
+  left: -25%;
+}
+
+.-left-2\\\\/4 {
+  left: -50%;
+}
+
+.-left-3\\\\/4 {
+  left: -75%;
+}
+
+.-left-full {
+  left: -100%;
+}
+
+.focus\\\\:top-0:focus {
+  top: 0px;
+}
+
+.focus\\\\:top-1:focus {
+  top: 0.25rem;
+}
+
+.focus\\\\:top-2:focus {
+  top: 0.5rem;
+}
+
+.focus\\\\:top-3:focus {
+  top: 0.75rem;
+}
+
+.focus\\\\:top-4:focus {
+  top: 1rem;
+}
+
+.focus\\\\:top-5:focus {
+  top: 1.25rem;
+}
+
+.focus\\\\:top-6:focus {
+  top: 1.5rem;
+}
+
+.focus\\\\:top-7:focus {
+  top: 1.75rem;
+}
+
+.focus\\\\:top-8:focus {
+  top: 2rem;
+}
+
+.focus\\\\:top-9:focus {
+  top: 2.25rem;
+}
+
+.focus\\\\:top-10:focus {
+  top: 2.5rem;
+}
+
+.focus\\\\:top-11:focus {
+  top: 2.75rem;
+}
+
+.focus\\\\:top-12:focus {
+  top: 3rem;
+}
+
+.focus\\\\:top-14:focus {
+  top: 3.5rem;
+}
+
+.focus\\\\:top-16:focus {
+  top: 4rem;
+}
+
+.focus\\\\:top-20:focus {
+  top: 5rem;
+}
+
+.focus\\\\:top-24:focus {
+  top: 6rem;
+}
+
+.focus\\\\:top-28:focus {
+  top: 7rem;
+}
+
+.focus\\\\:top-32:focus {
+  top: 8rem;
+}
+
+.focus\\\\:top-36:focus {
+  top: 9rem;
+}
+
+.focus\\\\:top-40:focus {
+  top: 10rem;
+}
+
+.focus\\\\:top-44:focus {
+  top: 11rem;
+}
+
+.focus\\\\:top-48:focus {
+  top: 12rem;
+}
+
+.focus\\\\:top-52:focus {
+  top: 13rem;
+}
+
+.focus\\\\:top-56:focus {
+  top: 14rem;
+}
+
+.focus\\\\:top-60:focus {
+  top: 15rem;
+}
+
+.focus\\\\:top-64:focus {
+  top: 16rem;
+}
+
+.focus\\\\:top-72:focus {
+  top: 18rem;
+}
+
+.focus\\\\:top-80:focus {
+  top: 20rem;
+}
+
+.focus\\\\:top-96:focus {
+  top: 24rem;
+}
+
+.focus\\\\:top-auto:focus {
+  top: auto;
+}
+
+.focus\\\\:top-px:focus {
+  top: 1px;
+}
+
+.focus\\\\:top-0\\\\.5:focus {
+  top: 0.125rem;
+}
+
+.focus\\\\:top-1\\\\.5:focus {
+  top: 0.375rem;
+}
+
+.focus\\\\:top-2\\\\.5:focus {
+  top: 0.625rem;
+}
+
+.focus\\\\:top-3\\\\.5:focus {
+  top: 0.875rem;
+}
+
+.focus\\\\:-top-0:focus {
+  top: 0px;
+}
+
+.focus\\\\:-top-1:focus {
+  top: -0.25rem;
+}
+
+.focus\\\\:-top-2:focus {
+  top: -0.5rem;
+}
+
+.focus\\\\:-top-3:focus {
+  top: -0.75rem;
+}
+
+.focus\\\\:-top-4:focus {
+  top: -1rem;
+}
+
+.focus\\\\:-top-5:focus {
+  top: -1.25rem;
+}
+
+.focus\\\\:-top-6:focus {
+  top: -1.5rem;
+}
+
+.focus\\\\:-top-7:focus {
+  top: -1.75rem;
+}
+
+.focus\\\\:-top-8:focus {
+  top: -2rem;
+}
+
+.focus\\\\:-top-9:focus {
+  top: -2.25rem;
+}
+
+.focus\\\\:-top-10:focus {
+  top: -2.5rem;
+}
+
+.focus\\\\:-top-11:focus {
+  top: -2.75rem;
+}
+
+.focus\\\\:-top-12:focus {
+  top: -3rem;
+}
+
+.focus\\\\:-top-14:focus {
+  top: -3.5rem;
+}
+
+.focus\\\\:-top-16:focus {
+  top: -4rem;
+}
+
+.focus\\\\:-top-20:focus {
+  top: -5rem;
+}
+
+.focus\\\\:-top-24:focus {
+  top: -6rem;
+}
+
+.focus\\\\:-top-28:focus {
+  top: -7rem;
+}
+
+.focus\\\\:-top-32:focus {
+  top: -8rem;
+}
+
+.focus\\\\:-top-36:focus {
+  top: -9rem;
+}
+
+.focus\\\\:-top-40:focus {
+  top: -10rem;
+}
+
+.focus\\\\:-top-44:focus {
+  top: -11rem;
+}
+
+.focus\\\\:-top-48:focus {
+  top: -12rem;
+}
+
+.focus\\\\:-top-52:focus {
+  top: -13rem;
+}
+
+.focus\\\\:-top-56:focus {
+  top: -14rem;
+}
+
+.focus\\\\:-top-60:focus {
+  top: -15rem;
+}
+
+.focus\\\\:-top-64:focus {
+  top: -16rem;
+}
+
+.focus\\\\:-top-72:focus {
+  top: -18rem;
+}
+
+.focus\\\\:-top-80:focus {
+  top: -20rem;
+}
+
+.focus\\\\:-top-96:focus {
+  top: -24rem;
+}
+
+.focus\\\\:-top-px:focus {
+  top: -1px;
+}
+
+.focus\\\\:-top-0\\\\.5:focus {
+  top: -0.125rem;
+}
+
+.focus\\\\:-top-1\\\\.5:focus {
+  top: -0.375rem;
+}
+
+.focus\\\\:-top-2\\\\.5:focus {
+  top: -0.625rem;
+}
+
+.focus\\\\:-top-3\\\\.5:focus {
+  top: -0.875rem;
+}
+
+.focus\\\\:top-1\\\\/2:focus {
+  top: 50%;
+}
+
+.focus\\\\:top-1\\\\/3:focus {
+  top: 33.333333%;
+}
+
+.focus\\\\:top-2\\\\/3:focus {
+  top: 66.666667%;
+}
+
+.focus\\\\:top-1\\\\/4:focus {
+  top: 25%;
+}
+
+.focus\\\\:top-2\\\\/4:focus {
+  top: 50%;
+}
+
+.focus\\\\:top-3\\\\/4:focus {
+  top: 75%;
+}
+
+.focus\\\\:top-full:focus {
+  top: 100%;
+}
+
+.focus\\\\:-top-1\\\\/2:focus {
+  top: -50%;
+}
+
+.focus\\\\:-top-1\\\\/3:focus {
+  top: -33.333333%;
+}
+
+.focus\\\\:-top-2\\\\/3:focus {
+  top: -66.666667%;
+}
+
+.focus\\\\:-top-1\\\\/4:focus {
+  top: -25%;
+}
+
+.focus\\\\:-top-2\\\\/4:focus {
+  top: -50%;
+}
+
+.focus\\\\:-top-3\\\\/4:focus {
+  top: -75%;
+}
+
+.focus\\\\:-top-full:focus {
+  top: -100%;
+}
+
+.focus\\\\:right-0:focus {
+  right: 0px;
+}
+
+.focus\\\\:right-1:focus {
+  right: 0.25rem;
+}
+
+.focus\\\\:right-2:focus {
+  right: 0.5rem;
+}
+
+.focus\\\\:right-3:focus {
+  right: 0.75rem;
+}
+
+.focus\\\\:right-4:focus {
+  right: 1rem;
+}
+
+.focus\\\\:right-5:focus {
+  right: 1.25rem;
+}
+
+.focus\\\\:right-6:focus {
+  right: 1.5rem;
+}
+
+.focus\\\\:right-7:focus {
+  right: 1.75rem;
+}
+
+.focus\\\\:right-8:focus {
+  right: 2rem;
+}
+
+.focus\\\\:right-9:focus {
+  right: 2.25rem;
+}
+
+.focus\\\\:right-10:focus {
+  right: 2.5rem;
+}
+
+.focus\\\\:right-11:focus {
+  right: 2.75rem;
+}
+
+.focus\\\\:right-12:focus {
+  right: 3rem;
+}
+
+.focus\\\\:right-14:focus {
+  right: 3.5rem;
+}
+
+.focus\\\\:right-16:focus {
+  right: 4rem;
+}
+
+.focus\\\\:right-20:focus {
+  right: 5rem;
+}
+
+.focus\\\\:right-24:focus {
+  right: 6rem;
+}
+
+.focus\\\\:right-28:focus {
+  right: 7rem;
+}
+
+.focus\\\\:right-32:focus {
+  right: 8rem;
+}
+
+.focus\\\\:right-36:focus {
+  right: 9rem;
+}
+
+.focus\\\\:right-40:focus {
+  right: 10rem;
+}
+
+.focus\\\\:right-44:focus {
+  right: 11rem;
+}
+
+.focus\\\\:right-48:focus {
+  right: 12rem;
+}
+
+.focus\\\\:right-52:focus {
+  right: 13rem;
+}
+
+.focus\\\\:right-56:focus {
+  right: 14rem;
+}
+
+.focus\\\\:right-60:focus {
+  right: 15rem;
+}
+
+.focus\\\\:right-64:focus {
+  right: 16rem;
+}
+
+.focus\\\\:right-72:focus {
+  right: 18rem;
+}
+
+.focus\\\\:right-80:focus {
+  right: 20rem;
+}
+
+.focus\\\\:right-96:focus {
+  right: 24rem;
+}
+
+.focus\\\\:right-auto:focus {
+  right: auto;
+}
+
+.focus\\\\:right-px:focus {
+  right: 1px;
+}
+
+.focus\\\\:right-0\\\\.5:focus {
+  right: 0.125rem;
+}
+
+.focus\\\\:right-1\\\\.5:focus {
+  right: 0.375rem;
+}
+
+.focus\\\\:right-2\\\\.5:focus {
+  right: 0.625rem;
+}
+
+.focus\\\\:right-3\\\\.5:focus {
+  right: 0.875rem;
+}
+
+.focus\\\\:-right-0:focus {
+  right: 0px;
+}
+
+.focus\\\\:-right-1:focus {
+  right: -0.25rem;
+}
+
+.focus\\\\:-right-2:focus {
+  right: -0.5rem;
+}
+
+.focus\\\\:-right-3:focus {
+  right: -0.75rem;
+}
+
+.focus\\\\:-right-4:focus {
+  right: -1rem;
+}
+
+.focus\\\\:-right-5:focus {
+  right: -1.25rem;
+}
+
+.focus\\\\:-right-6:focus {
+  right: -1.5rem;
+}
+
+.focus\\\\:-right-7:focus {
+  right: -1.75rem;
+}
+
+.focus\\\\:-right-8:focus {
+  right: -2rem;
+}
+
+.focus\\\\:-right-9:focus {
+  right: -2.25rem;
+}
+
+.focus\\\\:-right-10:focus {
+  right: -2.5rem;
+}
+
+.focus\\\\:-right-11:focus {
+  right: -2.75rem;
+}
+
+.focus\\\\:-right-12:focus {
+  right: -3rem;
+}
+
+.focus\\\\:-right-14:focus {
+  right: -3.5rem;
+}
+
+.focus\\\\:-right-16:focus {
+  right: -4rem;
+}
+
+.focus\\\\:-right-20:focus {
+  right: -5rem;
+}
+
+.focus\\\\:-right-24:focus {
+  right: -6rem;
+}
+
+.focus\\\\:-right-28:focus {
+  right: -7rem;
+}
+
+.focus\\\\:-right-32:focus {
+  right: -8rem;
+}
+
+.focus\\\\:-right-36:focus {
+  right: -9rem;
+}
+
+.focus\\\\:-right-40:focus {
+  right: -10rem;
+}
+
+.focus\\\\:-right-44:focus {
+  right: -11rem;
+}
+
+.focus\\\\:-right-48:focus {
+  right: -12rem;
+}
+
+.focus\\\\:-right-52:focus {
+  right: -13rem;
+}
+
+.focus\\\\:-right-56:focus {
+  right: -14rem;
+}
+
+.focus\\\\:-right-60:focus {
+  right: -15rem;
+}
+
+.focus\\\\:-right-64:focus {
+  right: -16rem;
+}
+
+.focus\\\\:-right-72:focus {
+  right: -18rem;
+}
+
+.focus\\\\:-right-80:focus {
+  right: -20rem;
+}
+
+.focus\\\\:-right-96:focus {
+  right: -24rem;
+}
+
+.focus\\\\:-right-px:focus {
+  right: -1px;
+}
+
+.focus\\\\:-right-0\\\\.5:focus {
+  right: -0.125rem;
+}
+
+.focus\\\\:-right-1\\\\.5:focus {
+  right: -0.375rem;
+}
+
+.focus\\\\:-right-2\\\\.5:focus {
+  right: -0.625rem;
+}
+
+.focus\\\\:-right-3\\\\.5:focus {
+  right: -0.875rem;
+}
+
+.focus\\\\:right-1\\\\/2:focus {
+  right: 50%;
+}
+
+.focus\\\\:right-1\\\\/3:focus {
+  right: 33.333333%;
+}
+
+.focus\\\\:right-2\\\\/3:focus {
+  right: 66.666667%;
+}
+
+.focus\\\\:right-1\\\\/4:focus {
+  right: 25%;
+}
+
+.focus\\\\:right-2\\\\/4:focus {
+  right: 50%;
+}
+
+.focus\\\\:right-3\\\\/4:focus {
+  right: 75%;
+}
+
+.focus\\\\:right-full:focus {
+  right: 100%;
+}
+
+.focus\\\\:-right-1\\\\/2:focus {
+  right: -50%;
+}
+
+.focus\\\\:-right-1\\\\/3:focus {
+  right: -33.333333%;
+}
+
+.focus\\\\:-right-2\\\\/3:focus {
+  right: -66.666667%;
+}
+
+.focus\\\\:-right-1\\\\/4:focus {
+  right: -25%;
+}
+
+.focus\\\\:-right-2\\\\/4:focus {
+  right: -50%;
+}
+
+.focus\\\\:-right-3\\\\/4:focus {
+  right: -75%;
+}
+
+.focus\\\\:-right-full:focus {
+  right: -100%;
+}
+
+.focus\\\\:bottom-0:focus {
+  bottom: 0px;
+}
+
+.focus\\\\:bottom-1:focus {
+  bottom: 0.25rem;
+}
+
+.focus\\\\:bottom-2:focus {
+  bottom: 0.5rem;
+}
+
+.focus\\\\:bottom-3:focus {
+  bottom: 0.75rem;
+}
+
+.focus\\\\:bottom-4:focus {
+  bottom: 1rem;
+}
+
+.focus\\\\:bottom-5:focus {
+  bottom: 1.25rem;
+}
+
+.focus\\\\:bottom-6:focus {
+  bottom: 1.5rem;
+}
+
+.focus\\\\:bottom-7:focus {
+  bottom: 1.75rem;
+}
+
+.focus\\\\:bottom-8:focus {
+  bottom: 2rem;
+}
+
+.focus\\\\:bottom-9:focus {
+  bottom: 2.25rem;
+}
+
+.focus\\\\:bottom-10:focus {
+  bottom: 2.5rem;
+}
+
+.focus\\\\:bottom-11:focus {
+  bottom: 2.75rem;
+}
+
+.focus\\\\:bottom-12:focus {
+  bottom: 3rem;
+}
+
+.focus\\\\:bottom-14:focus {
+  bottom: 3.5rem;
+}
+
+.focus\\\\:bottom-16:focus {
+  bottom: 4rem;
+}
+
+.focus\\\\:bottom-20:focus {
+  bottom: 5rem;
+}
+
+.focus\\\\:bottom-24:focus {
+  bottom: 6rem;
+}
+
+.focus\\\\:bottom-28:focus {
+  bottom: 7rem;
+}
+
+.focus\\\\:bottom-32:focus {
+  bottom: 8rem;
+}
+
+.focus\\\\:bottom-36:focus {
+  bottom: 9rem;
+}
+
+.focus\\\\:bottom-40:focus {
+  bottom: 10rem;
+}
+
+.focus\\\\:bottom-44:focus {
+  bottom: 11rem;
+}
+
+.focus\\\\:bottom-48:focus {
+  bottom: 12rem;
+}
+
+.focus\\\\:bottom-52:focus {
+  bottom: 13rem;
+}
+
+.focus\\\\:bottom-56:focus {
+  bottom: 14rem;
+}
+
+.focus\\\\:bottom-60:focus {
+  bottom: 15rem;
+}
+
+.focus\\\\:bottom-64:focus {
+  bottom: 16rem;
+}
+
+.focus\\\\:bottom-72:focus {
+  bottom: 18rem;
+}
+
+.focus\\\\:bottom-80:focus {
+  bottom: 20rem;
+}
+
+.focus\\\\:bottom-96:focus {
+  bottom: 24rem;
+}
+
+.focus\\\\:bottom-auto:focus {
+  bottom: auto;
+}
+
+.focus\\\\:bottom-px:focus {
+  bottom: 1px;
+}
+
+.focus\\\\:bottom-0\\\\.5:focus {
+  bottom: 0.125rem;
+}
+
+.focus\\\\:bottom-1\\\\.5:focus {
+  bottom: 0.375rem;
+}
+
+.focus\\\\:bottom-2\\\\.5:focus {
+  bottom: 0.625rem;
+}
+
+.focus\\\\:bottom-3\\\\.5:focus {
+  bottom: 0.875rem;
+}
+
+.focus\\\\:-bottom-0:focus {
+  bottom: 0px;
+}
+
+.focus\\\\:-bottom-1:focus {
+  bottom: -0.25rem;
+}
+
+.focus\\\\:-bottom-2:focus {
+  bottom: -0.5rem;
+}
+
+.focus\\\\:-bottom-3:focus {
+  bottom: -0.75rem;
+}
+
+.focus\\\\:-bottom-4:focus {
+  bottom: -1rem;
+}
+
+.focus\\\\:-bottom-5:focus {
+  bottom: -1.25rem;
+}
+
+.focus\\\\:-bottom-6:focus {
+  bottom: -1.5rem;
+}
+
+.focus\\\\:-bottom-7:focus {
+  bottom: -1.75rem;
+}
+
+.focus\\\\:-bottom-8:focus {
+  bottom: -2rem;
+}
+
+.focus\\\\:-bottom-9:focus {
+  bottom: -2.25rem;
+}
+
+.focus\\\\:-bottom-10:focus {
+  bottom: -2.5rem;
+}
+
+.focus\\\\:-bottom-11:focus {
+  bottom: -2.75rem;
+}
+
+.focus\\\\:-bottom-12:focus {
+  bottom: -3rem;
+}
+
+.focus\\\\:-bottom-14:focus {
+  bottom: -3.5rem;
+}
+
+.focus\\\\:-bottom-16:focus {
+  bottom: -4rem;
+}
+
+.focus\\\\:-bottom-20:focus {
+  bottom: -5rem;
+}
+
+.focus\\\\:-bottom-24:focus {
+  bottom: -6rem;
+}
+
+.focus\\\\:-bottom-28:focus {
+  bottom: -7rem;
+}
+
+.focus\\\\:-bottom-32:focus {
+  bottom: -8rem;
+}
+
+.focus\\\\:-bottom-36:focus {
+  bottom: -9rem;
+}
+
+.focus\\\\:-bottom-40:focus {
+  bottom: -10rem;
+}
+
+.focus\\\\:-bottom-44:focus {
+  bottom: -11rem;
+}
+
+.focus\\\\:-bottom-48:focus {
+  bottom: -12rem;
+}
+
+.focus\\\\:-bottom-52:focus {
+  bottom: -13rem;
+}
+
+.focus\\\\:-bottom-56:focus {
+  bottom: -14rem;
+}
+
+.focus\\\\:-bottom-60:focus {
+  bottom: -15rem;
+}
+
+.focus\\\\:-bottom-64:focus {
+  bottom: -16rem;
+}
+
+.focus\\\\:-bottom-72:focus {
+  bottom: -18rem;
+}
+
+.focus\\\\:-bottom-80:focus {
+  bottom: -20rem;
+}
+
+.focus\\\\:-bottom-96:focus {
+  bottom: -24rem;
+}
+
+.focus\\\\:-bottom-px:focus {
+  bottom: -1px;
+}
+
+.focus\\\\:-bottom-0\\\\.5:focus {
+  bottom: -0.125rem;
+}
+
+.focus\\\\:-bottom-1\\\\.5:focus {
+  bottom: -0.375rem;
+}
+
+.focus\\\\:-bottom-2\\\\.5:focus {
+  bottom: -0.625rem;
+}
+
+.focus\\\\:-bottom-3\\\\.5:focus {
+  bottom: -0.875rem;
+}
+
+.focus\\\\:bottom-1\\\\/2:focus {
+  bottom: 50%;
+}
+
+.focus\\\\:bottom-1\\\\/3:focus {
+  bottom: 33.333333%;
+}
+
+.focus\\\\:bottom-2\\\\/3:focus {
+  bottom: 66.666667%;
+}
+
+.focus\\\\:bottom-1\\\\/4:focus {
+  bottom: 25%;
+}
+
+.focus\\\\:bottom-2\\\\/4:focus {
+  bottom: 50%;
+}
+
+.focus\\\\:bottom-3\\\\/4:focus {
+  bottom: 75%;
+}
+
+.focus\\\\:bottom-full:focus {
+  bottom: 100%;
+}
+
+.focus\\\\:-bottom-1\\\\/2:focus {
+  bottom: -50%;
+}
+
+.focus\\\\:-bottom-1\\\\/3:focus {
+  bottom: -33.333333%;
+}
+
+.focus\\\\:-bottom-2\\\\/3:focus {
+  bottom: -66.666667%;
+}
+
+.focus\\\\:-bottom-1\\\\/4:focus {
+  bottom: -25%;
+}
+
+.focus\\\\:-bottom-2\\\\/4:focus {
+  bottom: -50%;
+}
+
+.focus\\\\:-bottom-3\\\\/4:focus {
+  bottom: -75%;
+}
+
+.focus\\\\:-bottom-full:focus {
+  bottom: -100%;
+}
+
+.focus\\\\:left-0:focus {
+  left: 0px;
+}
+
+.focus\\\\:left-1:focus {
+  left: 0.25rem;
+}
+
+.focus\\\\:left-2:focus {
+  left: 0.5rem;
+}
+
+.focus\\\\:left-3:focus {
+  left: 0.75rem;
+}
+
+.focus\\\\:left-4:focus {
+  left: 1rem;
+}
+
+.focus\\\\:left-5:focus {
+  left: 1.25rem;
+}
+
+.focus\\\\:left-6:focus {
+  left: 1.5rem;
+}
+
+.focus\\\\:left-7:focus {
+  left: 1.75rem;
+}
+
+.focus\\\\:left-8:focus {
+  left: 2rem;
+}
+
+.focus\\\\:left-9:focus {
+  left: 2.25rem;
+}
+
+.focus\\\\:left-10:focus {
+  left: 2.5rem;
+}
+
+.focus\\\\:left-11:focus {
+  left: 2.75rem;
+}
+
+.focus\\\\:left-12:focus {
+  left: 3rem;
+}
+
+.focus\\\\:left-14:focus {
+  left: 3.5rem;
+}
+
+.focus\\\\:left-16:focus {
+  left: 4rem;
+}
+
+.focus\\\\:left-20:focus {
+  left: 5rem;
+}
+
+.focus\\\\:left-24:focus {
+  left: 6rem;
+}
+
+.focus\\\\:left-28:focus {
+  left: 7rem;
+}
+
+.focus\\\\:left-32:focus {
+  left: 8rem;
+}
+
+.focus\\\\:left-36:focus {
+  left: 9rem;
+}
+
+.focus\\\\:left-40:focus {
+  left: 10rem;
+}
+
+.focus\\\\:left-44:focus {
+  left: 11rem;
+}
+
+.focus\\\\:left-48:focus {
+  left: 12rem;
+}
+
+.focus\\\\:left-52:focus {
+  left: 13rem;
+}
+
+.focus\\\\:left-56:focus {
+  left: 14rem;
+}
+
+.focus\\\\:left-60:focus {
+  left: 15rem;
+}
+
+.focus\\\\:left-64:focus {
+  left: 16rem;
+}
+
+.focus\\\\:left-72:focus {
+  left: 18rem;
+}
+
+.focus\\\\:left-80:focus {
+  left: 20rem;
+}
+
+.focus\\\\:left-96:focus {
+  left: 24rem;
+}
+
+.focus\\\\:left-auto:focus {
+  left: auto;
+}
+
+.focus\\\\:left-px:focus {
+  left: 1px;
+}
+
+.focus\\\\:left-0\\\\.5:focus {
+  left: 0.125rem;
+}
+
+.focus\\\\:left-1\\\\.5:focus {
+  left: 0.375rem;
+}
+
+.focus\\\\:left-2\\\\.5:focus {
+  left: 0.625rem;
+}
+
+.focus\\\\:left-3\\\\.5:focus {
+  left: 0.875rem;
+}
+
+.focus\\\\:-left-0:focus {
+  left: 0px;
+}
+
+.focus\\\\:-left-1:focus {
+  left: -0.25rem;
+}
+
+.focus\\\\:-left-2:focus {
+  left: -0.5rem;
+}
+
+.focus\\\\:-left-3:focus {
+  left: -0.75rem;
+}
+
+.focus\\\\:-left-4:focus {
+  left: -1rem;
+}
+
+.focus\\\\:-left-5:focus {
+  left: -1.25rem;
+}
+
+.focus\\\\:-left-6:focus {
+  left: -1.5rem;
+}
+
+.focus\\\\:-left-7:focus {
+  left: -1.75rem;
+}
+
+.focus\\\\:-left-8:focus {
+  left: -2rem;
+}
+
+.focus\\\\:-left-9:focus {
+  left: -2.25rem;
+}
+
+.focus\\\\:-left-10:focus {
+  left: -2.5rem;
+}
+
+.focus\\\\:-left-11:focus {
+  left: -2.75rem;
+}
+
+.focus\\\\:-left-12:focus {
+  left: -3rem;
+}
+
+.focus\\\\:-left-14:focus {
+  left: -3.5rem;
+}
+
+.focus\\\\:-left-16:focus {
+  left: -4rem;
+}
+
+.focus\\\\:-left-20:focus {
+  left: -5rem;
+}
+
+.focus\\\\:-left-24:focus {
+  left: -6rem;
+}
+
+.focus\\\\:-left-28:focus {
+  left: -7rem;
+}
+
+.focus\\\\:-left-32:focus {
+  left: -8rem;
+}
+
+.focus\\\\:-left-36:focus {
+  left: -9rem;
+}
+
+.focus\\\\:-left-40:focus {
+  left: -10rem;
+}
+
+.focus\\\\:-left-44:focus {
+  left: -11rem;
+}
+
+.focus\\\\:-left-48:focus {
+  left: -12rem;
+}
+
+.focus\\\\:-left-52:focus {
+  left: -13rem;
+}
+
+.focus\\\\:-left-56:focus {
+  left: -14rem;
+}
+
+.focus\\\\:-left-60:focus {
+  left: -15rem;
+}
+
+.focus\\\\:-left-64:focus {
+  left: -16rem;
+}
+
+.focus\\\\:-left-72:focus {
+  left: -18rem;
+}
+
+.focus\\\\:-left-80:focus {
+  left: -20rem;
+}
+
+.focus\\\\:-left-96:focus {
+  left: -24rem;
+}
+
+.focus\\\\:-left-px:focus {
+  left: -1px;
+}
+
+.focus\\\\:-left-0\\\\.5:focus {
+  left: -0.125rem;
+}
+
+.focus\\\\:-left-1\\\\.5:focus {
+  left: -0.375rem;
+}
+
+.focus\\\\:-left-2\\\\.5:focus {
+  left: -0.625rem;
+}
+
+.focus\\\\:-left-3\\\\.5:focus {
+  left: -0.875rem;
+}
+
+.focus\\\\:left-1\\\\/2:focus {
+  left: 50%;
+}
+
+.focus\\\\:left-1\\\\/3:focus {
+  left: 33.333333%;
+}
+
+.focus\\\\:left-2\\\\/3:focus {
+  left: 66.666667%;
+}
+
+.focus\\\\:left-1\\\\/4:focus {
+  left: 25%;
+}
+
+.focus\\\\:left-2\\\\/4:focus {
+  left: 50%;
+}
+
+.focus\\\\:left-3\\\\/4:focus {
+  left: 75%;
+}
+
+.focus\\\\:left-full:focus {
+  left: 100%;
+}
+
+.focus\\\\:-left-1\\\\/2:focus {
+  left: -50%;
+}
+
+.focus\\\\:-left-1\\\\/3:focus {
+  left: -33.333333%;
+}
+
+.focus\\\\:-left-2\\\\/3:focus {
+  left: -66.666667%;
+}
+
+.focus\\\\:-left-1\\\\/4:focus {
+  left: -25%;
+}
+
+.focus\\\\:-left-2\\\\/4:focus {
+  left: -50%;
+}
+
+.focus\\\\:-left-3\\\\/4:focus {
+  left: -75%;
+}
+
+.focus\\\\:-left-full:focus {
+  left: -100%;
+}
+
+.isolate {
+  isolation: isolate;
+}
+
+.isolation-auto {
+  isolation: auto;
+}
+
+.z-1 {
+  z-index: 1;
+}
+
+.z-2 {
+  z-index: 2;
+}
+
+.z-3 {
+  z-index: 3;
+}
+
+.z-4 {
+  z-index: 4;
+}
+
+.z-5 {
+  z-index: 5;
+}
+
+.z-6 {
+  z-index: 6;
+}
+
+.z-7 {
+  z-index: 7;
+}
+
+.z-8 {
+  z-index: 8;
+}
+
+.z-9 {
+  z-index: 9;
+}
+
+.z-10 {
+  z-index: 10;
+}
+
+.-z-1 {
+  z-index: -1;
+}
+
+.z-flash-messages {
+  z-index: var(--z-index-flash-messages);
+}
+
+.z-overlay {
+  z-index: var(--z-index-overlay);
+}
+
+.z-tooltip {
+  z-index: var(--z-index-tooltip);
+}
+
+.z-popover-sticky {
+  z-index: var(--z-index-popover-sticky);
+}
+
+.z-popover {
+  z-index: var(--z-index-popover);
+}
+
+.z-skip-to-content {
+  z-index: var(--z-index-skip-to-content);
+}
+
+.z-tablist {
+  z-index: var(--z-index-tablist);
+}
+
+.z-tabpanel {
+  z-index: var(--z-index-tabpanel);
+}
+
+.z-tabpanel-scrim {
+  z-index: var(--z-index-tabpanel-scrim);
+}
+
+.z-template-head {
+  z-index: var(--z-index-template-head);
+}
+
+.z-template-main-head-sticky {
+  z-index: var(--z-index-template-main-head-sticky);
+}
+
+.z-template-main-head {
+  z-index: var(--z-index-template-main-head);
+}
+
+.z-template-main {
+  z-index: var(--z-index-template-main);
+}
+
+.z-search-results-navigation {
+  z-index: var(--z-index-navigation-search);
+}
+
+.hover\\\\:z-1:hover {
+  z-index: 1;
+}
+
+.hover\\\\:z-2:hover {
+  z-index: 2;
+}
+
+.hover\\\\:z-3:hover {
+  z-index: 3;
+}
+
+.hover\\\\:z-4:hover {
+  z-index: 4;
+}
+
+.hover\\\\:z-5:hover {
+  z-index: 5;
+}
+
+.hover\\\\:z-6:hover {
+  z-index: 6;
+}
+
+.hover\\\\:z-7:hover {
+  z-index: 7;
+}
+
+.hover\\\\:z-8:hover {
+  z-index: 8;
+}
+
+.hover\\\\:z-9:hover {
+  z-index: 9;
+}
+
+.hover\\\\:z-10:hover {
+  z-index: 10;
+}
+
+.hover\\\\:-z-1:hover {
+  z-index: -1;
+}
+
+.hover\\\\:z-flash-messages:hover {
+  z-index: var(--z-index-flash-messages);
+}
+
+.hover\\\\:z-overlay:hover {
+  z-index: var(--z-index-overlay);
+}
+
+.hover\\\\:z-tooltip:hover {
+  z-index: var(--z-index-tooltip);
+}
+
+.hover\\\\:z-popover-sticky:hover {
+  z-index: var(--z-index-popover-sticky);
+}
+
+.hover\\\\:z-popover:hover {
+  z-index: var(--z-index-popover);
+}
+
+.hover\\\\:z-skip-to-content:hover {
+  z-index: var(--z-index-skip-to-content);
+}
+
+.hover\\\\:z-tablist:hover {
+  z-index: var(--z-index-tablist);
+}
+
+.hover\\\\:z-tabpanel:hover {
+  z-index: var(--z-index-tabpanel);
+}
+
+.hover\\\\:z-tabpanel-scrim:hover {
+  z-index: var(--z-index-tabpanel-scrim);
+}
+
+.hover\\\\:z-template-head:hover {
+  z-index: var(--z-index-template-head);
+}
+
+.hover\\\\:z-template-main-head-sticky:hover {
+  z-index: var(--z-index-template-main-head-sticky);
+}
+
+.hover\\\\:z-template-main-head:hover {
+  z-index: var(--z-index-template-main-head);
+}
+
+.hover\\\\:z-template-main:hover {
+  z-index: var(--z-index-template-main);
+}
+
+.hover\\\\:z-search-results-navigation:hover {
+  z-index: var(--z-index-navigation-search);
+}
+
+.active\\\\:z-1:active {
+  z-index: 1;
+}
+
+.active\\\\:z-2:active {
+  z-index: 2;
+}
+
+.active\\\\:z-3:active {
+  z-index: 3;
+}
+
+.active\\\\:z-4:active {
+  z-index: 4;
+}
+
+.active\\\\:z-5:active {
+  z-index: 5;
+}
+
+.active\\\\:z-6:active {
+  z-index: 6;
+}
+
+.active\\\\:z-7:active {
+  z-index: 7;
+}
+
+.active\\\\:z-8:active {
+  z-index: 8;
+}
+
+.active\\\\:z-9:active {
+  z-index: 9;
+}
+
+.active\\\\:z-10:active {
+  z-index: 10;
+}
+
+.active\\\\:-z-1:active {
+  z-index: -1;
+}
+
+.active\\\\:z-flash-messages:active {
+  z-index: var(--z-index-flash-messages);
+}
+
+.active\\\\:z-overlay:active {
+  z-index: var(--z-index-overlay);
+}
+
+.active\\\\:z-tooltip:active {
+  z-index: var(--z-index-tooltip);
+}
+
+.active\\\\:z-popover-sticky:active {
+  z-index: var(--z-index-popover-sticky);
+}
+
+.active\\\\:z-popover:active {
+  z-index: var(--z-index-popover);
+}
+
+.active\\\\:z-skip-to-content:active {
+  z-index: var(--z-index-skip-to-content);
+}
+
+.active\\\\:z-tablist:active {
+  z-index: var(--z-index-tablist);
+}
+
+.active\\\\:z-tabpanel:active {
+  z-index: var(--z-index-tabpanel);
+}
+
+.active\\\\:z-tabpanel-scrim:active {
+  z-index: var(--z-index-tabpanel-scrim);
+}
+
+.active\\\\:z-template-head:active {
+  z-index: var(--z-index-template-head);
+}
+
+.active\\\\:z-template-main-head-sticky:active {
+  z-index: var(--z-index-template-main-head-sticky);
+}
+
+.active\\\\:z-template-main-head:active {
+  z-index: var(--z-index-template-main-head);
+}
+
+.active\\\\:z-template-main:active {
+  z-index: var(--z-index-template-main);
+}
+
+.active\\\\:z-search-results-navigation:active {
+  z-index: var(--z-index-navigation-search);
+}
+
+.group:hover .group-hover\\\\:z-1 {
+  z-index: 1;
+}
+
+.group:hover .group-hover\\\\:z-2 {
+  z-index: 2;
+}
+
+.group:hover .group-hover\\\\:z-3 {
+  z-index: 3;
+}
+
+.group:hover .group-hover\\\\:z-4 {
+  z-index: 4;
+}
+
+.group:hover .group-hover\\\\:z-5 {
+  z-index: 5;
+}
+
+.group:hover .group-hover\\\\:z-6 {
+  z-index: 6;
+}
+
+.group:hover .group-hover\\\\:z-7 {
+  z-index: 7;
+}
+
+.group:hover .group-hover\\\\:z-8 {
+  z-index: 8;
+}
+
+.group:hover .group-hover\\\\:z-9 {
+  z-index: 9;
+}
+
+.group:hover .group-hover\\\\:z-10 {
+  z-index: 10;
+}
+
+.group:hover .group-hover\\\\:-z-1 {
+  z-index: -1;
+}
+
+.group:hover .group-hover\\\\:z-flash-messages {
+  z-index: var(--z-index-flash-messages);
+}
+
+.group:hover .group-hover\\\\:z-overlay {
+  z-index: var(--z-index-overlay);
+}
+
+.group:hover .group-hover\\\\:z-tooltip {
+  z-index: var(--z-index-tooltip);
+}
+
+.group:hover .group-hover\\\\:z-popover-sticky {
+  z-index: var(--z-index-popover-sticky);
+}
+
+.group:hover .group-hover\\\\:z-popover {
+  z-index: var(--z-index-popover);
+}
+
+.group:hover .group-hover\\\\:z-skip-to-content {
+  z-index: var(--z-index-skip-to-content);
+}
+
+.group:hover .group-hover\\\\:z-tablist {
+  z-index: var(--z-index-tablist);
+}
+
+.group:hover .group-hover\\\\:z-tabpanel {
+  z-index: var(--z-index-tabpanel);
+}
+
+.group:hover .group-hover\\\\:z-tabpanel-scrim {
+  z-index: var(--z-index-tabpanel-scrim);
+}
+
+.group:hover .group-hover\\\\:z-template-head {
+  z-index: var(--z-index-template-head);
+}
+
+.group:hover .group-hover\\\\:z-template-main-head-sticky {
+  z-index: var(--z-index-template-main-head-sticky);
+}
+
+.group:hover .group-hover\\\\:z-template-main-head {
+  z-index: var(--z-index-template-main-head);
+}
+
+.group:hover .group-hover\\\\:z-template-main {
+  z-index: var(--z-index-template-main);
+}
+
+.group:hover .group-hover\\\\:z-search-results-navigation {
+  z-index: var(--z-index-navigation-search);
+}
+
+.order-1 {
+  order: 1;
+}
+
+.order-2 {
+  order: 2;
+}
+
+.order-3 {
+  order: 3;
+}
+
+.order-4 {
+  order: 4;
+}
+
+.order-5 {
+  order: 5;
+}
+
+.order-6 {
+  order: 6;
+}
+
+.order-7 {
+  order: 7;
+}
+
+.order-8 {
+  order: 8;
+}
+
+.order-9 {
+  order: 9;
+}
+
+.order-10 {
+  order: 10;
+}
+
+.order-11 {
+  order: 11;
+}
+
+.order-12 {
+  order: 12;
+}
+
+.order-first {
+  order: -9999;
+}
+
+.order-last {
+  order: 9999;
+}
+
+.order-none {
+  order: 0;
+}
+
+.col-auto {
+  grid-column: auto;
+}
+
+.col-span-1 {
+  grid-column: span 1 / span 1;
+}
+
+.col-span-2 {
+  grid-column: span 2 / span 2;
+}
+
+.col-span-3 {
+  grid-column: span 3 / span 3;
+}
+
+.col-span-4 {
+  grid-column: span 4 / span 4;
+}
+
+.col-span-5 {
+  grid-column: span 5 / span 5;
+}
+
+.col-span-6 {
+  grid-column: span 6 / span 6;
+}
+
+.col-span-7 {
+  grid-column: span 7 / span 7;
+}
+
+.col-span-8 {
+  grid-column: span 8 / span 8;
+}
+
+.col-span-9 {
+  grid-column: span 9 / span 9;
+}
+
+.col-span-10 {
+  grid-column: span 10 / span 10;
+}
+
+.col-span-11 {
+  grid-column: span 11 / span 11;
+}
+
+.col-span-12 {
+  grid-column: span 12 / span 12;
+}
+
+.col-span-full {
+  grid-column: 1 / -1;
+}
+
+.col-start-1 {
+  grid-column-start: 1;
+}
+
+.col-start-2 {
+  grid-column-start: 2;
+}
+
+.col-start-3 {
+  grid-column-start: 3;
+}
+
+.col-start-4 {
+  grid-column-start: 4;
+}
+
+.col-start-5 {
+  grid-column-start: 5;
+}
+
+.col-start-6 {
+  grid-column-start: 6;
+}
+
+.col-start-7 {
+  grid-column-start: 7;
+}
+
+.col-start-8 {
+  grid-column-start: 8;
+}
+
+.col-start-9 {
+  grid-column-start: 9;
+}
+
+.col-start-10 {
+  grid-column-start: 10;
+}
+
+.col-start-11 {
+  grid-column-start: 11;
+}
+
+.col-start-12 {
+  grid-column-start: 12;
+}
+
+.col-start-13 {
+  grid-column-start: 13;
+}
+
+.col-start-auto {
+  grid-column-start: auto;
+}
+
+.col-end-1 {
+  grid-column-end: 1;
+}
+
+.col-end-2 {
+  grid-column-end: 2;
+}
+
+.col-end-3 {
+  grid-column-end: 3;
+}
+
+.col-end-4 {
+  grid-column-end: 4;
+}
+
+.col-end-5 {
+  grid-column-end: 5;
+}
+
+.col-end-6 {
+  grid-column-end: 6;
+}
+
+.col-end-7 {
+  grid-column-end: 7;
+}
+
+.col-end-8 {
+  grid-column-end: 8;
+}
+
+.col-end-9 {
+  grid-column-end: 9;
+}
+
+.col-end-10 {
+  grid-column-end: 10;
+}
+
+.col-end-11 {
+  grid-column-end: 11;
+}
+
+.col-end-12 {
+  grid-column-end: 12;
+}
+
+.col-end-13 {
+  grid-column-end: 13;
+}
+
+.col-end-auto {
+  grid-column-end: auto;
+}
+
+.row-auto {
+  grid-row: auto;
+}
+
+.row-span-1 {
+  grid-row: span 1 / span 1;
+}
+
+.row-span-2 {
+  grid-row: span 2 / span 2;
+}
+
+.row-span-3 {
+  grid-row: span 3 / span 3;
+}
+
+.row-span-4 {
+  grid-row: span 4 / span 4;
+}
+
+.row-span-5 {
+  grid-row: span 5 / span 5;
+}
+
+.row-span-6 {
+  grid-row: span 6 / span 6;
+}
+
+.row-span-full {
+  grid-row: 1 / -1;
+}
+
+.row-start-1 {
+  grid-row-start: 1;
+}
+
+.row-start-2 {
+  grid-row-start: 2;
+}
+
+.row-start-3 {
+  grid-row-start: 3;
+}
+
+.row-start-4 {
+  grid-row-start: 4;
+}
+
+.row-start-5 {
+  grid-row-start: 5;
+}
+
+.row-start-6 {
+  grid-row-start: 6;
+}
+
+.row-start-7 {
+  grid-row-start: 7;
+}
+
+.row-start-auto {
+  grid-row-start: auto;
+}
+
+.row-end-1 {
+  grid-row-end: 1;
+}
+
+.row-end-2 {
+  grid-row-end: 2;
+}
+
+.row-end-3 {
+  grid-row-end: 3;
+}
+
+.row-end-4 {
+  grid-row-end: 4;
+}
+
+.row-end-5 {
+  grid-row-end: 5;
+}
+
+.row-end-6 {
+  grid-row-end: 6;
+}
+
+.row-end-7 {
+  grid-row-end: 7;
+}
+
+.row-end-auto {
+  grid-row-end: auto;
+}
+
+.float-right {
+  float: right;
+}
+
+.float-left {
+  float: left;
+}
+
+.float-none {
+  float: none;
+}
+
+.clear-left {
+  clear: left;
+}
+
+.clear-right {
+  clear: right;
+}
+
+.clear-both {
+  clear: both;
+}
+
+.clear-none {
+  clear: none;
+}
+
+.m-0 {
+  margin: 0px;
+}
+
+.m-1 {
+  margin: 0.25rem;
+}
+
+.m-2 {
+  margin: 0.5rem;
+}
+
+.m-3 {
+  margin: 0.75rem;
+}
+
+.m-4 {
+  margin: 1rem;
+}
+
+.m-5 {
+  margin: 1.25rem;
+}
+
+.m-6 {
+  margin: 1.5rem;
+}
+
+.m-7 {
+  margin: 1.75rem;
+}
+
+.m-8 {
+  margin: 2rem;
+}
+
+.m-9 {
+  margin: 2.25rem;
+}
+
+.m-10 {
+  margin: 2.5rem;
+}
+
+.m-11 {
+  margin: 2.75rem;
+}
+
+.m-12 {
+  margin: 3rem;
+}
+
+.m-14 {
+  margin: 3.5rem;
+}
+
+.m-16 {
+  margin: 4rem;
+}
+
+.m-20 {
+  margin: 5rem;
+}
+
+.m-24 {
+  margin: 6rem;
+}
+
+.m-28 {
+  margin: 7rem;
+}
+
+.m-32 {
+  margin: 8rem;
+}
+
+.m-36 {
+  margin: 9rem;
+}
+
+.m-40 {
+  margin: 10rem;
+}
+
+.m-44 {
+  margin: 11rem;
+}
+
+.m-48 {
+  margin: 12rem;
+}
+
+.m-52 {
+  margin: 13rem;
+}
+
+.m-56 {
+  margin: 14rem;
+}
+
+.m-60 {
+  margin: 15rem;
+}
+
+.m-64 {
+  margin: 16rem;
+}
+
+.m-72 {
+  margin: 18rem;
+}
+
+.m-80 {
+  margin: 20rem;
+}
+
+.m-96 {
+  margin: 24rem;
+}
+
+.m-auto {
+  margin: auto;
+}
+
+.m-px {
+  margin: 1px;
+}
+
+.m-0\\\\.5 {
+  margin: 0.125rem;
+}
+
+.m-1\\\\.5 {
+  margin: 0.375rem;
+}
+
+.m-2\\\\.5 {
+  margin: 0.625rem;
+}
+
+.m-3\\\\.5 {
+  margin: 0.875rem;
+}
+
+.-m-0 {
+  margin: 0px;
+}
+
+.-m-1 {
+  margin: -0.25rem;
+}
+
+.-m-2 {
+  margin: -0.5rem;
+}
+
+.-m-3 {
+  margin: -0.75rem;
+}
+
+.-m-4 {
+  margin: -1rem;
+}
+
+.-m-5 {
+  margin: -1.25rem;
+}
+
+.-m-6 {
+  margin: -1.5rem;
+}
+
+.-m-7 {
+  margin: -1.75rem;
+}
+
+.-m-8 {
+  margin: -2rem;
+}
+
+.-m-9 {
+  margin: -2.25rem;
+}
+
+.-m-10 {
+  margin: -2.5rem;
+}
+
+.-m-11 {
+  margin: -2.75rem;
+}
+
+.-m-12 {
+  margin: -3rem;
+}
+
+.-m-14 {
+  margin: -3.5rem;
+}
+
+.-m-16 {
+  margin: -4rem;
+}
+
+.-m-20 {
+  margin: -5rem;
+}
+
+.-m-24 {
+  margin: -6rem;
+}
+
+.-m-28 {
+  margin: -7rem;
+}
+
+.-m-32 {
+  margin: -8rem;
+}
+
+.-m-36 {
+  margin: -9rem;
+}
+
+.-m-40 {
+  margin: -10rem;
+}
+
+.-m-44 {
+  margin: -11rem;
+}
+
+.-m-48 {
+  margin: -12rem;
+}
+
+.-m-52 {
+  margin: -13rem;
+}
+
+.-m-56 {
+  margin: -14rem;
+}
+
+.-m-60 {
+  margin: -15rem;
+}
+
+.-m-64 {
+  margin: -16rem;
+}
+
+.-m-72 {
+  margin: -18rem;
+}
+
+.-m-80 {
+  margin: -20rem;
+}
+
+.-m-96 {
+  margin: -24rem;
+}
+
+.-m-px {
+  margin: -1px;
+}
+
+.-m-0\\\\.5 {
+  margin: -0.125rem;
+}
+
+.-m-1\\\\.5 {
+  margin: -0.375rem;
+}
+
+.-m-2\\\\.5 {
+  margin: -0.625rem;
+}
+
+.-m-3\\\\.5 {
+  margin: -0.875rem;
+}
+
+.first\\\\:m-0:first-child {
+  margin: 0px;
+}
+
+.first\\\\:m-1:first-child {
+  margin: 0.25rem;
+}
+
+.first\\\\:m-2:first-child {
+  margin: 0.5rem;
+}
+
+.first\\\\:m-3:first-child {
+  margin: 0.75rem;
+}
+
+.first\\\\:m-4:first-child {
+  margin: 1rem;
+}
+
+.first\\\\:m-5:first-child {
+  margin: 1.25rem;
+}
+
+.first\\\\:m-6:first-child {
+  margin: 1.5rem;
+}
+
+.first\\\\:m-7:first-child {
+  margin: 1.75rem;
+}
+
+.first\\\\:m-8:first-child {
+  margin: 2rem;
+}
+
+.first\\\\:m-9:first-child {
+  margin: 2.25rem;
+}
+
+.first\\\\:m-10:first-child {
+  margin: 2.5rem;
+}
+
+.first\\\\:m-11:first-child {
+  margin: 2.75rem;
+}
+
+.first\\\\:m-12:first-child {
+  margin: 3rem;
+}
+
+.first\\\\:m-14:first-child {
+  margin: 3.5rem;
+}
+
+.first\\\\:m-16:first-child {
+  margin: 4rem;
+}
+
+.first\\\\:m-20:first-child {
+  margin: 5rem;
+}
+
+.first\\\\:m-24:first-child {
+  margin: 6rem;
+}
+
+.first\\\\:m-28:first-child {
+  margin: 7rem;
+}
+
+.first\\\\:m-32:first-child {
+  margin: 8rem;
+}
+
+.first\\\\:m-36:first-child {
+  margin: 9rem;
+}
+
+.first\\\\:m-40:first-child {
+  margin: 10rem;
+}
+
+.first\\\\:m-44:first-child {
+  margin: 11rem;
+}
+
+.first\\\\:m-48:first-child {
+  margin: 12rem;
+}
+
+.first\\\\:m-52:first-child {
+  margin: 13rem;
+}
+
+.first\\\\:m-56:first-child {
+  margin: 14rem;
+}
+
+.first\\\\:m-60:first-child {
+  margin: 15rem;
+}
+
+.first\\\\:m-64:first-child {
+  margin: 16rem;
+}
+
+.first\\\\:m-72:first-child {
+  margin: 18rem;
+}
+
+.first\\\\:m-80:first-child {
+  margin: 20rem;
+}
+
+.first\\\\:m-96:first-child {
+  margin: 24rem;
+}
+
+.first\\\\:m-auto:first-child {
+  margin: auto;
+}
+
+.first\\\\:m-px:first-child {
+  margin: 1px;
+}
+
+.first\\\\:m-0\\\\.5:first-child {
+  margin: 0.125rem;
+}
+
+.first\\\\:m-1\\\\.5:first-child {
+  margin: 0.375rem;
+}
+
+.first\\\\:m-2\\\\.5:first-child {
+  margin: 0.625rem;
+}
+
+.first\\\\:m-3\\\\.5:first-child {
+  margin: 0.875rem;
+}
+
+.first\\\\:-m-0:first-child {
+  margin: 0px;
+}
+
+.first\\\\:-m-1:first-child {
+  margin: -0.25rem;
+}
+
+.first\\\\:-m-2:first-child {
+  margin: -0.5rem;
+}
+
+.first\\\\:-m-3:first-child {
+  margin: -0.75rem;
+}
+
+.first\\\\:-m-4:first-child {
+  margin: -1rem;
+}
+
+.first\\\\:-m-5:first-child {
+  margin: -1.25rem;
+}
+
+.first\\\\:-m-6:first-child {
+  margin: -1.5rem;
+}
+
+.first\\\\:-m-7:first-child {
+  margin: -1.75rem;
+}
+
+.first\\\\:-m-8:first-child {
+  margin: -2rem;
+}
+
+.first\\\\:-m-9:first-child {
+  margin: -2.25rem;
+}
+
+.first\\\\:-m-10:first-child {
+  margin: -2.5rem;
+}
+
+.first\\\\:-m-11:first-child {
+  margin: -2.75rem;
+}
+
+.first\\\\:-m-12:first-child {
+  margin: -3rem;
+}
+
+.first\\\\:-m-14:first-child {
+  margin: -3.5rem;
+}
+
+.first\\\\:-m-16:first-child {
+  margin: -4rem;
+}
+
+.first\\\\:-m-20:first-child {
+  margin: -5rem;
+}
+
+.first\\\\:-m-24:first-child {
+  margin: -6rem;
+}
+
+.first\\\\:-m-28:first-child {
+  margin: -7rem;
+}
+
+.first\\\\:-m-32:first-child {
+  margin: -8rem;
+}
+
+.first\\\\:-m-36:first-child {
+  margin: -9rem;
+}
+
+.first\\\\:-m-40:first-child {
+  margin: -10rem;
+}
+
+.first\\\\:-m-44:first-child {
+  margin: -11rem;
+}
+
+.first\\\\:-m-48:first-child {
+  margin: -12rem;
+}
+
+.first\\\\:-m-52:first-child {
+  margin: -13rem;
+}
+
+.first\\\\:-m-56:first-child {
+  margin: -14rem;
+}
+
+.first\\\\:-m-60:first-child {
+  margin: -15rem;
+}
+
+.first\\\\:-m-64:first-child {
+  margin: -16rem;
+}
+
+.first\\\\:-m-72:first-child {
+  margin: -18rem;
+}
+
+.first\\\\:-m-80:first-child {
+  margin: -20rem;
+}
+
+.first\\\\:-m-96:first-child {
+  margin: -24rem;
+}
+
+.first\\\\:-m-px:first-child {
+  margin: -1px;
+}
+
+.first\\\\:-m-0\\\\.5:first-child {
+  margin: -0.125rem;
+}
+
+.first\\\\:-m-1\\\\.5:first-child {
+  margin: -0.375rem;
+}
+
+.first\\\\:-m-2\\\\.5:first-child {
+  margin: -0.625rem;
+}
+
+.first\\\\:-m-3\\\\.5:first-child {
+  margin: -0.875rem;
+}
+
+.last\\\\:m-0:last-child {
+  margin: 0px;
+}
+
+.last\\\\:m-1:last-child {
+  margin: 0.25rem;
+}
+
+.last\\\\:m-2:last-child {
+  margin: 0.5rem;
+}
+
+.last\\\\:m-3:last-child {
+  margin: 0.75rem;
+}
+
+.last\\\\:m-4:last-child {
+  margin: 1rem;
+}
+
+.last\\\\:m-5:last-child {
+  margin: 1.25rem;
+}
+
+.last\\\\:m-6:last-child {
+  margin: 1.5rem;
+}
+
+.last\\\\:m-7:last-child {
+  margin: 1.75rem;
+}
+
+.last\\\\:m-8:last-child {
+  margin: 2rem;
+}
+
+.last\\\\:m-9:last-child {
+  margin: 2.25rem;
+}
+
+.last\\\\:m-10:last-child {
+  margin: 2.5rem;
+}
+
+.last\\\\:m-11:last-child {
+  margin: 2.75rem;
+}
+
+.last\\\\:m-12:last-child {
+  margin: 3rem;
+}
+
+.last\\\\:m-14:last-child {
+  margin: 3.5rem;
+}
+
+.last\\\\:m-16:last-child {
+  margin: 4rem;
+}
+
+.last\\\\:m-20:last-child {
+  margin: 5rem;
+}
+
+.last\\\\:m-24:last-child {
+  margin: 6rem;
+}
+
+.last\\\\:m-28:last-child {
+  margin: 7rem;
+}
+
+.last\\\\:m-32:last-child {
+  margin: 8rem;
+}
+
+.last\\\\:m-36:last-child {
+  margin: 9rem;
+}
+
+.last\\\\:m-40:last-child {
+  margin: 10rem;
+}
+
+.last\\\\:m-44:last-child {
+  margin: 11rem;
+}
+
+.last\\\\:m-48:last-child {
+  margin: 12rem;
+}
+
+.last\\\\:m-52:last-child {
+  margin: 13rem;
+}
+
+.last\\\\:m-56:last-child {
+  margin: 14rem;
+}
+
+.last\\\\:m-60:last-child {
+  margin: 15rem;
+}
+
+.last\\\\:m-64:last-child {
+  margin: 16rem;
+}
+
+.last\\\\:m-72:last-child {
+  margin: 18rem;
+}
+
+.last\\\\:m-80:last-child {
+  margin: 20rem;
+}
+
+.last\\\\:m-96:last-child {
+  margin: 24rem;
+}
+
+.last\\\\:m-auto:last-child {
+  margin: auto;
+}
+
+.last\\\\:m-px:last-child {
+  margin: 1px;
+}
+
+.last\\\\:m-0\\\\.5:last-child {
+  margin: 0.125rem;
+}
+
+.last\\\\:m-1\\\\.5:last-child {
+  margin: 0.375rem;
+}
+
+.last\\\\:m-2\\\\.5:last-child {
+  margin: 0.625rem;
+}
+
+.last\\\\:m-3\\\\.5:last-child {
+  margin: 0.875rem;
+}
+
+.last\\\\:-m-0:last-child {
+  margin: 0px;
+}
+
+.last\\\\:-m-1:last-child {
+  margin: -0.25rem;
+}
+
+.last\\\\:-m-2:last-child {
+  margin: -0.5rem;
+}
+
+.last\\\\:-m-3:last-child {
+  margin: -0.75rem;
+}
+
+.last\\\\:-m-4:last-child {
+  margin: -1rem;
+}
+
+.last\\\\:-m-5:last-child {
+  margin: -1.25rem;
+}
+
+.last\\\\:-m-6:last-child {
+  margin: -1.5rem;
+}
+
+.last\\\\:-m-7:last-child {
+  margin: -1.75rem;
+}
+
+.last\\\\:-m-8:last-child {
+  margin: -2rem;
+}
+
+.last\\\\:-m-9:last-child {
+  margin: -2.25rem;
+}
+
+.last\\\\:-m-10:last-child {
+  margin: -2.5rem;
+}
+
+.last\\\\:-m-11:last-child {
+  margin: -2.75rem;
+}
+
+.last\\\\:-m-12:last-child {
+  margin: -3rem;
+}
+
+.last\\\\:-m-14:last-child {
+  margin: -3.5rem;
+}
+
+.last\\\\:-m-16:last-child {
+  margin: -4rem;
+}
+
+.last\\\\:-m-20:last-child {
+  margin: -5rem;
+}
+
+.last\\\\:-m-24:last-child {
+  margin: -6rem;
+}
+
+.last\\\\:-m-28:last-child {
+  margin: -7rem;
+}
+
+.last\\\\:-m-32:last-child {
+  margin: -8rem;
+}
+
+.last\\\\:-m-36:last-child {
+  margin: -9rem;
+}
+
+.last\\\\:-m-40:last-child {
+  margin: -10rem;
+}
+
+.last\\\\:-m-44:last-child {
+  margin: -11rem;
+}
+
+.last\\\\:-m-48:last-child {
+  margin: -12rem;
+}
+
+.last\\\\:-m-52:last-child {
+  margin: -13rem;
+}
+
+.last\\\\:-m-56:last-child {
+  margin: -14rem;
+}
+
+.last\\\\:-m-60:last-child {
+  margin: -15rem;
+}
+
+.last\\\\:-m-64:last-child {
+  margin: -16rem;
+}
+
+.last\\\\:-m-72:last-child {
+  margin: -18rem;
+}
+
+.last\\\\:-m-80:last-child {
+  margin: -20rem;
+}
+
+.last\\\\:-m-96:last-child {
+  margin: -24rem;
+}
+
+.last\\\\:-m-px:last-child {
+  margin: -1px;
+}
+
+.last\\\\:-m-0\\\\.5:last-child {
+  margin: -0.125rem;
+}
+
+.last\\\\:-m-1\\\\.5:last-child {
+  margin: -0.375rem;
+}
+
+.last\\\\:-m-2\\\\.5:last-child {
+  margin: -0.625rem;
+}
+
+.last\\\\:-m-3\\\\.5:last-child {
+  margin: -0.875rem;
+}
+
+.mx-0 {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.mx-1 {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.mx-2 {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.mx-3 {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
+}
+
+.mx-4 {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.mx-5 {
+  margin-left: 1.25rem;
+  margin-right: 1.25rem;
+}
+
+.mx-6 {
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+}
+
+.mx-7 {
+  margin-left: 1.75rem;
+  margin-right: 1.75rem;
+}
+
+.mx-8 {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.mx-9 {
+  margin-left: 2.25rem;
+  margin-right: 2.25rem;
+}
+
+.mx-10 {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
+}
+
+.mx-11 {
+  margin-left: 2.75rem;
+  margin-right: 2.75rem;
+}
+
+.mx-12 {
+  margin-left: 3rem;
+  margin-right: 3rem;
+}
+
+.mx-14 {
+  margin-left: 3.5rem;
+  margin-right: 3.5rem;
+}
+
+.mx-16 {
+  margin-left: 4rem;
+  margin-right: 4rem;
+}
+
+.mx-20 {
+  margin-left: 5rem;
+  margin-right: 5rem;
+}
+
+.mx-24 {
+  margin-left: 6rem;
+  margin-right: 6rem;
+}
+
+.mx-28 {
+  margin-left: 7rem;
+  margin-right: 7rem;
+}
+
+.mx-32 {
+  margin-left: 8rem;
+  margin-right: 8rem;
+}
+
+.mx-36 {
+  margin-left: 9rem;
+  margin-right: 9rem;
+}
+
+.mx-40 {
+  margin-left: 10rem;
+  margin-right: 10rem;
+}
+
+.mx-44 {
+  margin-left: 11rem;
+  margin-right: 11rem;
+}
+
+.mx-48 {
+  margin-left: 12rem;
+  margin-right: 12rem;
+}
+
+.mx-52 {
+  margin-left: 13rem;
+  margin-right: 13rem;
+}
+
+.mx-56 {
+  margin-left: 14rem;
+  margin-right: 14rem;
+}
+
+.mx-60 {
+  margin-left: 15rem;
+  margin-right: 15rem;
+}
+
+.mx-64 {
+  margin-left: 16rem;
+  margin-right: 16rem;
+}
+
+.mx-72 {
+  margin-left: 18rem;
+  margin-right: 18rem;
+}
+
+.mx-80 {
+  margin-left: 20rem;
+  margin-right: 20rem;
+}
+
+.mx-96 {
+  margin-left: 24rem;
+  margin-right: 24rem;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.mx-px {
+  margin-left: 1px;
+  margin-right: 1px;
+}
+
+.mx-0\\\\.5 {
+  margin-left: 0.125rem;
+  margin-right: 0.125rem;
+}
+
+.mx-1\\\\.5 {
+  margin-left: 0.375rem;
+  margin-right: 0.375rem;
+}
+
+.mx-2\\\\.5 {
+  margin-left: 0.625rem;
+  margin-right: 0.625rem;
+}
+
+.mx-3\\\\.5 {
+  margin-left: 0.875rem;
+  margin-right: 0.875rem;
+}
+
+.-mx-0 {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.-mx-1 {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+.-mx-2 {
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+}
+
+.-mx-3 {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
+
+.-mx-4 {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+.-mx-5 {
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+}
+
+.-mx-6 {
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+}
+
+.-mx-7 {
+  margin-left: -1.75rem;
+  margin-right: -1.75rem;
+}
+
+.-mx-8 {
+  margin-left: -2rem;
+  margin-right: -2rem;
+}
+
+.-mx-9 {
+  margin-left: -2.25rem;
+  margin-right: -2.25rem;
+}
+
+.-mx-10 {
+  margin-left: -2.5rem;
+  margin-right: -2.5rem;
+}
+
+.-mx-11 {
+  margin-left: -2.75rem;
+  margin-right: -2.75rem;
+}
+
+.-mx-12 {
+  margin-left: -3rem;
+  margin-right: -3rem;
+}
+
+.-mx-14 {
+  margin-left: -3.5rem;
+  margin-right: -3.5rem;
+}
+
+.-mx-16 {
+  margin-left: -4rem;
+  margin-right: -4rem;
+}
+
+.-mx-20 {
+  margin-left: -5rem;
+  margin-right: -5rem;
+}
+
+.-mx-24 {
+  margin-left: -6rem;
+  margin-right: -6rem;
+}
+
+.-mx-28 {
+  margin-left: -7rem;
+  margin-right: -7rem;
+}
+
+.-mx-32 {
+  margin-left: -8rem;
+  margin-right: -8rem;
+}
+
+.-mx-36 {
+  margin-left: -9rem;
+  margin-right: -9rem;
+}
+
+.-mx-40 {
+  margin-left: -10rem;
+  margin-right: -10rem;
+}
+
+.-mx-44 {
+  margin-left: -11rem;
+  margin-right: -11rem;
+}
+
+.-mx-48 {
+  margin-left: -12rem;
+  margin-right: -12rem;
+}
+
+.-mx-52 {
+  margin-left: -13rem;
+  margin-right: -13rem;
+}
+
+.-mx-56 {
+  margin-left: -14rem;
+  margin-right: -14rem;
+}
+
+.-mx-60 {
+  margin-left: -15rem;
+  margin-right: -15rem;
+}
+
+.-mx-64 {
+  margin-left: -16rem;
+  margin-right: -16rem;
+}
+
+.-mx-72 {
+  margin-left: -18rem;
+  margin-right: -18rem;
+}
+
+.-mx-80 {
+  margin-left: -20rem;
+  margin-right: -20rem;
+}
+
+.-mx-96 {
+  margin-left: -24rem;
+  margin-right: -24rem;
+}
+
+.-mx-px {
+  margin-left: -1px;
+  margin-right: -1px;
+}
+
+.-mx-0\\\\.5 {
+  margin-left: -0.125rem;
+  margin-right: -0.125rem;
+}
+
+.-mx-1\\\\.5 {
+  margin-left: -0.375rem;
+  margin-right: -0.375rem;
+}
+
+.-mx-2\\\\.5 {
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+}
+
+.-mx-3\\\\.5 {
+  margin-left: -0.875rem;
+  margin-right: -0.875rem;
+}
+
+.my-0 {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.my-1 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.my-3 {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.my-5 {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.my-6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.my-7 {
+  margin-top: 1.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.my-8 {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.my-9 {
+  margin-top: 2.25rem;
+  margin-bottom: 2.25rem;
+}
+
+.my-10 {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.my-11 {
+  margin-top: 2.75rem;
+  margin-bottom: 2.75rem;
+}
+
+.my-12 {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
+
+.my-14 {
+  margin-top: 3.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.my-16 {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+
+.my-20 {
+  margin-top: 5rem;
+  margin-bottom: 5rem;
+}
+
+.my-24 {
+  margin-top: 6rem;
+  margin-bottom: 6rem;
+}
+
+.my-28 {
+  margin-top: 7rem;
+  margin-bottom: 7rem;
+}
+
+.my-32 {
+  margin-top: 8rem;
+  margin-bottom: 8rem;
+}
+
+.my-36 {
+  margin-top: 9rem;
+  margin-bottom: 9rem;
+}
+
+.my-40 {
+  margin-top: 10rem;
+  margin-bottom: 10rem;
+}
+
+.my-44 {
+  margin-top: 11rem;
+  margin-bottom: 11rem;
+}
+
+.my-48 {
+  margin-top: 12rem;
+  margin-bottom: 12rem;
+}
+
+.my-52 {
+  margin-top: 13rem;
+  margin-bottom: 13rem;
+}
+
+.my-56 {
+  margin-top: 14rem;
+  margin-bottom: 14rem;
+}
+
+.my-60 {
+  margin-top: 15rem;
+  margin-bottom: 15rem;
+}
+
+.my-64 {
+  margin-top: 16rem;
+  margin-bottom: 16rem;
+}
+
+.my-72 {
+  margin-top: 18rem;
+  margin-bottom: 18rem;
+}
+
+.my-80 {
+  margin-top: 20rem;
+  margin-bottom: 20rem;
+}
+
+.my-96 {
+  margin-top: 24rem;
+  margin-bottom: 24rem;
+}
+
+.my-auto {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.my-px {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+
+.my-0\\\\.5 {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+}
+
+.my-1\\\\.5 {
+  margin-top: 0.375rem;
+  margin-bottom: 0.375rem;
+}
+
+.my-2\\\\.5 {
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+}
+
+.my-3\\\\.5 {
+  margin-top: 0.875rem;
+  margin-bottom: 0.875rem;
+}
+
+.-my-0 {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.-my-1 {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+}
+
+.-my-2 {
+  margin-top: -0.5rem;
+  margin-bottom: -0.5rem;
+}
+
+.-my-3 {
+  margin-top: -0.75rem;
+  margin-bottom: -0.75rem;
+}
+
+.-my-4 {
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+}
+
+.-my-5 {
+  margin-top: -1.25rem;
+  margin-bottom: -1.25rem;
+}
+
+.-my-6 {
+  margin-top: -1.5rem;
+  margin-bottom: -1.5rem;
+}
+
+.-my-7 {
+  margin-top: -1.75rem;
+  margin-bottom: -1.75rem;
+}
+
+.-my-8 {
+  margin-top: -2rem;
+  margin-bottom: -2rem;
+}
+
+.-my-9 {
+  margin-top: -2.25rem;
+  margin-bottom: -2.25rem;
+}
+
+.-my-10 {
+  margin-top: -2.5rem;
+  margin-bottom: -2.5rem;
+}
+
+.-my-11 {
+  margin-top: -2.75rem;
+  margin-bottom: -2.75rem;
+}
+
+.-my-12 {
+  margin-top: -3rem;
+  margin-bottom: -3rem;
+}
+
+.-my-14 {
+  margin-top: -3.5rem;
+  margin-bottom: -3.5rem;
+}
+
+.-my-16 {
+  margin-top: -4rem;
+  margin-bottom: -4rem;
+}
+
+.-my-20 {
+  margin-top: -5rem;
+  margin-bottom: -5rem;
+}
+
+.-my-24 {
+  margin-top: -6rem;
+  margin-bottom: -6rem;
+}
+
+.-my-28 {
+  margin-top: -7rem;
+  margin-bottom: -7rem;
+}
+
+.-my-32 {
+  margin-top: -8rem;
+  margin-bottom: -8rem;
+}
+
+.-my-36 {
+  margin-top: -9rem;
+  margin-bottom: -9rem;
+}
+
+.-my-40 {
+  margin-top: -10rem;
+  margin-bottom: -10rem;
+}
+
+.-my-44 {
+  margin-top: -11rem;
+  margin-bottom: -11rem;
+}
+
+.-my-48 {
+  margin-top: -12rem;
+  margin-bottom: -12rem;
+}
+
+.-my-52 {
+  margin-top: -13rem;
+  margin-bottom: -13rem;
+}
+
+.-my-56 {
+  margin-top: -14rem;
+  margin-bottom: -14rem;
+}
+
+.-my-60 {
+  margin-top: -15rem;
+  margin-bottom: -15rem;
+}
+
+.-my-64 {
+  margin-top: -16rem;
+  margin-bottom: -16rem;
+}
+
+.-my-72 {
+  margin-top: -18rem;
+  margin-bottom: -18rem;
+}
+
+.-my-80 {
+  margin-top: -20rem;
+  margin-bottom: -20rem;
+}
+
+.-my-96 {
+  margin-top: -24rem;
+  margin-bottom: -24rem;
+}
+
+.-my-px {
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+
+.-my-0\\\\.5 {
+  margin-top: -0.125rem;
+  margin-bottom: -0.125rem;
+}
+
+.-my-1\\\\.5 {
+  margin-top: -0.375rem;
+  margin-bottom: -0.375rem;
+}
+
+.-my-2\\\\.5 {
+  margin-top: -0.625rem;
+  margin-bottom: -0.625rem;
+}
+
+.-my-3\\\\.5 {
+  margin-top: -0.875rem;
+  margin-bottom: -0.875rem;
+}
+
+.first\\\\:mx-0:first-child {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.first\\\\:mx-1:first-child {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.first\\\\:mx-2:first-child {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.first\\\\:mx-3:first-child {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
+}
+
+.first\\\\:mx-4:first-child {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.first\\\\:mx-5:first-child {
+  margin-left: 1.25rem;
+  margin-right: 1.25rem;
+}
+
+.first\\\\:mx-6:first-child {
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+}
+
+.first\\\\:mx-7:first-child {
+  margin-left: 1.75rem;
+  margin-right: 1.75rem;
+}
+
+.first\\\\:mx-8:first-child {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.first\\\\:mx-9:first-child {
+  margin-left: 2.25rem;
+  margin-right: 2.25rem;
+}
+
+.first\\\\:mx-10:first-child {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
+}
+
+.first\\\\:mx-11:first-child {
+  margin-left: 2.75rem;
+  margin-right: 2.75rem;
+}
+
+.first\\\\:mx-12:first-child {
+  margin-left: 3rem;
+  margin-right: 3rem;
+}
+
+.first\\\\:mx-14:first-child {
+  margin-left: 3.5rem;
+  margin-right: 3.5rem;
+}
+
+.first\\\\:mx-16:first-child {
+  margin-left: 4rem;
+  margin-right: 4rem;
+}
+
+.first\\\\:mx-20:first-child {
+  margin-left: 5rem;
+  margin-right: 5rem;
+}
+
+.first\\\\:mx-24:first-child {
+  margin-left: 6rem;
+  margin-right: 6rem;
+}
+
+.first\\\\:mx-28:first-child {
+  margin-left: 7rem;
+  margin-right: 7rem;
+}
+
+.first\\\\:mx-32:first-child {
+  margin-left: 8rem;
+  margin-right: 8rem;
+}
+
+.first\\\\:mx-36:first-child {
+  margin-left: 9rem;
+  margin-right: 9rem;
+}
+
+.first\\\\:mx-40:first-child {
+  margin-left: 10rem;
+  margin-right: 10rem;
+}
+
+.first\\\\:mx-44:first-child {
+  margin-left: 11rem;
+  margin-right: 11rem;
+}
+
+.first\\\\:mx-48:first-child {
+  margin-left: 12rem;
+  margin-right: 12rem;
+}
+
+.first\\\\:mx-52:first-child {
+  margin-left: 13rem;
+  margin-right: 13rem;
+}
+
+.first\\\\:mx-56:first-child {
+  margin-left: 14rem;
+  margin-right: 14rem;
+}
+
+.first\\\\:mx-60:first-child {
+  margin-left: 15rem;
+  margin-right: 15rem;
+}
+
+.first\\\\:mx-64:first-child {
+  margin-left: 16rem;
+  margin-right: 16rem;
+}
+
+.first\\\\:mx-72:first-child {
+  margin-left: 18rem;
+  margin-right: 18rem;
+}
+
+.first\\\\:mx-80:first-child {
+  margin-left: 20rem;
+  margin-right: 20rem;
+}
+
+.first\\\\:mx-96:first-child {
+  margin-left: 24rem;
+  margin-right: 24rem;
+}
+
+.first\\\\:mx-auto:first-child {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.first\\\\:mx-px:first-child {
+  margin-left: 1px;
+  margin-right: 1px;
+}
+
+.first\\\\:mx-0\\\\.5:first-child {
+  margin-left: 0.125rem;
+  margin-right: 0.125rem;
+}
+
+.first\\\\:mx-1\\\\.5:first-child {
+  margin-left: 0.375rem;
+  margin-right: 0.375rem;
+}
+
+.first\\\\:mx-2\\\\.5:first-child {
+  margin-left: 0.625rem;
+  margin-right: 0.625rem;
+}
+
+.first\\\\:mx-3\\\\.5:first-child {
+  margin-left: 0.875rem;
+  margin-right: 0.875rem;
+}
+
+.first\\\\:-mx-0:first-child {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.first\\\\:-mx-1:first-child {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+.first\\\\:-mx-2:first-child {
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+}
+
+.first\\\\:-mx-3:first-child {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
+
+.first\\\\:-mx-4:first-child {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+.first\\\\:-mx-5:first-child {
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+}
+
+.first\\\\:-mx-6:first-child {
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+}
+
+.first\\\\:-mx-7:first-child {
+  margin-left: -1.75rem;
+  margin-right: -1.75rem;
+}
+
+.first\\\\:-mx-8:first-child {
+  margin-left: -2rem;
+  margin-right: -2rem;
+}
+
+.first\\\\:-mx-9:first-child {
+  margin-left: -2.25rem;
+  margin-right: -2.25rem;
+}
+
+.first\\\\:-mx-10:first-child {
+  margin-left: -2.5rem;
+  margin-right: -2.5rem;
+}
+
+.first\\\\:-mx-11:first-child {
+  margin-left: -2.75rem;
+  margin-right: -2.75rem;
+}
+
+.first\\\\:-mx-12:first-child {
+  margin-left: -3rem;
+  margin-right: -3rem;
+}
+
+.first\\\\:-mx-14:first-child {
+  margin-left: -3.5rem;
+  margin-right: -3.5rem;
+}
+
+.first\\\\:-mx-16:first-child {
+  margin-left: -4rem;
+  margin-right: -4rem;
+}
+
+.first\\\\:-mx-20:first-child {
+  margin-left: -5rem;
+  margin-right: -5rem;
+}
+
+.first\\\\:-mx-24:first-child {
+  margin-left: -6rem;
+  margin-right: -6rem;
+}
+
+.first\\\\:-mx-28:first-child {
+  margin-left: -7rem;
+  margin-right: -7rem;
+}
+
+.first\\\\:-mx-32:first-child {
+  margin-left: -8rem;
+  margin-right: -8rem;
+}
+
+.first\\\\:-mx-36:first-child {
+  margin-left: -9rem;
+  margin-right: -9rem;
+}
+
+.first\\\\:-mx-40:first-child {
+  margin-left: -10rem;
+  margin-right: -10rem;
+}
+
+.first\\\\:-mx-44:first-child {
+  margin-left: -11rem;
+  margin-right: -11rem;
+}
+
+.first\\\\:-mx-48:first-child {
+  margin-left: -12rem;
+  margin-right: -12rem;
+}
+
+.first\\\\:-mx-52:first-child {
+  margin-left: -13rem;
+  margin-right: -13rem;
+}
+
+.first\\\\:-mx-56:first-child {
+  margin-left: -14rem;
+  margin-right: -14rem;
+}
+
+.first\\\\:-mx-60:first-child {
+  margin-left: -15rem;
+  margin-right: -15rem;
+}
+
+.first\\\\:-mx-64:first-child {
+  margin-left: -16rem;
+  margin-right: -16rem;
+}
+
+.first\\\\:-mx-72:first-child {
+  margin-left: -18rem;
+  margin-right: -18rem;
+}
+
+.first\\\\:-mx-80:first-child {
+  margin-left: -20rem;
+  margin-right: -20rem;
+}
+
+.first\\\\:-mx-96:first-child {
+  margin-left: -24rem;
+  margin-right: -24rem;
+}
+
+.first\\\\:-mx-px:first-child {
+  margin-left: -1px;
+  margin-right: -1px;
+}
+
+.first\\\\:-mx-0\\\\.5:first-child {
+  margin-left: -0.125rem;
+  margin-right: -0.125rem;
+}
+
+.first\\\\:-mx-1\\\\.5:first-child {
+  margin-left: -0.375rem;
+  margin-right: -0.375rem;
+}
+
+.first\\\\:-mx-2\\\\.5:first-child {
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+}
+
+.first\\\\:-mx-3\\\\.5:first-child {
+  margin-left: -0.875rem;
+  margin-right: -0.875rem;
+}
+
+.first\\\\:my-0:first-child {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.first\\\\:my-1:first-child {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.first\\\\:my-2:first-child {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.first\\\\:my-3:first-child {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.first\\\\:my-4:first-child {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.first\\\\:my-5:first-child {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.first\\\\:my-6:first-child {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.first\\\\:my-7:first-child {
+  margin-top: 1.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.first\\\\:my-8:first-child {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.first\\\\:my-9:first-child {
+  margin-top: 2.25rem;
+  margin-bottom: 2.25rem;
+}
+
+.first\\\\:my-10:first-child {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.first\\\\:my-11:first-child {
+  margin-top: 2.75rem;
+  margin-bottom: 2.75rem;
+}
+
+.first\\\\:my-12:first-child {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
+
+.first\\\\:my-14:first-child {
+  margin-top: 3.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.first\\\\:my-16:first-child {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+
+.first\\\\:my-20:first-child {
+  margin-top: 5rem;
+  margin-bottom: 5rem;
+}
+
+.first\\\\:my-24:first-child {
+  margin-top: 6rem;
+  margin-bottom: 6rem;
+}
+
+.first\\\\:my-28:first-child {
+  margin-top: 7rem;
+  margin-bottom: 7rem;
+}
+
+.first\\\\:my-32:first-child {
+  margin-top: 8rem;
+  margin-bottom: 8rem;
+}
+
+.first\\\\:my-36:first-child {
+  margin-top: 9rem;
+  margin-bottom: 9rem;
+}
+
+.first\\\\:my-40:first-child {
+  margin-top: 10rem;
+  margin-bottom: 10rem;
+}
+
+.first\\\\:my-44:first-child {
+  margin-top: 11rem;
+  margin-bottom: 11rem;
+}
+
+.first\\\\:my-48:first-child {
+  margin-top: 12rem;
+  margin-bottom: 12rem;
+}
+
+.first\\\\:my-52:first-child {
+  margin-top: 13rem;
+  margin-bottom: 13rem;
+}
+
+.first\\\\:my-56:first-child {
+  margin-top: 14rem;
+  margin-bottom: 14rem;
+}
+
+.first\\\\:my-60:first-child {
+  margin-top: 15rem;
+  margin-bottom: 15rem;
+}
+
+.first\\\\:my-64:first-child {
+  margin-top: 16rem;
+  margin-bottom: 16rem;
+}
+
+.first\\\\:my-72:first-child {
+  margin-top: 18rem;
+  margin-bottom: 18rem;
+}
+
+.first\\\\:my-80:first-child {
+  margin-top: 20rem;
+  margin-bottom: 20rem;
+}
+
+.first\\\\:my-96:first-child {
+  margin-top: 24rem;
+  margin-bottom: 24rem;
+}
+
+.first\\\\:my-auto:first-child {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.first\\\\:my-px:first-child {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+
+.first\\\\:my-0\\\\.5:first-child {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+}
+
+.first\\\\:my-1\\\\.5:first-child {
+  margin-top: 0.375rem;
+  margin-bottom: 0.375rem;
+}
+
+.first\\\\:my-2\\\\.5:first-child {
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+}
+
+.first\\\\:my-3\\\\.5:first-child {
+  margin-top: 0.875rem;
+  margin-bottom: 0.875rem;
+}
+
+.first\\\\:-my-0:first-child {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.first\\\\:-my-1:first-child {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+}
+
+.first\\\\:-my-2:first-child {
+  margin-top: -0.5rem;
+  margin-bottom: -0.5rem;
+}
+
+.first\\\\:-my-3:first-child {
+  margin-top: -0.75rem;
+  margin-bottom: -0.75rem;
+}
+
+.first\\\\:-my-4:first-child {
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+}
+
+.first\\\\:-my-5:first-child {
+  margin-top: -1.25rem;
+  margin-bottom: -1.25rem;
+}
+
+.first\\\\:-my-6:first-child {
+  margin-top: -1.5rem;
+  margin-bottom: -1.5rem;
+}
+
+.first\\\\:-my-7:first-child {
+  margin-top: -1.75rem;
+  margin-bottom: -1.75rem;
+}
+
+.first\\\\:-my-8:first-child {
+  margin-top: -2rem;
+  margin-bottom: -2rem;
+}
+
+.first\\\\:-my-9:first-child {
+  margin-top: -2.25rem;
+  margin-bottom: -2.25rem;
+}
+
+.first\\\\:-my-10:first-child {
+  margin-top: -2.5rem;
+  margin-bottom: -2.5rem;
+}
+
+.first\\\\:-my-11:first-child {
+  margin-top: -2.75rem;
+  margin-bottom: -2.75rem;
+}
+
+.first\\\\:-my-12:first-child {
+  margin-top: -3rem;
+  margin-bottom: -3rem;
+}
+
+.first\\\\:-my-14:first-child {
+  margin-top: -3.5rem;
+  margin-bottom: -3.5rem;
+}
+
+.first\\\\:-my-16:first-child {
+  margin-top: -4rem;
+  margin-bottom: -4rem;
+}
+
+.first\\\\:-my-20:first-child {
+  margin-top: -5rem;
+  margin-bottom: -5rem;
+}
+
+.first\\\\:-my-24:first-child {
+  margin-top: -6rem;
+  margin-bottom: -6rem;
+}
+
+.first\\\\:-my-28:first-child {
+  margin-top: -7rem;
+  margin-bottom: -7rem;
+}
+
+.first\\\\:-my-32:first-child {
+  margin-top: -8rem;
+  margin-bottom: -8rem;
+}
+
+.first\\\\:-my-36:first-child {
+  margin-top: -9rem;
+  margin-bottom: -9rem;
+}
+
+.first\\\\:-my-40:first-child {
+  margin-top: -10rem;
+  margin-bottom: -10rem;
+}
+
+.first\\\\:-my-44:first-child {
+  margin-top: -11rem;
+  margin-bottom: -11rem;
+}
+
+.first\\\\:-my-48:first-child {
+  margin-top: -12rem;
+  margin-bottom: -12rem;
+}
+
+.first\\\\:-my-52:first-child {
+  margin-top: -13rem;
+  margin-bottom: -13rem;
+}
+
+.first\\\\:-my-56:first-child {
+  margin-top: -14rem;
+  margin-bottom: -14rem;
+}
+
+.first\\\\:-my-60:first-child {
+  margin-top: -15rem;
+  margin-bottom: -15rem;
+}
+
+.first\\\\:-my-64:first-child {
+  margin-top: -16rem;
+  margin-bottom: -16rem;
+}
+
+.first\\\\:-my-72:first-child {
+  margin-top: -18rem;
+  margin-bottom: -18rem;
+}
+
+.first\\\\:-my-80:first-child {
+  margin-top: -20rem;
+  margin-bottom: -20rem;
+}
+
+.first\\\\:-my-96:first-child {
+  margin-top: -24rem;
+  margin-bottom: -24rem;
+}
+
+.first\\\\:-my-px:first-child {
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+
+.first\\\\:-my-0\\\\.5:first-child {
+  margin-top: -0.125rem;
+  margin-bottom: -0.125rem;
+}
+
+.first\\\\:-my-1\\\\.5:first-child {
+  margin-top: -0.375rem;
+  margin-bottom: -0.375rem;
+}
+
+.first\\\\:-my-2\\\\.5:first-child {
+  margin-top: -0.625rem;
+  margin-bottom: -0.625rem;
+}
+
+.first\\\\:-my-3\\\\.5:first-child {
+  margin-top: -0.875rem;
+  margin-bottom: -0.875rem;
+}
+
+.last\\\\:mx-0:last-child {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.last\\\\:mx-1:last-child {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.last\\\\:mx-2:last-child {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.last\\\\:mx-3:last-child {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
+}
+
+.last\\\\:mx-4:last-child {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.last\\\\:mx-5:last-child {
+  margin-left: 1.25rem;
+  margin-right: 1.25rem;
+}
+
+.last\\\\:mx-6:last-child {
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+}
+
+.last\\\\:mx-7:last-child {
+  margin-left: 1.75rem;
+  margin-right: 1.75rem;
+}
+
+.last\\\\:mx-8:last-child {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.last\\\\:mx-9:last-child {
+  margin-left: 2.25rem;
+  margin-right: 2.25rem;
+}
+
+.last\\\\:mx-10:last-child {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
+}
+
+.last\\\\:mx-11:last-child {
+  margin-left: 2.75rem;
+  margin-right: 2.75rem;
+}
+
+.last\\\\:mx-12:last-child {
+  margin-left: 3rem;
+  margin-right: 3rem;
+}
+
+.last\\\\:mx-14:last-child {
+  margin-left: 3.5rem;
+  margin-right: 3.5rem;
+}
+
+.last\\\\:mx-16:last-child {
+  margin-left: 4rem;
+  margin-right: 4rem;
+}
+
+.last\\\\:mx-20:last-child {
+  margin-left: 5rem;
+  margin-right: 5rem;
+}
+
+.last\\\\:mx-24:last-child {
+  margin-left: 6rem;
+  margin-right: 6rem;
+}
+
+.last\\\\:mx-28:last-child {
+  margin-left: 7rem;
+  margin-right: 7rem;
+}
+
+.last\\\\:mx-32:last-child {
+  margin-left: 8rem;
+  margin-right: 8rem;
+}
+
+.last\\\\:mx-36:last-child {
+  margin-left: 9rem;
+  margin-right: 9rem;
+}
+
+.last\\\\:mx-40:last-child {
+  margin-left: 10rem;
+  margin-right: 10rem;
+}
+
+.last\\\\:mx-44:last-child {
+  margin-left: 11rem;
+  margin-right: 11rem;
+}
+
+.last\\\\:mx-48:last-child {
+  margin-left: 12rem;
+  margin-right: 12rem;
+}
+
+.last\\\\:mx-52:last-child {
+  margin-left: 13rem;
+  margin-right: 13rem;
+}
+
+.last\\\\:mx-56:last-child {
+  margin-left: 14rem;
+  margin-right: 14rem;
+}
+
+.last\\\\:mx-60:last-child {
+  margin-left: 15rem;
+  margin-right: 15rem;
+}
+
+.last\\\\:mx-64:last-child {
+  margin-left: 16rem;
+  margin-right: 16rem;
+}
+
+.last\\\\:mx-72:last-child {
+  margin-left: 18rem;
+  margin-right: 18rem;
+}
+
+.last\\\\:mx-80:last-child {
+  margin-left: 20rem;
+  margin-right: 20rem;
+}
+
+.last\\\\:mx-96:last-child {
+  margin-left: 24rem;
+  margin-right: 24rem;
+}
+
+.last\\\\:mx-auto:last-child {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.last\\\\:mx-px:last-child {
+  margin-left: 1px;
+  margin-right: 1px;
+}
+
+.last\\\\:mx-0\\\\.5:last-child {
+  margin-left: 0.125rem;
+  margin-right: 0.125rem;
+}
+
+.last\\\\:mx-1\\\\.5:last-child {
+  margin-left: 0.375rem;
+  margin-right: 0.375rem;
+}
+
+.last\\\\:mx-2\\\\.5:last-child {
+  margin-left: 0.625rem;
+  margin-right: 0.625rem;
+}
+
+.last\\\\:mx-3\\\\.5:last-child {
+  margin-left: 0.875rem;
+  margin-right: 0.875rem;
+}
+
+.last\\\\:-mx-0:last-child {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.last\\\\:-mx-1:last-child {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+.last\\\\:-mx-2:last-child {
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+}
+
+.last\\\\:-mx-3:last-child {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
+
+.last\\\\:-mx-4:last-child {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+.last\\\\:-mx-5:last-child {
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+}
+
+.last\\\\:-mx-6:last-child {
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+}
+
+.last\\\\:-mx-7:last-child {
+  margin-left: -1.75rem;
+  margin-right: -1.75rem;
+}
+
+.last\\\\:-mx-8:last-child {
+  margin-left: -2rem;
+  margin-right: -2rem;
+}
+
+.last\\\\:-mx-9:last-child {
+  margin-left: -2.25rem;
+  margin-right: -2.25rem;
+}
+
+.last\\\\:-mx-10:last-child {
+  margin-left: -2.5rem;
+  margin-right: -2.5rem;
+}
+
+.last\\\\:-mx-11:last-child {
+  margin-left: -2.75rem;
+  margin-right: -2.75rem;
+}
+
+.last\\\\:-mx-12:last-child {
+  margin-left: -3rem;
+  margin-right: -3rem;
+}
+
+.last\\\\:-mx-14:last-child {
+  margin-left: -3.5rem;
+  margin-right: -3.5rem;
+}
+
+.last\\\\:-mx-16:last-child {
+  margin-left: -4rem;
+  margin-right: -4rem;
+}
+
+.last\\\\:-mx-20:last-child {
+  margin-left: -5rem;
+  margin-right: -5rem;
+}
+
+.last\\\\:-mx-24:last-child {
+  margin-left: -6rem;
+  margin-right: -6rem;
+}
+
+.last\\\\:-mx-28:last-child {
+  margin-left: -7rem;
+  margin-right: -7rem;
+}
+
+.last\\\\:-mx-32:last-child {
+  margin-left: -8rem;
+  margin-right: -8rem;
+}
+
+.last\\\\:-mx-36:last-child {
+  margin-left: -9rem;
+  margin-right: -9rem;
+}
+
+.last\\\\:-mx-40:last-child {
+  margin-left: -10rem;
+  margin-right: -10rem;
+}
+
+.last\\\\:-mx-44:last-child {
+  margin-left: -11rem;
+  margin-right: -11rem;
+}
+
+.last\\\\:-mx-48:last-child {
+  margin-left: -12rem;
+  margin-right: -12rem;
+}
+
+.last\\\\:-mx-52:last-child {
+  margin-left: -13rem;
+  margin-right: -13rem;
+}
+
+.last\\\\:-mx-56:last-child {
+  margin-left: -14rem;
+  margin-right: -14rem;
+}
+
+.last\\\\:-mx-60:last-child {
+  margin-left: -15rem;
+  margin-right: -15rem;
+}
+
+.last\\\\:-mx-64:last-child {
+  margin-left: -16rem;
+  margin-right: -16rem;
+}
+
+.last\\\\:-mx-72:last-child {
+  margin-left: -18rem;
+  margin-right: -18rem;
+}
+
+.last\\\\:-mx-80:last-child {
+  margin-left: -20rem;
+  margin-right: -20rem;
+}
+
+.last\\\\:-mx-96:last-child {
+  margin-left: -24rem;
+  margin-right: -24rem;
+}
+
+.last\\\\:-mx-px:last-child {
+  margin-left: -1px;
+  margin-right: -1px;
+}
+
+.last\\\\:-mx-0\\\\.5:last-child {
+  margin-left: -0.125rem;
+  margin-right: -0.125rem;
+}
+
+.last\\\\:-mx-1\\\\.5:last-child {
+  margin-left: -0.375rem;
+  margin-right: -0.375rem;
+}
+
+.last\\\\:-mx-2\\\\.5:last-child {
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+}
+
+.last\\\\:-mx-3\\\\.5:last-child {
+  margin-left: -0.875rem;
+  margin-right: -0.875rem;
+}
+
+.last\\\\:my-0:last-child {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.last\\\\:my-1:last-child {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.last\\\\:my-2:last-child {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.last\\\\:my-3:last-child {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.last\\\\:my-4:last-child {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.last\\\\:my-5:last-child {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.last\\\\:my-6:last-child {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.last\\\\:my-7:last-child {
+  margin-top: 1.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.last\\\\:my-8:last-child {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.last\\\\:my-9:last-child {
+  margin-top: 2.25rem;
+  margin-bottom: 2.25rem;
+}
+
+.last\\\\:my-10:last-child {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.last\\\\:my-11:last-child {
+  margin-top: 2.75rem;
+  margin-bottom: 2.75rem;
+}
+
+.last\\\\:my-12:last-child {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
+
+.last\\\\:my-14:last-child {
+  margin-top: 3.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.last\\\\:my-16:last-child {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+
+.last\\\\:my-20:last-child {
+  margin-top: 5rem;
+  margin-bottom: 5rem;
+}
+
+.last\\\\:my-24:last-child {
+  margin-top: 6rem;
+  margin-bottom: 6rem;
+}
+
+.last\\\\:my-28:last-child {
+  margin-top: 7rem;
+  margin-bottom: 7rem;
+}
+
+.last\\\\:my-32:last-child {
+  margin-top: 8rem;
+  margin-bottom: 8rem;
+}
+
+.last\\\\:my-36:last-child {
+  margin-top: 9rem;
+  margin-bottom: 9rem;
+}
+
+.last\\\\:my-40:last-child {
+  margin-top: 10rem;
+  margin-bottom: 10rem;
+}
+
+.last\\\\:my-44:last-child {
+  margin-top: 11rem;
+  margin-bottom: 11rem;
+}
+
+.last\\\\:my-48:last-child {
+  margin-top: 12rem;
+  margin-bottom: 12rem;
+}
+
+.last\\\\:my-52:last-child {
+  margin-top: 13rem;
+  margin-bottom: 13rem;
+}
+
+.last\\\\:my-56:last-child {
+  margin-top: 14rem;
+  margin-bottom: 14rem;
+}
+
+.last\\\\:my-60:last-child {
+  margin-top: 15rem;
+  margin-bottom: 15rem;
+}
+
+.last\\\\:my-64:last-child {
+  margin-top: 16rem;
+  margin-bottom: 16rem;
+}
+
+.last\\\\:my-72:last-child {
+  margin-top: 18rem;
+  margin-bottom: 18rem;
+}
+
+.last\\\\:my-80:last-child {
+  margin-top: 20rem;
+  margin-bottom: 20rem;
+}
+
+.last\\\\:my-96:last-child {
+  margin-top: 24rem;
+  margin-bottom: 24rem;
+}
+
+.last\\\\:my-auto:last-child {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.last\\\\:my-px:last-child {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+
+.last\\\\:my-0\\\\.5:last-child {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+}
+
+.last\\\\:my-1\\\\.5:last-child {
+  margin-top: 0.375rem;
+  margin-bottom: 0.375rem;
+}
+
+.last\\\\:my-2\\\\.5:last-child {
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+}
+
+.last\\\\:my-3\\\\.5:last-child {
+  margin-top: 0.875rem;
+  margin-bottom: 0.875rem;
+}
+
+.last\\\\:-my-0:last-child {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.last\\\\:-my-1:last-child {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+}
+
+.last\\\\:-my-2:last-child {
+  margin-top: -0.5rem;
+  margin-bottom: -0.5rem;
+}
+
+.last\\\\:-my-3:last-child {
+  margin-top: -0.75rem;
+  margin-bottom: -0.75rem;
+}
+
+.last\\\\:-my-4:last-child {
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+}
+
+.last\\\\:-my-5:last-child {
+  margin-top: -1.25rem;
+  margin-bottom: -1.25rem;
+}
+
+.last\\\\:-my-6:last-child {
+  margin-top: -1.5rem;
+  margin-bottom: -1.5rem;
+}
+
+.last\\\\:-my-7:last-child {
+  margin-top: -1.75rem;
+  margin-bottom: -1.75rem;
+}
+
+.last\\\\:-my-8:last-child {
+  margin-top: -2rem;
+  margin-bottom: -2rem;
+}
+
+.last\\\\:-my-9:last-child {
+  margin-top: -2.25rem;
+  margin-bottom: -2.25rem;
+}
+
+.last\\\\:-my-10:last-child {
+  margin-top: -2.5rem;
+  margin-bottom: -2.5rem;
+}
+
+.last\\\\:-my-11:last-child {
+  margin-top: -2.75rem;
+  margin-bottom: -2.75rem;
+}
+
+.last\\\\:-my-12:last-child {
+  margin-top: -3rem;
+  margin-bottom: -3rem;
+}
+
+.last\\\\:-my-14:last-child {
+  margin-top: -3.5rem;
+  margin-bottom: -3.5rem;
+}
+
+.last\\\\:-my-16:last-child {
+  margin-top: -4rem;
+  margin-bottom: -4rem;
+}
+
+.last\\\\:-my-20:last-child {
+  margin-top: -5rem;
+  margin-bottom: -5rem;
+}
+
+.last\\\\:-my-24:last-child {
+  margin-top: -6rem;
+  margin-bottom: -6rem;
+}
+
+.last\\\\:-my-28:last-child {
+  margin-top: -7rem;
+  margin-bottom: -7rem;
+}
+
+.last\\\\:-my-32:last-child {
+  margin-top: -8rem;
+  margin-bottom: -8rem;
+}
+
+.last\\\\:-my-36:last-child {
+  margin-top: -9rem;
+  margin-bottom: -9rem;
+}
+
+.last\\\\:-my-40:last-child {
+  margin-top: -10rem;
+  margin-bottom: -10rem;
+}
+
+.last\\\\:-my-44:last-child {
+  margin-top: -11rem;
+  margin-bottom: -11rem;
+}
+
+.last\\\\:-my-48:last-child {
+  margin-top: -12rem;
+  margin-bottom: -12rem;
+}
+
+.last\\\\:-my-52:last-child {
+  margin-top: -13rem;
+  margin-bottom: -13rem;
+}
+
+.last\\\\:-my-56:last-child {
+  margin-top: -14rem;
+  margin-bottom: -14rem;
+}
+
+.last\\\\:-my-60:last-child {
+  margin-top: -15rem;
+  margin-bottom: -15rem;
+}
+
+.last\\\\:-my-64:last-child {
+  margin-top: -16rem;
+  margin-bottom: -16rem;
+}
+
+.last\\\\:-my-72:last-child {
+  margin-top: -18rem;
+  margin-bottom: -18rem;
+}
+
+.last\\\\:-my-80:last-child {
+  margin-top: -20rem;
+  margin-bottom: -20rem;
+}
+
+.last\\\\:-my-96:last-child {
+  margin-top: -24rem;
+  margin-bottom: -24rem;
+}
+
+.last\\\\:-my-px:last-child {
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+
+.last\\\\:-my-0\\\\.5:last-child {
+  margin-top: -0.125rem;
+  margin-bottom: -0.125rem;
+}
+
+.last\\\\:-my-1\\\\.5:last-child {
+  margin-top: -0.375rem;
+  margin-bottom: -0.375rem;
+}
+
+.last\\\\:-my-2\\\\.5:last-child {
+  margin-top: -0.625rem;
+  margin-bottom: -0.625rem;
+}
+
+.last\\\\:-my-3\\\\.5:last-child {
+  margin-top: -0.875rem;
+  margin-bottom: -0.875rem;
+}
+
+.mt-0 {
+  margin-top: 0px;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
+}
+
+.mt-5 {
+  margin-top: 1.25rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mt-7 {
+  margin-top: 1.75rem;
+}
+
+.mt-8 {
+  margin-top: 2rem;
+}
+
+.mt-9 {
+  margin-top: 2.25rem;
+}
+
+.mt-10 {
+  margin-top: 2.5rem;
+}
+
+.mt-11 {
+  margin-top: 2.75rem;
+}
+
+.mt-12 {
+  margin-top: 3rem;
+}
+
+.mt-14 {
+  margin-top: 3.5rem;
+}
+
+.mt-16 {
+  margin-top: 4rem;
+}
+
+.mt-20 {
+  margin-top: 5rem;
+}
+
+.mt-24 {
+  margin-top: 6rem;
+}
+
+.mt-28 {
+  margin-top: 7rem;
+}
+
+.mt-32 {
+  margin-top: 8rem;
+}
+
+.mt-36 {
+  margin-top: 9rem;
+}
+
+.mt-40 {
+  margin-top: 10rem;
+}
+
+.mt-44 {
+  margin-top: 11rem;
+}
+
+.mt-48 {
+  margin-top: 12rem;
+}
+
+.mt-52 {
+  margin-top: 13rem;
+}
+
+.mt-56 {
+  margin-top: 14rem;
+}
+
+.mt-60 {
+  margin-top: 15rem;
+}
+
+.mt-64 {
+  margin-top: 16rem;
+}
+
+.mt-72 {
+  margin-top: 18rem;
+}
+
+.mt-80 {
+  margin-top: 20rem;
+}
+
+.mt-96 {
+  margin-top: 24rem;
+}
+
+.mt-auto {
+  margin-top: auto;
+}
+
+.mt-px {
+  margin-top: 1px;
+}
+
+.mt-0\\\\.5 {
+  margin-top: 0.125rem;
+}
+
+.mt-1\\\\.5 {
+  margin-top: 0.375rem;
+}
+
+.mt-2\\\\.5 {
+  margin-top: 0.625rem;
+}
+
+.mt-3\\\\.5 {
+  margin-top: 0.875rem;
+}
+
+.-mt-0 {
+  margin-top: 0px;
+}
+
+.-mt-1 {
+  margin-top: -0.25rem;
+}
+
+.-mt-2 {
+  margin-top: -0.5rem;
+}
+
+.-mt-3 {
+  margin-top: -0.75rem;
+}
+
+.-mt-4 {
+  margin-top: -1rem;
+}
+
+.-mt-5 {
+  margin-top: -1.25rem;
+}
+
+.-mt-6 {
+  margin-top: -1.5rem;
+}
+
+.-mt-7 {
+  margin-top: -1.75rem;
+}
+
+.-mt-8 {
+  margin-top: -2rem;
+}
+
+.-mt-9 {
+  margin-top: -2.25rem;
+}
+
+.-mt-10 {
+  margin-top: -2.5rem;
+}
+
+.-mt-11 {
+  margin-top: -2.75rem;
+}
+
+.-mt-12 {
+  margin-top: -3rem;
+}
+
+.-mt-14 {
+  margin-top: -3.5rem;
+}
+
+.-mt-16 {
+  margin-top: -4rem;
+}
+
+.-mt-20 {
+  margin-top: -5rem;
+}
+
+.-mt-24 {
+  margin-top: -6rem;
+}
+
+.-mt-28 {
+  margin-top: -7rem;
+}
+
+.-mt-32 {
+  margin-top: -8rem;
+}
+
+.-mt-36 {
+  margin-top: -9rem;
+}
+
+.-mt-40 {
+  margin-top: -10rem;
+}
+
+.-mt-44 {
+  margin-top: -11rem;
+}
+
+.-mt-48 {
+  margin-top: -12rem;
+}
+
+.-mt-52 {
+  margin-top: -13rem;
+}
+
+.-mt-56 {
+  margin-top: -14rem;
+}
+
+.-mt-60 {
+  margin-top: -15rem;
+}
+
+.-mt-64 {
+  margin-top: -16rem;
+}
+
+.-mt-72 {
+  margin-top: -18rem;
+}
+
+.-mt-80 {
+  margin-top: -20rem;
+}
+
+.-mt-96 {
+  margin-top: -24rem;
+}
+
+.-mt-px {
+  margin-top: -1px;
+}
+
+.-mt-0\\\\.5 {
+  margin-top: -0.125rem;
+}
+
+.-mt-1\\\\.5 {
+  margin-top: -0.375rem;
+}
+
+.-mt-2\\\\.5 {
+  margin-top: -0.625rem;
+}
+
+.-mt-3\\\\.5 {
+  margin-top: -0.875rem;
+}
+
+.mr-0 {
+  margin-right: 0px;
+}
+
+.mr-1 {
+  margin-right: 0.25rem;
+}
+
+.mr-2 {
+  margin-right: 0.5rem;
+}
+
+.mr-3 {
+  margin-right: 0.75rem;
+}
+
+.mr-4 {
+  margin-right: 1rem;
+}
+
+.mr-5 {
+  margin-right: 1.25rem;
+}
+
+.mr-6 {
+  margin-right: 1.5rem;
+}
+
+.mr-7 {
+  margin-right: 1.75rem;
+}
+
+.mr-8 {
+  margin-right: 2rem;
+}
+
+.mr-9 {
+  margin-right: 2.25rem;
+}
+
+.mr-10 {
+  margin-right: 2.5rem;
+}
+
+.mr-11 {
+  margin-right: 2.75rem;
+}
+
+.mr-12 {
+  margin-right: 3rem;
+}
+
+.mr-14 {
+  margin-right: 3.5rem;
+}
+
+.mr-16 {
+  margin-right: 4rem;
+}
+
+.mr-20 {
+  margin-right: 5rem;
+}
+
+.mr-24 {
+  margin-right: 6rem;
+}
+
+.mr-28 {
+  margin-right: 7rem;
+}
+
+.mr-32 {
+  margin-right: 8rem;
+}
+
+.mr-36 {
+  margin-right: 9rem;
+}
+
+.mr-40 {
+  margin-right: 10rem;
+}
+
+.mr-44 {
+  margin-right: 11rem;
+}
+
+.mr-48 {
+  margin-right: 12rem;
+}
+
+.mr-52 {
+  margin-right: 13rem;
+}
+
+.mr-56 {
+  margin-right: 14rem;
+}
+
+.mr-60 {
+  margin-right: 15rem;
+}
+
+.mr-64 {
+  margin-right: 16rem;
+}
+
+.mr-72 {
+  margin-right: 18rem;
+}
+
+.mr-80 {
+  margin-right: 20rem;
+}
+
+.mr-96 {
+  margin-right: 24rem;
+}
+
+.mr-auto {
+  margin-right: auto;
+}
+
+.mr-px {
+  margin-right: 1px;
+}
+
+.mr-0\\\\.5 {
+  margin-right: 0.125rem;
+}
+
+.mr-1\\\\.5 {
+  margin-right: 0.375rem;
+}
+
+.mr-2\\\\.5 {
+  margin-right: 0.625rem;
+}
+
+.mr-3\\\\.5 {
+  margin-right: 0.875rem;
+}
+
+.-mr-0 {
+  margin-right: 0px;
+}
+
+.-mr-1 {
+  margin-right: -0.25rem;
+}
+
+.-mr-2 {
+  margin-right: -0.5rem;
+}
+
+.-mr-3 {
+  margin-right: -0.75rem;
+}
+
+.-mr-4 {
+  margin-right: -1rem;
+}
+
+.-mr-5 {
+  margin-right: -1.25rem;
+}
+
+.-mr-6 {
+  margin-right: -1.5rem;
+}
+
+.-mr-7 {
+  margin-right: -1.75rem;
+}
+
+.-mr-8 {
+  margin-right: -2rem;
+}
+
+.-mr-9 {
+  margin-right: -2.25rem;
+}
+
+.-mr-10 {
+  margin-right: -2.5rem;
+}
+
+.-mr-11 {
+  margin-right: -2.75rem;
+}
+
+.-mr-12 {
+  margin-right: -3rem;
+}
+
+.-mr-14 {
+  margin-right: -3.5rem;
+}
+
+.-mr-16 {
+  margin-right: -4rem;
+}
+
+.-mr-20 {
+  margin-right: -5rem;
+}
+
+.-mr-24 {
+  margin-right: -6rem;
+}
+
+.-mr-28 {
+  margin-right: -7rem;
+}
+
+.-mr-32 {
+  margin-right: -8rem;
+}
+
+.-mr-36 {
+  margin-right: -9rem;
+}
+
+.-mr-40 {
+  margin-right: -10rem;
+}
+
+.-mr-44 {
+  margin-right: -11rem;
+}
+
+.-mr-48 {
+  margin-right: -12rem;
+}
+
+.-mr-52 {
+  margin-right: -13rem;
+}
+
+.-mr-56 {
+  margin-right: -14rem;
+}
+
+.-mr-60 {
+  margin-right: -15rem;
+}
+
+.-mr-64 {
+  margin-right: -16rem;
+}
+
+.-mr-72 {
+  margin-right: -18rem;
+}
+
+.-mr-80 {
+  margin-right: -20rem;
+}
+
+.-mr-96 {
+  margin-right: -24rem;
+}
+
+.-mr-px {
+  margin-right: -1px;
+}
+
+.-mr-0\\\\.5 {
+  margin-right: -0.125rem;
+}
+
+.-mr-1\\\\.5 {
+  margin-right: -0.375rem;
+}
+
+.-mr-2\\\\.5 {
+  margin-right: -0.625rem;
+}
+
+.-mr-3\\\\.5 {
+  margin-right: -0.875rem;
+}
+
+.mb-0 {
+  margin-bottom: 0px;
+}
+
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mb-5 {
+  margin-bottom: 1.25rem;
+}
+
+.mb-6 {
+  margin-bottom: 1.5rem;
+}
+
+.mb-7 {
+  margin-bottom: 1.75rem;
+}
+
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
+.mb-9 {
+  margin-bottom: 2.25rem;
+}
+
+.mb-10 {
+  margin-bottom: 2.5rem;
+}
+
+.mb-11 {
+  margin-bottom: 2.75rem;
+}
+
+.mb-12 {
+  margin-bottom: 3rem;
+}
+
+.mb-14 {
+  margin-bottom: 3.5rem;
+}
+
+.mb-16 {
+  margin-bottom: 4rem;
+}
+
+.mb-20 {
+  margin-bottom: 5rem;
+}
+
+.mb-24 {
+  margin-bottom: 6rem;
+}
+
+.mb-28 {
+  margin-bottom: 7rem;
+}
+
+.mb-32 {
+  margin-bottom: 8rem;
+}
+
+.mb-36 {
+  margin-bottom: 9rem;
+}
+
+.mb-40 {
+  margin-bottom: 10rem;
+}
+
+.mb-44 {
+  margin-bottom: 11rem;
+}
+
+.mb-48 {
+  margin-bottom: 12rem;
+}
+
+.mb-52 {
+  margin-bottom: 13rem;
+}
+
+.mb-56 {
+  margin-bottom: 14rem;
+}
+
+.mb-60 {
+  margin-bottom: 15rem;
+}
+
+.mb-64 {
+  margin-bottom: 16rem;
+}
+
+.mb-72 {
+  margin-bottom: 18rem;
+}
+
+.mb-80 {
+  margin-bottom: 20rem;
+}
+
+.mb-96 {
+  margin-bottom: 24rem;
+}
+
+.mb-auto {
+  margin-bottom: auto;
+}
+
+.mb-px {
+  margin-bottom: 1px;
+}
+
+.mb-0\\\\.5 {
+  margin-bottom: 0.125rem;
+}
+
+.mb-1\\\\.5 {
+  margin-bottom: 0.375rem;
+}
+
+.mb-2\\\\.5 {
+  margin-bottom: 0.625rem;
+}
+
+.mb-3\\\\.5 {
+  margin-bottom: 0.875rem;
+}
+
+.-mb-0 {
+  margin-bottom: 0px;
+}
+
+.-mb-1 {
+  margin-bottom: -0.25rem;
+}
+
+.-mb-2 {
+  margin-bottom: -0.5rem;
+}
+
+.-mb-3 {
+  margin-bottom: -0.75rem;
+}
+
+.-mb-4 {
+  margin-bottom: -1rem;
+}
+
+.-mb-5 {
+  margin-bottom: -1.25rem;
+}
+
+.-mb-6 {
+  margin-bottom: -1.5rem;
+}
+
+.-mb-7 {
+  margin-bottom: -1.75rem;
+}
+
+.-mb-8 {
+  margin-bottom: -2rem;
+}
+
+.-mb-9 {
+  margin-bottom: -2.25rem;
+}
+
+.-mb-10 {
+  margin-bottom: -2.5rem;
+}
+
+.-mb-11 {
+  margin-bottom: -2.75rem;
+}
+
+.-mb-12 {
+  margin-bottom: -3rem;
+}
+
+.-mb-14 {
+  margin-bottom: -3.5rem;
+}
+
+.-mb-16 {
+  margin-bottom: -4rem;
+}
+
+.-mb-20 {
+  margin-bottom: -5rem;
+}
+
+.-mb-24 {
+  margin-bottom: -6rem;
+}
+
+.-mb-28 {
+  margin-bottom: -7rem;
+}
+
+.-mb-32 {
+  margin-bottom: -8rem;
+}
+
+.-mb-36 {
+  margin-bottom: -9rem;
+}
+
+.-mb-40 {
+  margin-bottom: -10rem;
+}
+
+.-mb-44 {
+  margin-bottom: -11rem;
+}
+
+.-mb-48 {
+  margin-bottom: -12rem;
+}
+
+.-mb-52 {
+  margin-bottom: -13rem;
+}
+
+.-mb-56 {
+  margin-bottom: -14rem;
+}
+
+.-mb-60 {
+  margin-bottom: -15rem;
+}
+
+.-mb-64 {
+  margin-bottom: -16rem;
+}
+
+.-mb-72 {
+  margin-bottom: -18rem;
+}
+
+.-mb-80 {
+  margin-bottom: -20rem;
+}
+
+.-mb-96 {
+  margin-bottom: -24rem;
+}
+
+.-mb-px {
+  margin-bottom: -1px;
+}
+
+.-mb-0\\\\.5 {
+  margin-bottom: -0.125rem;
+}
+
+.-mb-1\\\\.5 {
+  margin-bottom: -0.375rem;
+}
+
+.-mb-2\\\\.5 {
+  margin-bottom: -0.625rem;
+}
+
+.-mb-3\\\\.5 {
+  margin-bottom: -0.875rem;
+}
+
+.ml-0 {
+  margin-left: 0px;
+}
+
+.ml-1 {
+  margin-left: 0.25rem;
+}
+
+.ml-2 {
+  margin-left: 0.5rem;
+}
+
+.ml-3 {
+  margin-left: 0.75rem;
+}
+
+.ml-4 {
+  margin-left: 1rem;
+}
+
+.ml-5 {
+  margin-left: 1.25rem;
+}
+
+.ml-6 {
+  margin-left: 1.5rem;
+}
+
+.ml-7 {
+  margin-left: 1.75rem;
+}
+
+.ml-8 {
+  margin-left: 2rem;
+}
+
+.ml-9 {
+  margin-left: 2.25rem;
+}
+
+.ml-10 {
+  margin-left: 2.5rem;
+}
+
+.ml-11 {
+  margin-left: 2.75rem;
+}
+
+.ml-12 {
+  margin-left: 3rem;
+}
+
+.ml-14 {
+  margin-left: 3.5rem;
+}
+
+.ml-16 {
+  margin-left: 4rem;
+}
+
+.ml-20 {
+  margin-left: 5rem;
+}
+
+.ml-24 {
+  margin-left: 6rem;
+}
+
+.ml-28 {
+  margin-left: 7rem;
+}
+
+.ml-32 {
+  margin-left: 8rem;
+}
+
+.ml-36 {
+  margin-left: 9rem;
+}
+
+.ml-40 {
+  margin-left: 10rem;
+}
+
+.ml-44 {
+  margin-left: 11rem;
+}
+
+.ml-48 {
+  margin-left: 12rem;
+}
+
+.ml-52 {
+  margin-left: 13rem;
+}
+
+.ml-56 {
+  margin-left: 14rem;
+}
+
+.ml-60 {
+  margin-left: 15rem;
+}
+
+.ml-64 {
+  margin-left: 16rem;
+}
+
+.ml-72 {
+  margin-left: 18rem;
+}
+
+.ml-80 {
+  margin-left: 20rem;
+}
+
+.ml-96 {
+  margin-left: 24rem;
+}
+
+.ml-auto {
+  margin-left: auto;
+}
+
+.ml-px {
+  margin-left: 1px;
+}
+
+.ml-0\\\\.5 {
+  margin-left: 0.125rem;
+}
+
+.ml-1\\\\.5 {
+  margin-left: 0.375rem;
+}
+
+.ml-2\\\\.5 {
+  margin-left: 0.625rem;
+}
+
+.ml-3\\\\.5 {
+  margin-left: 0.875rem;
+}
+
+.-ml-0 {
+  margin-left: 0px;
+}
+
+.-ml-1 {
+  margin-left: -0.25rem;
+}
+
+.-ml-2 {
+  margin-left: -0.5rem;
+}
+
+.-ml-3 {
+  margin-left: -0.75rem;
+}
+
+.-ml-4 {
+  margin-left: -1rem;
+}
+
+.-ml-5 {
+  margin-left: -1.25rem;
+}
+
+.-ml-6 {
+  margin-left: -1.5rem;
+}
+
+.-ml-7 {
+  margin-left: -1.75rem;
+}
+
+.-ml-8 {
+  margin-left: -2rem;
+}
+
+.-ml-9 {
+  margin-left: -2.25rem;
+}
+
+.-ml-10 {
+  margin-left: -2.5rem;
+}
+
+.-ml-11 {
+  margin-left: -2.75rem;
+}
+
+.-ml-12 {
+  margin-left: -3rem;
+}
+
+.-ml-14 {
+  margin-left: -3.5rem;
+}
+
+.-ml-16 {
+  margin-left: -4rem;
+}
+
+.-ml-20 {
+  margin-left: -5rem;
+}
+
+.-ml-24 {
+  margin-left: -6rem;
+}
+
+.-ml-28 {
+  margin-left: -7rem;
+}
+
+.-ml-32 {
+  margin-left: -8rem;
+}
+
+.-ml-36 {
+  margin-left: -9rem;
+}
+
+.-ml-40 {
+  margin-left: -10rem;
+}
+
+.-ml-44 {
+  margin-left: -11rem;
+}
+
+.-ml-48 {
+  margin-left: -12rem;
+}
+
+.-ml-52 {
+  margin-left: -13rem;
+}
+
+.-ml-56 {
+  margin-left: -14rem;
+}
+
+.-ml-60 {
+  margin-left: -15rem;
+}
+
+.-ml-64 {
+  margin-left: -16rem;
+}
+
+.-ml-72 {
+  margin-left: -18rem;
+}
+
+.-ml-80 {
+  margin-left: -20rem;
+}
+
+.-ml-96 {
+  margin-left: -24rem;
+}
+
+.-ml-px {
+  margin-left: -1px;
+}
+
+.-ml-0\\\\.5 {
+  margin-left: -0.125rem;
+}
+
+.-ml-1\\\\.5 {
+  margin-left: -0.375rem;
+}
+
+.-ml-2\\\\.5 {
+  margin-left: -0.625rem;
+}
+
+.-ml-3\\\\.5 {
+  margin-left: -0.875rem;
+}
+
+.first\\\\:mt-0:first-child {
+  margin-top: 0px;
+}
+
+.first\\\\:mt-1:first-child {
+  margin-top: 0.25rem;
+}
+
+.first\\\\:mt-2:first-child {
+  margin-top: 0.5rem;
+}
+
+.first\\\\:mt-3:first-child {
+  margin-top: 0.75rem;
+}
+
+.first\\\\:mt-4:first-child {
+  margin-top: 1rem;
+}
+
+.first\\\\:mt-5:first-child {
+  margin-top: 1.25rem;
+}
+
+.first\\\\:mt-6:first-child {
+  margin-top: 1.5rem;
+}
+
+.first\\\\:mt-7:first-child {
+  margin-top: 1.75rem;
+}
+
+.first\\\\:mt-8:first-child {
+  margin-top: 2rem;
+}
+
+.first\\\\:mt-9:first-child {
+  margin-top: 2.25rem;
+}
+
+.first\\\\:mt-10:first-child {
+  margin-top: 2.5rem;
+}
+
+.first\\\\:mt-11:first-child {
+  margin-top: 2.75rem;
+}
+
+.first\\\\:mt-12:first-child {
+  margin-top: 3rem;
+}
+
+.first\\\\:mt-14:first-child {
+  margin-top: 3.5rem;
+}
+
+.first\\\\:mt-16:first-child {
+  margin-top: 4rem;
+}
+
+.first\\\\:mt-20:first-child {
+  margin-top: 5rem;
+}
+
+.first\\\\:mt-24:first-child {
+  margin-top: 6rem;
+}
+
+.first\\\\:mt-28:first-child {
+  margin-top: 7rem;
+}
+
+.first\\\\:mt-32:first-child {
+  margin-top: 8rem;
+}
+
+.first\\\\:mt-36:first-child {
+  margin-top: 9rem;
+}
+
+.first\\\\:mt-40:first-child {
+  margin-top: 10rem;
+}
+
+.first\\\\:mt-44:first-child {
+  margin-top: 11rem;
+}
+
+.first\\\\:mt-48:first-child {
+  margin-top: 12rem;
+}
+
+.first\\\\:mt-52:first-child {
+  margin-top: 13rem;
+}
+
+.first\\\\:mt-56:first-child {
+  margin-top: 14rem;
+}
+
+.first\\\\:mt-60:first-child {
+  margin-top: 15rem;
+}
+
+.first\\\\:mt-64:first-child {
+  margin-top: 16rem;
+}
+
+.first\\\\:mt-72:first-child {
+  margin-top: 18rem;
+}
+
+.first\\\\:mt-80:first-child {
+  margin-top: 20rem;
+}
+
+.first\\\\:mt-96:first-child {
+  margin-top: 24rem;
+}
+
+.first\\\\:mt-auto:first-child {
+  margin-top: auto;
+}
+
+.first\\\\:mt-px:first-child {
+  margin-top: 1px;
+}
+
+.first\\\\:mt-0\\\\.5:first-child {
+  margin-top: 0.125rem;
+}
+
+.first\\\\:mt-1\\\\.5:first-child {
+  margin-top: 0.375rem;
+}
+
+.first\\\\:mt-2\\\\.5:first-child {
+  margin-top: 0.625rem;
+}
+
+.first\\\\:mt-3\\\\.5:first-child {
+  margin-top: 0.875rem;
+}
+
+.first\\\\:-mt-0:first-child {
+  margin-top: 0px;
+}
+
+.first\\\\:-mt-1:first-child {
+  margin-top: -0.25rem;
+}
+
+.first\\\\:-mt-2:first-child {
+  margin-top: -0.5rem;
+}
+
+.first\\\\:-mt-3:first-child {
+  margin-top: -0.75rem;
+}
+
+.first\\\\:-mt-4:first-child {
+  margin-top: -1rem;
+}
+
+.first\\\\:-mt-5:first-child {
+  margin-top: -1.25rem;
+}
+
+.first\\\\:-mt-6:first-child {
+  margin-top: -1.5rem;
+}
+
+.first\\\\:-mt-7:first-child {
+  margin-top: -1.75rem;
+}
+
+.first\\\\:-mt-8:first-child {
+  margin-top: -2rem;
+}
+
+.first\\\\:-mt-9:first-child {
+  margin-top: -2.25rem;
+}
+
+.first\\\\:-mt-10:first-child {
+  margin-top: -2.5rem;
+}
+
+.first\\\\:-mt-11:first-child {
+  margin-top: -2.75rem;
+}
+
+.first\\\\:-mt-12:first-child {
+  margin-top: -3rem;
+}
+
+.first\\\\:-mt-14:first-child {
+  margin-top: -3.5rem;
+}
+
+.first\\\\:-mt-16:first-child {
+  margin-top: -4rem;
+}
+
+.first\\\\:-mt-20:first-child {
+  margin-top: -5rem;
+}
+
+.first\\\\:-mt-24:first-child {
+  margin-top: -6rem;
+}
+
+.first\\\\:-mt-28:first-child {
+  margin-top: -7rem;
+}
+
+.first\\\\:-mt-32:first-child {
+  margin-top: -8rem;
+}
+
+.first\\\\:-mt-36:first-child {
+  margin-top: -9rem;
+}
+
+.first\\\\:-mt-40:first-child {
+  margin-top: -10rem;
+}
+
+.first\\\\:-mt-44:first-child {
+  margin-top: -11rem;
+}
+
+.first\\\\:-mt-48:first-child {
+  margin-top: -12rem;
+}
+
+.first\\\\:-mt-52:first-child {
+  margin-top: -13rem;
+}
+
+.first\\\\:-mt-56:first-child {
+  margin-top: -14rem;
+}
+
+.first\\\\:-mt-60:first-child {
+  margin-top: -15rem;
+}
+
+.first\\\\:-mt-64:first-child {
+  margin-top: -16rem;
+}
+
+.first\\\\:-mt-72:first-child {
+  margin-top: -18rem;
+}
+
+.first\\\\:-mt-80:first-child {
+  margin-top: -20rem;
+}
+
+.first\\\\:-mt-96:first-child {
+  margin-top: -24rem;
+}
+
+.first\\\\:-mt-px:first-child {
+  margin-top: -1px;
+}
+
+.first\\\\:-mt-0\\\\.5:first-child {
+  margin-top: -0.125rem;
+}
+
+.first\\\\:-mt-1\\\\.5:first-child {
+  margin-top: -0.375rem;
+}
+
+.first\\\\:-mt-2\\\\.5:first-child {
+  margin-top: -0.625rem;
+}
+
+.first\\\\:-mt-3\\\\.5:first-child {
+  margin-top: -0.875rem;
+}
+
+.first\\\\:mr-0:first-child {
+  margin-right: 0px;
+}
+
+.first\\\\:mr-1:first-child {
+  margin-right: 0.25rem;
+}
+
+.first\\\\:mr-2:first-child {
+  margin-right: 0.5rem;
+}
+
+.first\\\\:mr-3:first-child {
+  margin-right: 0.75rem;
+}
+
+.first\\\\:mr-4:first-child {
+  margin-right: 1rem;
+}
+
+.first\\\\:mr-5:first-child {
+  margin-right: 1.25rem;
+}
+
+.first\\\\:mr-6:first-child {
+  margin-right: 1.5rem;
+}
+
+.first\\\\:mr-7:first-child {
+  margin-right: 1.75rem;
+}
+
+.first\\\\:mr-8:first-child {
+  margin-right: 2rem;
+}
+
+.first\\\\:mr-9:first-child {
+  margin-right: 2.25rem;
+}
+
+.first\\\\:mr-10:first-child {
+  margin-right: 2.5rem;
+}
+
+.first\\\\:mr-11:first-child {
+  margin-right: 2.75rem;
+}
+
+.first\\\\:mr-12:first-child {
+  margin-right: 3rem;
+}
+
+.first\\\\:mr-14:first-child {
+  margin-right: 3.5rem;
+}
+
+.first\\\\:mr-16:first-child {
+  margin-right: 4rem;
+}
+
+.first\\\\:mr-20:first-child {
+  margin-right: 5rem;
+}
+
+.first\\\\:mr-24:first-child {
+  margin-right: 6rem;
+}
+
+.first\\\\:mr-28:first-child {
+  margin-right: 7rem;
+}
+
+.first\\\\:mr-32:first-child {
+  margin-right: 8rem;
+}
+
+.first\\\\:mr-36:first-child {
+  margin-right: 9rem;
+}
+
+.first\\\\:mr-40:first-child {
+  margin-right: 10rem;
+}
+
+.first\\\\:mr-44:first-child {
+  margin-right: 11rem;
+}
+
+.first\\\\:mr-48:first-child {
+  margin-right: 12rem;
+}
+
+.first\\\\:mr-52:first-child {
+  margin-right: 13rem;
+}
+
+.first\\\\:mr-56:first-child {
+  margin-right: 14rem;
+}
+
+.first\\\\:mr-60:first-child {
+  margin-right: 15rem;
+}
+
+.first\\\\:mr-64:first-child {
+  margin-right: 16rem;
+}
+
+.first\\\\:mr-72:first-child {
+  margin-right: 18rem;
+}
+
+.first\\\\:mr-80:first-child {
+  margin-right: 20rem;
+}
+
+.first\\\\:mr-96:first-child {
+  margin-right: 24rem;
+}
+
+.first\\\\:mr-auto:first-child {
+  margin-right: auto;
+}
+
+.first\\\\:mr-px:first-child {
+  margin-right: 1px;
+}
+
+.first\\\\:mr-0\\\\.5:first-child {
+  margin-right: 0.125rem;
+}
+
+.first\\\\:mr-1\\\\.5:first-child {
+  margin-right: 0.375rem;
+}
+
+.first\\\\:mr-2\\\\.5:first-child {
+  margin-right: 0.625rem;
+}
+
+.first\\\\:mr-3\\\\.5:first-child {
+  margin-right: 0.875rem;
+}
+
+.first\\\\:-mr-0:first-child {
+  margin-right: 0px;
+}
+
+.first\\\\:-mr-1:first-child {
+  margin-right: -0.25rem;
+}
+
+.first\\\\:-mr-2:first-child {
+  margin-right: -0.5rem;
+}
+
+.first\\\\:-mr-3:first-child {
+  margin-right: -0.75rem;
+}
+
+.first\\\\:-mr-4:first-child {
+  margin-right: -1rem;
+}
+
+.first\\\\:-mr-5:first-child {
+  margin-right: -1.25rem;
+}
+
+.first\\\\:-mr-6:first-child {
+  margin-right: -1.5rem;
+}
+
+.first\\\\:-mr-7:first-child {
+  margin-right: -1.75rem;
+}
+
+.first\\\\:-mr-8:first-child {
+  margin-right: -2rem;
+}
+
+.first\\\\:-mr-9:first-child {
+  margin-right: -2.25rem;
+}
+
+.first\\\\:-mr-10:first-child {
+  margin-right: -2.5rem;
+}
+
+.first\\\\:-mr-11:first-child {
+  margin-right: -2.75rem;
+}
+
+.first\\\\:-mr-12:first-child {
+  margin-right: -3rem;
+}
+
+.first\\\\:-mr-14:first-child {
+  margin-right: -3.5rem;
+}
+
+.first\\\\:-mr-16:first-child {
+  margin-right: -4rem;
+}
+
+.first\\\\:-mr-20:first-child {
+  margin-right: -5rem;
+}
+
+.first\\\\:-mr-24:first-child {
+  margin-right: -6rem;
+}
+
+.first\\\\:-mr-28:first-child {
+  margin-right: -7rem;
+}
+
+.first\\\\:-mr-32:first-child {
+  margin-right: -8rem;
+}
+
+.first\\\\:-mr-36:first-child {
+  margin-right: -9rem;
+}
+
+.first\\\\:-mr-40:first-child {
+  margin-right: -10rem;
+}
+
+.first\\\\:-mr-44:first-child {
+  margin-right: -11rem;
+}
+
+.first\\\\:-mr-48:first-child {
+  margin-right: -12rem;
+}
+
+.first\\\\:-mr-52:first-child {
+  margin-right: -13rem;
+}
+
+.first\\\\:-mr-56:first-child {
+  margin-right: -14rem;
+}
+
+.first\\\\:-mr-60:first-child {
+  margin-right: -15rem;
+}
+
+.first\\\\:-mr-64:first-child {
+  margin-right: -16rem;
+}
+
+.first\\\\:-mr-72:first-child {
+  margin-right: -18rem;
+}
+
+.first\\\\:-mr-80:first-child {
+  margin-right: -20rem;
+}
+
+.first\\\\:-mr-96:first-child {
+  margin-right: -24rem;
+}
+
+.first\\\\:-mr-px:first-child {
+  margin-right: -1px;
+}
+
+.first\\\\:-mr-0\\\\.5:first-child {
+  margin-right: -0.125rem;
+}
+
+.first\\\\:-mr-1\\\\.5:first-child {
+  margin-right: -0.375rem;
+}
+
+.first\\\\:-mr-2\\\\.5:first-child {
+  margin-right: -0.625rem;
+}
+
+.first\\\\:-mr-3\\\\.5:first-child {
+  margin-right: -0.875rem;
+}
+
+.first\\\\:mb-0:first-child {
+  margin-bottom: 0px;
+}
+
+.first\\\\:mb-1:first-child {
+  margin-bottom: 0.25rem;
+}
+
+.first\\\\:mb-2:first-child {
+  margin-bottom: 0.5rem;
+}
+
+.first\\\\:mb-3:first-child {
+  margin-bottom: 0.75rem;
+}
+
+.first\\\\:mb-4:first-child {
+  margin-bottom: 1rem;
+}
+
+.first\\\\:mb-5:first-child {
+  margin-bottom: 1.25rem;
+}
+
+.first\\\\:mb-6:first-child {
+  margin-bottom: 1.5rem;
+}
+
+.first\\\\:mb-7:first-child {
+  margin-bottom: 1.75rem;
+}
+
+.first\\\\:mb-8:first-child {
+  margin-bottom: 2rem;
+}
+
+.first\\\\:mb-9:first-child {
+  margin-bottom: 2.25rem;
+}
+
+.first\\\\:mb-10:first-child {
+  margin-bottom: 2.5rem;
+}
+
+.first\\\\:mb-11:first-child {
+  margin-bottom: 2.75rem;
+}
+
+.first\\\\:mb-12:first-child {
+  margin-bottom: 3rem;
+}
+
+.first\\\\:mb-14:first-child {
+  margin-bottom: 3.5rem;
+}
+
+.first\\\\:mb-16:first-child {
+  margin-bottom: 4rem;
+}
+
+.first\\\\:mb-20:first-child {
+  margin-bottom: 5rem;
+}
+
+.first\\\\:mb-24:first-child {
+  margin-bottom: 6rem;
+}
+
+.first\\\\:mb-28:first-child {
+  margin-bottom: 7rem;
+}
+
+.first\\\\:mb-32:first-child {
+  margin-bottom: 8rem;
+}
+
+.first\\\\:mb-36:first-child {
+  margin-bottom: 9rem;
+}
+
+.first\\\\:mb-40:first-child {
+  margin-bottom: 10rem;
+}
+
+.first\\\\:mb-44:first-child {
+  margin-bottom: 11rem;
+}
+
+.first\\\\:mb-48:first-child {
+  margin-bottom: 12rem;
+}
+
+.first\\\\:mb-52:first-child {
+  margin-bottom: 13rem;
+}
+
+.first\\\\:mb-56:first-child {
+  margin-bottom: 14rem;
+}
+
+.first\\\\:mb-60:first-child {
+  margin-bottom: 15rem;
+}
+
+.first\\\\:mb-64:first-child {
+  margin-bottom: 16rem;
+}
+
+.first\\\\:mb-72:first-child {
+  margin-bottom: 18rem;
+}
+
+.first\\\\:mb-80:first-child {
+  margin-bottom: 20rem;
+}
+
+.first\\\\:mb-96:first-child {
+  margin-bottom: 24rem;
+}
+
+.first\\\\:mb-auto:first-child {
+  margin-bottom: auto;
+}
+
+.first\\\\:mb-px:first-child {
+  margin-bottom: 1px;
+}
+
+.first\\\\:mb-0\\\\.5:first-child {
+  margin-bottom: 0.125rem;
+}
+
+.first\\\\:mb-1\\\\.5:first-child {
+  margin-bottom: 0.375rem;
+}
+
+.first\\\\:mb-2\\\\.5:first-child {
+  margin-bottom: 0.625rem;
+}
+
+.first\\\\:mb-3\\\\.5:first-child {
+  margin-bottom: 0.875rem;
+}
+
+.first\\\\:-mb-0:first-child {
+  margin-bottom: 0px;
+}
+
+.first\\\\:-mb-1:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.first\\\\:-mb-2:first-child {
+  margin-bottom: -0.5rem;
+}
+
+.first\\\\:-mb-3:first-child {
+  margin-bottom: -0.75rem;
+}
+
+.first\\\\:-mb-4:first-child {
+  margin-bottom: -1rem;
+}
+
+.first\\\\:-mb-5:first-child {
+  margin-bottom: -1.25rem;
+}
+
+.first\\\\:-mb-6:first-child {
+  margin-bottom: -1.5rem;
+}
+
+.first\\\\:-mb-7:first-child {
+  margin-bottom: -1.75rem;
+}
+
+.first\\\\:-mb-8:first-child {
+  margin-bottom: -2rem;
+}
+
+.first\\\\:-mb-9:first-child {
+  margin-bottom: -2.25rem;
+}
+
+.first\\\\:-mb-10:first-child {
+  margin-bottom: -2.5rem;
+}
+
+.first\\\\:-mb-11:first-child {
+  margin-bottom: -2.75rem;
+}
+
+.first\\\\:-mb-12:first-child {
+  margin-bottom: -3rem;
+}
+
+.first\\\\:-mb-14:first-child {
+  margin-bottom: -3.5rem;
+}
+
+.first\\\\:-mb-16:first-child {
+  margin-bottom: -4rem;
+}
+
+.first\\\\:-mb-20:first-child {
+  margin-bottom: -5rem;
+}
+
+.first\\\\:-mb-24:first-child {
+  margin-bottom: -6rem;
+}
+
+.first\\\\:-mb-28:first-child {
+  margin-bottom: -7rem;
+}
+
+.first\\\\:-mb-32:first-child {
+  margin-bottom: -8rem;
+}
+
+.first\\\\:-mb-36:first-child {
+  margin-bottom: -9rem;
+}
+
+.first\\\\:-mb-40:first-child {
+  margin-bottom: -10rem;
+}
+
+.first\\\\:-mb-44:first-child {
+  margin-bottom: -11rem;
+}
+
+.first\\\\:-mb-48:first-child {
+  margin-bottom: -12rem;
+}
+
+.first\\\\:-mb-52:first-child {
+  margin-bottom: -13rem;
+}
+
+.first\\\\:-mb-56:first-child {
+  margin-bottom: -14rem;
+}
+
+.first\\\\:-mb-60:first-child {
+  margin-bottom: -15rem;
+}
+
+.first\\\\:-mb-64:first-child {
+  margin-bottom: -16rem;
+}
+
+.first\\\\:-mb-72:first-child {
+  margin-bottom: -18rem;
+}
+
+.first\\\\:-mb-80:first-child {
+  margin-bottom: -20rem;
+}
+
+.first\\\\:-mb-96:first-child {
+  margin-bottom: -24rem;
+}
+
+.first\\\\:-mb-px:first-child {
+  margin-bottom: -1px;
+}
+
+.first\\\\:-mb-0\\\\.5:first-child {
+  margin-bottom: -0.125rem;
+}
+
+.first\\\\:-mb-1\\\\.5:first-child {
+  margin-bottom: -0.375rem;
+}
+
+.first\\\\:-mb-2\\\\.5:first-child {
+  margin-bottom: -0.625rem;
+}
+
+.first\\\\:-mb-3\\\\.5:first-child {
+  margin-bottom: -0.875rem;
+}
+
+.first\\\\:ml-0:first-child {
+  margin-left: 0px;
+}
+
+.first\\\\:ml-1:first-child {
+  margin-left: 0.25rem;
+}
+
+.first\\\\:ml-2:first-child {
+  margin-left: 0.5rem;
+}
+
+.first\\\\:ml-3:first-child {
+  margin-left: 0.75rem;
+}
+
+.first\\\\:ml-4:first-child {
+  margin-left: 1rem;
+}
+
+.first\\\\:ml-5:first-child {
+  margin-left: 1.25rem;
+}
+
+.first\\\\:ml-6:first-child {
+  margin-left: 1.5rem;
+}
+
+.first\\\\:ml-7:first-child {
+  margin-left: 1.75rem;
+}
+
+.first\\\\:ml-8:first-child {
+  margin-left: 2rem;
+}
+
+.first\\\\:ml-9:first-child {
+  margin-left: 2.25rem;
+}
+
+.first\\\\:ml-10:first-child {
+  margin-left: 2.5rem;
+}
+
+.first\\\\:ml-11:first-child {
+  margin-left: 2.75rem;
+}
+
+.first\\\\:ml-12:first-child {
+  margin-left: 3rem;
+}
+
+.first\\\\:ml-14:first-child {
+  margin-left: 3.5rem;
+}
+
+.first\\\\:ml-16:first-child {
+  margin-left: 4rem;
+}
+
+.first\\\\:ml-20:first-child {
+  margin-left: 5rem;
+}
+
+.first\\\\:ml-24:first-child {
+  margin-left: 6rem;
+}
+
+.first\\\\:ml-28:first-child {
+  margin-left: 7rem;
+}
+
+.first\\\\:ml-32:first-child {
+  margin-left: 8rem;
+}
+
+.first\\\\:ml-36:first-child {
+  margin-left: 9rem;
+}
+
+.first\\\\:ml-40:first-child {
+  margin-left: 10rem;
+}
+
+.first\\\\:ml-44:first-child {
+  margin-left: 11rem;
+}
+
+.first\\\\:ml-48:first-child {
+  margin-left: 12rem;
+}
+
+.first\\\\:ml-52:first-child {
+  margin-left: 13rem;
+}
+
+.first\\\\:ml-56:first-child {
+  margin-left: 14rem;
+}
+
+.first\\\\:ml-60:first-child {
+  margin-left: 15rem;
+}
+
+.first\\\\:ml-64:first-child {
+  margin-left: 16rem;
+}
+
+.first\\\\:ml-72:first-child {
+  margin-left: 18rem;
+}
+
+.first\\\\:ml-80:first-child {
+  margin-left: 20rem;
+}
+
+.first\\\\:ml-96:first-child {
+  margin-left: 24rem;
+}
+
+.first\\\\:ml-auto:first-child {
+  margin-left: auto;
+}
+
+.first\\\\:ml-px:first-child {
+  margin-left: 1px;
+}
+
+.first\\\\:ml-0\\\\.5:first-child {
+  margin-left: 0.125rem;
+}
+
+.first\\\\:ml-1\\\\.5:first-child {
+  margin-left: 0.375rem;
+}
+
+.first\\\\:ml-2\\\\.5:first-child {
+  margin-left: 0.625rem;
+}
+
+.first\\\\:ml-3\\\\.5:first-child {
+  margin-left: 0.875rem;
+}
+
+.first\\\\:-ml-0:first-child {
+  margin-left: 0px;
+}
+
+.first\\\\:-ml-1:first-child {
+  margin-left: -0.25rem;
+}
+
+.first\\\\:-ml-2:first-child {
+  margin-left: -0.5rem;
+}
+
+.first\\\\:-ml-3:first-child {
+  margin-left: -0.75rem;
+}
+
+.first\\\\:-ml-4:first-child {
+  margin-left: -1rem;
+}
+
+.first\\\\:-ml-5:first-child {
+  margin-left: -1.25rem;
+}
+
+.first\\\\:-ml-6:first-child {
+  margin-left: -1.5rem;
+}
+
+.first\\\\:-ml-7:first-child {
+  margin-left: -1.75rem;
+}
+
+.first\\\\:-ml-8:first-child {
+  margin-left: -2rem;
+}
+
+.first\\\\:-ml-9:first-child {
+  margin-left: -2.25rem;
+}
+
+.first\\\\:-ml-10:first-child {
+  margin-left: -2.5rem;
+}
+
+.first\\\\:-ml-11:first-child {
+  margin-left: -2.75rem;
+}
+
+.first\\\\:-ml-12:first-child {
+  margin-left: -3rem;
+}
+
+.first\\\\:-ml-14:first-child {
+  margin-left: -3.5rem;
+}
+
+.first\\\\:-ml-16:first-child {
+  margin-left: -4rem;
+}
+
+.first\\\\:-ml-20:first-child {
+  margin-left: -5rem;
+}
+
+.first\\\\:-ml-24:first-child {
+  margin-left: -6rem;
+}
+
+.first\\\\:-ml-28:first-child {
+  margin-left: -7rem;
+}
+
+.first\\\\:-ml-32:first-child {
+  margin-left: -8rem;
+}
+
+.first\\\\:-ml-36:first-child {
+  margin-left: -9rem;
+}
+
+.first\\\\:-ml-40:first-child {
+  margin-left: -10rem;
+}
+
+.first\\\\:-ml-44:first-child {
+  margin-left: -11rem;
+}
+
+.first\\\\:-ml-48:first-child {
+  margin-left: -12rem;
+}
+
+.first\\\\:-ml-52:first-child {
+  margin-left: -13rem;
+}
+
+.first\\\\:-ml-56:first-child {
+  margin-left: -14rem;
+}
+
+.first\\\\:-ml-60:first-child {
+  margin-left: -15rem;
+}
+
+.first\\\\:-ml-64:first-child {
+  margin-left: -16rem;
+}
+
+.first\\\\:-ml-72:first-child {
+  margin-left: -18rem;
+}
+
+.first\\\\:-ml-80:first-child {
+  margin-left: -20rem;
+}
+
+.first\\\\:-ml-96:first-child {
+  margin-left: -24rem;
+}
+
+.first\\\\:-ml-px:first-child {
+  margin-left: -1px;
+}
+
+.first\\\\:-ml-0\\\\.5:first-child {
+  margin-left: -0.125rem;
+}
+
+.first\\\\:-ml-1\\\\.5:first-child {
+  margin-left: -0.375rem;
+}
+
+.first\\\\:-ml-2\\\\.5:first-child {
+  margin-left: -0.625rem;
+}
+
+.first\\\\:-ml-3\\\\.5:first-child {
+  margin-left: -0.875rem;
+}
+
+.last\\\\:mt-0:last-child {
+  margin-top: 0px;
+}
+
+.last\\\\:mt-1:last-child {
+  margin-top: 0.25rem;
+}
+
+.last\\\\:mt-2:last-child {
+  margin-top: 0.5rem;
+}
+
+.last\\\\:mt-3:last-child {
+  margin-top: 0.75rem;
+}
+
+.last\\\\:mt-4:last-child {
+  margin-top: 1rem;
+}
+
+.last\\\\:mt-5:last-child {
+  margin-top: 1.25rem;
+}
+
+.last\\\\:mt-6:last-child {
+  margin-top: 1.5rem;
+}
+
+.last\\\\:mt-7:last-child {
+  margin-top: 1.75rem;
+}
+
+.last\\\\:mt-8:last-child {
+  margin-top: 2rem;
+}
+
+.last\\\\:mt-9:last-child {
+  margin-top: 2.25rem;
+}
+
+.last\\\\:mt-10:last-child {
+  margin-top: 2.5rem;
+}
+
+.last\\\\:mt-11:last-child {
+  margin-top: 2.75rem;
+}
+
+.last\\\\:mt-12:last-child {
+  margin-top: 3rem;
+}
+
+.last\\\\:mt-14:last-child {
+  margin-top: 3.5rem;
+}
+
+.last\\\\:mt-16:last-child {
+  margin-top: 4rem;
+}
+
+.last\\\\:mt-20:last-child {
+  margin-top: 5rem;
+}
+
+.last\\\\:mt-24:last-child {
+  margin-top: 6rem;
+}
+
+.last\\\\:mt-28:last-child {
+  margin-top: 7rem;
+}
+
+.last\\\\:mt-32:last-child {
+  margin-top: 8rem;
+}
+
+.last\\\\:mt-36:last-child {
+  margin-top: 9rem;
+}
+
+.last\\\\:mt-40:last-child {
+  margin-top: 10rem;
+}
+
+.last\\\\:mt-44:last-child {
+  margin-top: 11rem;
+}
+
+.last\\\\:mt-48:last-child {
+  margin-top: 12rem;
+}
+
+.last\\\\:mt-52:last-child {
+  margin-top: 13rem;
+}
+
+.last\\\\:mt-56:last-child {
+  margin-top: 14rem;
+}
+
+.last\\\\:mt-60:last-child {
+  margin-top: 15rem;
+}
+
+.last\\\\:mt-64:last-child {
+  margin-top: 16rem;
+}
+
+.last\\\\:mt-72:last-child {
+  margin-top: 18rem;
+}
+
+.last\\\\:mt-80:last-child {
+  margin-top: 20rem;
+}
+
+.last\\\\:mt-96:last-child {
+  margin-top: 24rem;
+}
+
+.last\\\\:mt-auto:last-child {
+  margin-top: auto;
+}
+
+.last\\\\:mt-px:last-child {
+  margin-top: 1px;
+}
+
+.last\\\\:mt-0\\\\.5:last-child {
+  margin-top: 0.125rem;
+}
+
+.last\\\\:mt-1\\\\.5:last-child {
+  margin-top: 0.375rem;
+}
+
+.last\\\\:mt-2\\\\.5:last-child {
+  margin-top: 0.625rem;
+}
+
+.last\\\\:mt-3\\\\.5:last-child {
+  margin-top: 0.875rem;
+}
+
+.last\\\\:-mt-0:last-child {
+  margin-top: 0px;
+}
+
+.last\\\\:-mt-1:last-child {
+  margin-top: -0.25rem;
+}
+
+.last\\\\:-mt-2:last-child {
+  margin-top: -0.5rem;
+}
+
+.last\\\\:-mt-3:last-child {
+  margin-top: -0.75rem;
+}
+
+.last\\\\:-mt-4:last-child {
+  margin-top: -1rem;
+}
+
+.last\\\\:-mt-5:last-child {
+  margin-top: -1.25rem;
+}
+
+.last\\\\:-mt-6:last-child {
+  margin-top: -1.5rem;
+}
+
+.last\\\\:-mt-7:last-child {
+  margin-top: -1.75rem;
+}
+
+.last\\\\:-mt-8:last-child {
+  margin-top: -2rem;
+}
+
+.last\\\\:-mt-9:last-child {
+  margin-top: -2.25rem;
+}
+
+.last\\\\:-mt-10:last-child {
+  margin-top: -2.5rem;
+}
+
+.last\\\\:-mt-11:last-child {
+  margin-top: -2.75rem;
+}
+
+.last\\\\:-mt-12:last-child {
+  margin-top: -3rem;
+}
+
+.last\\\\:-mt-14:last-child {
+  margin-top: -3.5rem;
+}
+
+.last\\\\:-mt-16:last-child {
+  margin-top: -4rem;
+}
+
+.last\\\\:-mt-20:last-child {
+  margin-top: -5rem;
+}
+
+.last\\\\:-mt-24:last-child {
+  margin-top: -6rem;
+}
+
+.last\\\\:-mt-28:last-child {
+  margin-top: -7rem;
+}
+
+.last\\\\:-mt-32:last-child {
+  margin-top: -8rem;
+}
+
+.last\\\\:-mt-36:last-child {
+  margin-top: -9rem;
+}
+
+.last\\\\:-mt-40:last-child {
+  margin-top: -10rem;
+}
+
+.last\\\\:-mt-44:last-child {
+  margin-top: -11rem;
+}
+
+.last\\\\:-mt-48:last-child {
+  margin-top: -12rem;
+}
+
+.last\\\\:-mt-52:last-child {
+  margin-top: -13rem;
+}
+
+.last\\\\:-mt-56:last-child {
+  margin-top: -14rem;
+}
+
+.last\\\\:-mt-60:last-child {
+  margin-top: -15rem;
+}
+
+.last\\\\:-mt-64:last-child {
+  margin-top: -16rem;
+}
+
+.last\\\\:-mt-72:last-child {
+  margin-top: -18rem;
+}
+
+.last\\\\:-mt-80:last-child {
+  margin-top: -20rem;
+}
+
+.last\\\\:-mt-96:last-child {
+  margin-top: -24rem;
+}
+
+.last\\\\:-mt-px:last-child {
+  margin-top: -1px;
+}
+
+.last\\\\:-mt-0\\\\.5:last-child {
+  margin-top: -0.125rem;
+}
+
+.last\\\\:-mt-1\\\\.5:last-child {
+  margin-top: -0.375rem;
+}
+
+.last\\\\:-mt-2\\\\.5:last-child {
+  margin-top: -0.625rem;
+}
+
+.last\\\\:-mt-3\\\\.5:last-child {
+  margin-top: -0.875rem;
+}
+
+.last\\\\:mr-0:last-child {
+  margin-right: 0px;
+}
+
+.last\\\\:mr-1:last-child {
+  margin-right: 0.25rem;
+}
+
+.last\\\\:mr-2:last-child {
+  margin-right: 0.5rem;
+}
+
+.last\\\\:mr-3:last-child {
+  margin-right: 0.75rem;
+}
+
+.last\\\\:mr-4:last-child {
+  margin-right: 1rem;
+}
+
+.last\\\\:mr-5:last-child {
+  margin-right: 1.25rem;
+}
+
+.last\\\\:mr-6:last-child {
+  margin-right: 1.5rem;
+}
+
+.last\\\\:mr-7:last-child {
+  margin-right: 1.75rem;
+}
+
+.last\\\\:mr-8:last-child {
+  margin-right: 2rem;
+}
+
+.last\\\\:mr-9:last-child {
+  margin-right: 2.25rem;
+}
+
+.last\\\\:mr-10:last-child {
+  margin-right: 2.5rem;
+}
+
+.last\\\\:mr-11:last-child {
+  margin-right: 2.75rem;
+}
+
+.last\\\\:mr-12:last-child {
+  margin-right: 3rem;
+}
+
+.last\\\\:mr-14:last-child {
+  margin-right: 3.5rem;
+}
+
+.last\\\\:mr-16:last-child {
+  margin-right: 4rem;
+}
+
+.last\\\\:mr-20:last-child {
+  margin-right: 5rem;
+}
+
+.last\\\\:mr-24:last-child {
+  margin-right: 6rem;
+}
+
+.last\\\\:mr-28:last-child {
+  margin-right: 7rem;
+}
+
+.last\\\\:mr-32:last-child {
+  margin-right: 8rem;
+}
+
+.last\\\\:mr-36:last-child {
+  margin-right: 9rem;
+}
+
+.last\\\\:mr-40:last-child {
+  margin-right: 10rem;
+}
+
+.last\\\\:mr-44:last-child {
+  margin-right: 11rem;
+}
+
+.last\\\\:mr-48:last-child {
+  margin-right: 12rem;
+}
+
+.last\\\\:mr-52:last-child {
+  margin-right: 13rem;
+}
+
+.last\\\\:mr-56:last-child {
+  margin-right: 14rem;
+}
+
+.last\\\\:mr-60:last-child {
+  margin-right: 15rem;
+}
+
+.last\\\\:mr-64:last-child {
+  margin-right: 16rem;
+}
+
+.last\\\\:mr-72:last-child {
+  margin-right: 18rem;
+}
+
+.last\\\\:mr-80:last-child {
+  margin-right: 20rem;
+}
+
+.last\\\\:mr-96:last-child {
+  margin-right: 24rem;
+}
+
+.last\\\\:mr-auto:last-child {
+  margin-right: auto;
+}
+
+.last\\\\:mr-px:last-child {
+  margin-right: 1px;
+}
+
+.last\\\\:mr-0\\\\.5:last-child {
+  margin-right: 0.125rem;
+}
+
+.last\\\\:mr-1\\\\.5:last-child {
+  margin-right: 0.375rem;
+}
+
+.last\\\\:mr-2\\\\.5:last-child {
+  margin-right: 0.625rem;
+}
+
+.last\\\\:mr-3\\\\.5:last-child {
+  margin-right: 0.875rem;
+}
+
+.last\\\\:-mr-0:last-child {
+  margin-right: 0px;
+}
+
+.last\\\\:-mr-1:last-child {
+  margin-right: -0.25rem;
+}
+
+.last\\\\:-mr-2:last-child {
+  margin-right: -0.5rem;
+}
+
+.last\\\\:-mr-3:last-child {
+  margin-right: -0.75rem;
+}
+
+.last\\\\:-mr-4:last-child {
+  margin-right: -1rem;
+}
+
+.last\\\\:-mr-5:last-child {
+  margin-right: -1.25rem;
+}
+
+.last\\\\:-mr-6:last-child {
+  margin-right: -1.5rem;
+}
+
+.last\\\\:-mr-7:last-child {
+  margin-right: -1.75rem;
+}
+
+.last\\\\:-mr-8:last-child {
+  margin-right: -2rem;
+}
+
+.last\\\\:-mr-9:last-child {
+  margin-right: -2.25rem;
+}
+
+.last\\\\:-mr-10:last-child {
+  margin-right: -2.5rem;
+}
+
+.last\\\\:-mr-11:last-child {
+  margin-right: -2.75rem;
+}
+
+.last\\\\:-mr-12:last-child {
+  margin-right: -3rem;
+}
+
+.last\\\\:-mr-14:last-child {
+  margin-right: -3.5rem;
+}
+
+.last\\\\:-mr-16:last-child {
+  margin-right: -4rem;
+}
+
+.last\\\\:-mr-20:last-child {
+  margin-right: -5rem;
+}
+
+.last\\\\:-mr-24:last-child {
+  margin-right: -6rem;
+}
+
+.last\\\\:-mr-28:last-child {
+  margin-right: -7rem;
+}
+
+.last\\\\:-mr-32:last-child {
+  margin-right: -8rem;
+}
+
+.last\\\\:-mr-36:last-child {
+  margin-right: -9rem;
+}
+
+.last\\\\:-mr-40:last-child {
+  margin-right: -10rem;
+}
+
+.last\\\\:-mr-44:last-child {
+  margin-right: -11rem;
+}
+
+.last\\\\:-mr-48:last-child {
+  margin-right: -12rem;
+}
+
+.last\\\\:-mr-52:last-child {
+  margin-right: -13rem;
+}
+
+.last\\\\:-mr-56:last-child {
+  margin-right: -14rem;
+}
+
+.last\\\\:-mr-60:last-child {
+  margin-right: -15rem;
+}
+
+.last\\\\:-mr-64:last-child {
+  margin-right: -16rem;
+}
+
+.last\\\\:-mr-72:last-child {
+  margin-right: -18rem;
+}
+
+.last\\\\:-mr-80:last-child {
+  margin-right: -20rem;
+}
+
+.last\\\\:-mr-96:last-child {
+  margin-right: -24rem;
+}
+
+.last\\\\:-mr-px:last-child {
+  margin-right: -1px;
+}
+
+.last\\\\:-mr-0\\\\.5:last-child {
+  margin-right: -0.125rem;
+}
+
+.last\\\\:-mr-1\\\\.5:last-child {
+  margin-right: -0.375rem;
+}
+
+.last\\\\:-mr-2\\\\.5:last-child {
+  margin-right: -0.625rem;
+}
+
+.last\\\\:-mr-3\\\\.5:last-child {
+  margin-right: -0.875rem;
+}
+
+.last\\\\:mb-0:last-child {
+  margin-bottom: 0px;
+}
+
+.last\\\\:mb-1:last-child {
+  margin-bottom: 0.25rem;
+}
+
+.last\\\\:mb-2:last-child {
+  margin-bottom: 0.5rem;
+}
+
+.last\\\\:mb-3:last-child {
+  margin-bottom: 0.75rem;
+}
+
+.last\\\\:mb-4:last-child {
+  margin-bottom: 1rem;
+}
+
+.last\\\\:mb-5:last-child {
+  margin-bottom: 1.25rem;
+}
+
+.last\\\\:mb-6:last-child {
+  margin-bottom: 1.5rem;
+}
+
+.last\\\\:mb-7:last-child {
+  margin-bottom: 1.75rem;
+}
+
+.last\\\\:mb-8:last-child {
+  margin-bottom: 2rem;
+}
+
+.last\\\\:mb-9:last-child {
+  margin-bottom: 2.25rem;
+}
+
+.last\\\\:mb-10:last-child {
+  margin-bottom: 2.5rem;
+}
+
+.last\\\\:mb-11:last-child {
+  margin-bottom: 2.75rem;
+}
+
+.last\\\\:mb-12:last-child {
+  margin-bottom: 3rem;
+}
+
+.last\\\\:mb-14:last-child {
+  margin-bottom: 3.5rem;
+}
+
+.last\\\\:mb-16:last-child {
+  margin-bottom: 4rem;
+}
+
+.last\\\\:mb-20:last-child {
+  margin-bottom: 5rem;
+}
+
+.last\\\\:mb-24:last-child {
+  margin-bottom: 6rem;
+}
+
+.last\\\\:mb-28:last-child {
+  margin-bottom: 7rem;
+}
+
+.last\\\\:mb-32:last-child {
+  margin-bottom: 8rem;
+}
+
+.last\\\\:mb-36:last-child {
+  margin-bottom: 9rem;
+}
+
+.last\\\\:mb-40:last-child {
+  margin-bottom: 10rem;
+}
+
+.last\\\\:mb-44:last-child {
+  margin-bottom: 11rem;
+}
+
+.last\\\\:mb-48:last-child {
+  margin-bottom: 12rem;
+}
+
+.last\\\\:mb-52:last-child {
+  margin-bottom: 13rem;
+}
+
+.last\\\\:mb-56:last-child {
+  margin-bottom: 14rem;
+}
+
+.last\\\\:mb-60:last-child {
+  margin-bottom: 15rem;
+}
+
+.last\\\\:mb-64:last-child {
+  margin-bottom: 16rem;
+}
+
+.last\\\\:mb-72:last-child {
+  margin-bottom: 18rem;
+}
+
+.last\\\\:mb-80:last-child {
+  margin-bottom: 20rem;
+}
+
+.last\\\\:mb-96:last-child {
+  margin-bottom: 24rem;
+}
+
+.last\\\\:mb-auto:last-child {
+  margin-bottom: auto;
+}
+
+.last\\\\:mb-px:last-child {
+  margin-bottom: 1px;
+}
+
+.last\\\\:mb-0\\\\.5:last-child {
+  margin-bottom: 0.125rem;
+}
+
+.last\\\\:mb-1\\\\.5:last-child {
+  margin-bottom: 0.375rem;
+}
+
+.last\\\\:mb-2\\\\.5:last-child {
+  margin-bottom: 0.625rem;
+}
+
+.last\\\\:mb-3\\\\.5:last-child {
+  margin-bottom: 0.875rem;
+}
+
+.last\\\\:-mb-0:last-child {
+  margin-bottom: 0px;
+}
+
+.last\\\\:-mb-1:last-child {
+  margin-bottom: -0.25rem;
+}
+
+.last\\\\:-mb-2:last-child {
+  margin-bottom: -0.5rem;
+}
+
+.last\\\\:-mb-3:last-child {
+  margin-bottom: -0.75rem;
+}
+
+.last\\\\:-mb-4:last-child {
+  margin-bottom: -1rem;
+}
+
+.last\\\\:-mb-5:last-child {
+  margin-bottom: -1.25rem;
+}
+
+.last\\\\:-mb-6:last-child {
+  margin-bottom: -1.5rem;
+}
+
+.last\\\\:-mb-7:last-child {
+  margin-bottom: -1.75rem;
+}
+
+.last\\\\:-mb-8:last-child {
+  margin-bottom: -2rem;
+}
+
+.last\\\\:-mb-9:last-child {
+  margin-bottom: -2.25rem;
+}
+
+.last\\\\:-mb-10:last-child {
+  margin-bottom: -2.5rem;
+}
+
+.last\\\\:-mb-11:last-child {
+  margin-bottom: -2.75rem;
+}
+
+.last\\\\:-mb-12:last-child {
+  margin-bottom: -3rem;
+}
+
+.last\\\\:-mb-14:last-child {
+  margin-bottom: -3.5rem;
+}
+
+.last\\\\:-mb-16:last-child {
+  margin-bottom: -4rem;
+}
+
+.last\\\\:-mb-20:last-child {
+  margin-bottom: -5rem;
+}
+
+.last\\\\:-mb-24:last-child {
+  margin-bottom: -6rem;
+}
+
+.last\\\\:-mb-28:last-child {
+  margin-bottom: -7rem;
+}
+
+.last\\\\:-mb-32:last-child {
+  margin-bottom: -8rem;
+}
+
+.last\\\\:-mb-36:last-child {
+  margin-bottom: -9rem;
+}
+
+.last\\\\:-mb-40:last-child {
+  margin-bottom: -10rem;
+}
+
+.last\\\\:-mb-44:last-child {
+  margin-bottom: -11rem;
+}
+
+.last\\\\:-mb-48:last-child {
+  margin-bottom: -12rem;
+}
+
+.last\\\\:-mb-52:last-child {
+  margin-bottom: -13rem;
+}
+
+.last\\\\:-mb-56:last-child {
+  margin-bottom: -14rem;
+}
+
+.last\\\\:-mb-60:last-child {
+  margin-bottom: -15rem;
+}
+
+.last\\\\:-mb-64:last-child {
+  margin-bottom: -16rem;
+}
+
+.last\\\\:-mb-72:last-child {
+  margin-bottom: -18rem;
+}
+
+.last\\\\:-mb-80:last-child {
+  margin-bottom: -20rem;
+}
+
+.last\\\\:-mb-96:last-child {
+  margin-bottom: -24rem;
+}
+
+.last\\\\:-mb-px:last-child {
+  margin-bottom: -1px;
+}
+
+.last\\\\:-mb-0\\\\.5:last-child {
+  margin-bottom: -0.125rem;
+}
+
+.last\\\\:-mb-1\\\\.5:last-child {
+  margin-bottom: -0.375rem;
+}
+
+.last\\\\:-mb-2\\\\.5:last-child {
+  margin-bottom: -0.625rem;
+}
+
+.last\\\\:-mb-3\\\\.5:last-child {
+  margin-bottom: -0.875rem;
+}
+
+.last\\\\:ml-0:last-child {
+  margin-left: 0px;
+}
+
+.last\\\\:ml-1:last-child {
+  margin-left: 0.25rem;
+}
+
+.last\\\\:ml-2:last-child {
+  margin-left: 0.5rem;
+}
+
+.last\\\\:ml-3:last-child {
+  margin-left: 0.75rem;
+}
+
+.last\\\\:ml-4:last-child {
+  margin-left: 1rem;
+}
+
+.last\\\\:ml-5:last-child {
+  margin-left: 1.25rem;
+}
+
+.last\\\\:ml-6:last-child {
+  margin-left: 1.5rem;
+}
+
+.last\\\\:ml-7:last-child {
+  margin-left: 1.75rem;
+}
+
+.last\\\\:ml-8:last-child {
+  margin-left: 2rem;
+}
+
+.last\\\\:ml-9:last-child {
+  margin-left: 2.25rem;
+}
+
+.last\\\\:ml-10:last-child {
+  margin-left: 2.5rem;
+}
+
+.last\\\\:ml-11:last-child {
+  margin-left: 2.75rem;
+}
+
+.last\\\\:ml-12:last-child {
+  margin-left: 3rem;
+}
+
+.last\\\\:ml-14:last-child {
+  margin-left: 3.5rem;
+}
+
+.last\\\\:ml-16:last-child {
+  margin-left: 4rem;
+}
+
+.last\\\\:ml-20:last-child {
+  margin-left: 5rem;
+}
+
+.last\\\\:ml-24:last-child {
+  margin-left: 6rem;
+}
+
+.last\\\\:ml-28:last-child {
+  margin-left: 7rem;
+}
+
+.last\\\\:ml-32:last-child {
+  margin-left: 8rem;
+}
+
+.last\\\\:ml-36:last-child {
+  margin-left: 9rem;
+}
+
+.last\\\\:ml-40:last-child {
+  margin-left: 10rem;
+}
+
+.last\\\\:ml-44:last-child {
+  margin-left: 11rem;
+}
+
+.last\\\\:ml-48:last-child {
+  margin-left: 12rem;
+}
+
+.last\\\\:ml-52:last-child {
+  margin-left: 13rem;
+}
+
+.last\\\\:ml-56:last-child {
+  margin-left: 14rem;
+}
+
+.last\\\\:ml-60:last-child {
+  margin-left: 15rem;
+}
+
+.last\\\\:ml-64:last-child {
+  margin-left: 16rem;
+}
+
+.last\\\\:ml-72:last-child {
+  margin-left: 18rem;
+}
+
+.last\\\\:ml-80:last-child {
+  margin-left: 20rem;
+}
+
+.last\\\\:ml-96:last-child {
+  margin-left: 24rem;
+}
+
+.last\\\\:ml-auto:last-child {
+  margin-left: auto;
+}
+
+.last\\\\:ml-px:last-child {
+  margin-left: 1px;
+}
+
+.last\\\\:ml-0\\\\.5:last-child {
+  margin-left: 0.125rem;
+}
+
+.last\\\\:ml-1\\\\.5:last-child {
+  margin-left: 0.375rem;
+}
+
+.last\\\\:ml-2\\\\.5:last-child {
+  margin-left: 0.625rem;
+}
+
+.last\\\\:ml-3\\\\.5:last-child {
+  margin-left: 0.875rem;
+}
+
+.last\\\\:-ml-0:last-child {
+  margin-left: 0px;
+}
+
+.last\\\\:-ml-1:last-child {
+  margin-left: -0.25rem;
+}
+
+.last\\\\:-ml-2:last-child {
+  margin-left: -0.5rem;
+}
+
+.last\\\\:-ml-3:last-child {
+  margin-left: -0.75rem;
+}
+
+.last\\\\:-ml-4:last-child {
+  margin-left: -1rem;
+}
+
+.last\\\\:-ml-5:last-child {
+  margin-left: -1.25rem;
+}
+
+.last\\\\:-ml-6:last-child {
+  margin-left: -1.5rem;
+}
+
+.last\\\\:-ml-7:last-child {
+  margin-left: -1.75rem;
+}
+
+.last\\\\:-ml-8:last-child {
+  margin-left: -2rem;
+}
+
+.last\\\\:-ml-9:last-child {
+  margin-left: -2.25rem;
+}
+
+.last\\\\:-ml-10:last-child {
+  margin-left: -2.5rem;
+}
+
+.last\\\\:-ml-11:last-child {
+  margin-left: -2.75rem;
+}
+
+.last\\\\:-ml-12:last-child {
+  margin-left: -3rem;
+}
+
+.last\\\\:-ml-14:last-child {
+  margin-left: -3.5rem;
+}
+
+.last\\\\:-ml-16:last-child {
+  margin-left: -4rem;
+}
+
+.last\\\\:-ml-20:last-child {
+  margin-left: -5rem;
+}
+
+.last\\\\:-ml-24:last-child {
+  margin-left: -6rem;
+}
+
+.last\\\\:-ml-28:last-child {
+  margin-left: -7rem;
+}
+
+.last\\\\:-ml-32:last-child {
+  margin-left: -8rem;
+}
+
+.last\\\\:-ml-36:last-child {
+  margin-left: -9rem;
+}
+
+.last\\\\:-ml-40:last-child {
+  margin-left: -10rem;
+}
+
+.last\\\\:-ml-44:last-child {
+  margin-left: -11rem;
+}
+
+.last\\\\:-ml-48:last-child {
+  margin-left: -12rem;
+}
+
+.last\\\\:-ml-52:last-child {
+  margin-left: -13rem;
+}
+
+.last\\\\:-ml-56:last-child {
+  margin-left: -14rem;
+}
+
+.last\\\\:-ml-60:last-child {
+  margin-left: -15rem;
+}
+
+.last\\\\:-ml-64:last-child {
+  margin-left: -16rem;
+}
+
+.last\\\\:-ml-72:last-child {
+  margin-left: -18rem;
+}
+
+.last\\\\:-ml-80:last-child {
+  margin-left: -20rem;
+}
+
+.last\\\\:-ml-96:last-child {
+  margin-left: -24rem;
+}
+
+.last\\\\:-ml-px:last-child {
+  margin-left: -1px;
+}
+
+.last\\\\:-ml-0\\\\.5:last-child {
+  margin-left: -0.125rem;
+}
+
+.last\\\\:-ml-1\\\\.5:last-child {
+  margin-left: -0.375rem;
+}
+
+.last\\\\:-ml-2\\\\.5:last-child {
+  margin-left: -0.625rem;
+}
+
+.last\\\\:-ml-3\\\\.5:last-child {
+  margin-left: -0.875rem;
+}
+
+.box-border {
+  box-sizing: border-box;
+}
+
+.box-content {
+  box-sizing: content-box;
+}
+
+.block {
+  display: block;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+.inline {
+  display: inline;
+}
+
+.flex {
+  display: flex;
+}
+
+.inline-flex {
+  display: inline-flex;
+}
+
+.table {
+  display: table;
+}
+
+.inline-table {
+  display: inline-table;
+}
+
+.table-caption {
+  display: table-caption;
+}
+
+.table-cell {
+  display: table-cell;
+}
+
+.table-column {
+  display: table-column;
+}
+
+.table-column-group {
+  display: table-column-group;
+}
+
+.table-footer-group {
+  display: table-footer-group;
+}
+
+.table-header-group {
+  display: table-header-group;
+}
+
+.table-row-group {
+  display: table-row-group;
+}
+
+.table-row {
+  display: table-row;
+}
+
+.flow-root {
+  display: flow-root;
+}
+
+.grid {
+  display: grid;
+}
+
+.inline-grid {
+  display: inline-grid;
+}
+
+.contents {
+  display: contents;
+}
+
+.list-item {
+  display: list-item;
+}
+
+.hidden {
+  display: none;
+}
+
+.group:hover .group-hover\\\\:block {
+  display: block;
+}
+
+.group:hover .group-hover\\\\:inline-block {
+  display: inline-block;
+}
+
+.group:hover .group-hover\\\\:inline {
+  display: inline;
+}
+
+.group:hover .group-hover\\\\:flex {
+  display: flex;
+}
+
+.group:hover .group-hover\\\\:inline-flex {
+  display: inline-flex;
+}
+
+.group:hover .group-hover\\\\:table {
+  display: table;
+}
+
+.group:hover .group-hover\\\\:inline-table {
+  display: inline-table;
+}
+
+.group:hover .group-hover\\\\:table-caption {
+  display: table-caption;
+}
+
+.group:hover .group-hover\\\\:table-cell {
+  display: table-cell;
+}
+
+.group:hover .group-hover\\\\:table-column {
+  display: table-column;
+}
+
+.group:hover .group-hover\\\\:table-column-group {
+  display: table-column-group;
+}
+
+.group:hover .group-hover\\\\:table-footer-group {
+  display: table-footer-group;
+}
+
+.group:hover .group-hover\\\\:table-header-group {
+  display: table-header-group;
+}
+
+.group:hover .group-hover\\\\:table-row-group {
+  display: table-row-group;
+}
+
+.group:hover .group-hover\\\\:table-row {
+  display: table-row;
+}
+
+.group:hover .group-hover\\\\:flow-root {
+  display: flow-root;
+}
+
+.group:hover .group-hover\\\\:grid {
+  display: grid;
+}
+
+.group:hover .group-hover\\\\:inline-grid {
+  display: inline-grid;
+}
+
+.group:hover .group-hover\\\\:contents {
+  display: contents;
+}
+
+.group:hover .group-hover\\\\:list-item {
+  display: list-item;
+}
+
+.group:hover .group-hover\\\\:hidden {
+  display: none;
+}
+
+.h-0 {
+  height: 0px;
+}
+
+.h-1 {
+  height: 0.25rem;
+}
+
+.h-2 {
+  height: 0.5rem;
+}
+
+.h-3 {
+  height: 0.75rem;
+}
+
+.h-4 {
+  height: 1rem;
+}
+
+.h-5 {
+  height: 1.25rem;
+}
+
+.h-6 {
+  height: 1.5rem;
+}
+
+.h-7 {
+  height: 1.75rem;
+}
+
+.h-8 {
+  height: 2rem;
+}
+
+.h-9 {
+  height: 2.25rem;
+}
+
+.h-10 {
+  height: 2.5rem;
+}
+
+.h-11 {
+  height: 2.75rem;
+}
+
+.h-12 {
+  height: 3rem;
+}
+
+.h-14 {
+  height: 3.5rem;
+}
+
+.h-16 {
+  height: 4rem;
+}
+
+.h-20 {
+  height: 5rem;
+}
+
+.h-24 {
+  height: 6rem;
+}
+
+.h-28 {
+  height: 7rem;
+}
+
+.h-32 {
+  height: 8rem;
+}
+
+.h-36 {
+  height: 9rem;
+}
+
+.h-40 {
+  height: 10rem;
+}
+
+.h-44 {
+  height: 11rem;
+}
+
+.h-48 {
+  height: 12rem;
+}
+
+.h-52 {
+  height: 13rem;
+}
+
+.h-56 {
+  height: 14rem;
+}
+
+.h-60 {
+  height: 15rem;
+}
+
+.h-64 {
+  height: 16rem;
+}
+
+.h-72 {
+  height: 18rem;
+}
+
+.h-80 {
+  height: 20rem;
+}
+
+.h-96 {
+  height: 24rem;
+}
+
+.h-auto {
+  height: auto;
+}
+
+.h-px {
+  height: 1px;
+}
+
+.h-0\\\\.5 {
+  height: 0.125rem;
+}
+
+.h-1\\\\.5 {
+  height: 0.375rem;
+}
+
+.h-2\\\\.5 {
+  height: 0.375rem;
+}
+
+.h-3\\\\.5 {
+  height: 0.875rem;
+}
+
+.h-1\\\\/2 {
+  height: 50%;
+}
+
+.h-1\\\\/3 {
+  height: 33.333333%;
+}
+
+.h-2\\\\/3 {
+  height: 66.666667%;
+}
+
+.h-1\\\\/4 {
+  height: 25%;
+}
+
+.h-2\\\\/4 {
+  height: 50%;
+}
+
+.h-3\\\\/4 {
+  height: 75%;
+}
+
+.h-1\\\\/5 {
+  height: 20%;
+}
+
+.h-2\\\\/5 {
+  height: 40%;
+}
+
+.h-3\\\\/5 {
+  height: 60%;
+}
+
+.h-4\\\\/5 {
+  height: 80%;
+}
+
+.h-1\\\\/6 {
+  height: 16.666667%;
+}
+
+.h-2\\\\/6 {
+  height: 33.333333%;
+}
+
+.h-3\\\\/6 {
+  height: 50%;
+}
+
+.h-4\\\\/6 {
+  height: 66.666667%;
+}
+
+.h-5\\\\/6 {
+  height: 83.333333%;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.h-screen {
+  height: 100vh;
+}
+
+.h-main-content-area {
+  height: calc(100vh - var(--template-head-height));
+}
+
+.max-h-0 {
+  max-height: 0px;
+}
+
+.max-h-1 {
+  max-height: 0.25rem;
+}
+
+.max-h-2 {
+  max-height: 0.5rem;
+}
+
+.max-h-3 {
+  max-height: 0.75rem;
+}
+
+.max-h-4 {
+  max-height: 1rem;
+}
+
+.max-h-5 {
+  max-height: 1.25rem;
+}
+
+.max-h-6 {
+  max-height: 1.5rem;
+}
+
+.max-h-7 {
+  max-height: 1.75rem;
+}
+
+.max-h-8 {
+  max-height: 2rem;
+}
+
+.max-h-9 {
+  max-height: 2.25rem;
+}
+
+.max-h-10 {
+  max-height: 2.5rem;
+}
+
+.max-h-11 {
+  max-height: 2.75rem;
+}
+
+.max-h-12 {
+  max-height: 3rem;
+}
+
+.max-h-14 {
+  max-height: 3.5rem;
+}
+
+.max-h-16 {
+  max-height: 4rem;
+}
+
+.max-h-20 {
+  max-height: 5rem;
+}
+
+.max-h-24 {
+  max-height: 6rem;
+}
+
+.max-h-28 {
+  max-height: 7rem;
+}
+
+.max-h-32 {
+  max-height: 8rem;
+}
+
+.max-h-36 {
+  max-height: 9rem;
+}
+
+.max-h-40 {
+  max-height: 10rem;
+}
+
+.max-h-44 {
+  max-height: 11rem;
+}
+
+.max-h-48 {
+  max-height: 12rem;
+}
+
+.max-h-52 {
+  max-height: 13rem;
+}
+
+.max-h-56 {
+  max-height: 14rem;
+}
+
+.max-h-60 {
+  max-height: 15rem;
+}
+
+.max-h-64 {
+  max-height: 16rem;
+}
+
+.max-h-72 {
+  max-height: 18rem;
+}
+
+.max-h-80 {
+  max-height: 20rem;
+}
+
+.max-h-96 {
+  max-height: 24rem;
+}
+
+.max-h-px {
+  max-height: 1px;
+}
+
+.max-h-0\\\\.5 {
+  max-height: 0.125rem;
+}
+
+.max-h-1\\\\.5 {
+  max-height: 0.375rem;
+}
+
+.max-h-2\\\\.5 {
+  max-height: 0.625rem;
+}
+
+.max-h-3\\\\.5 {
+  max-height: 0.875rem;
+}
+
+.max-h-full {
+  max-height: 100%;
+}
+
+.max-h-screen {
+  max-height: 100vh;
+}
+
+.max-h-listbox {
+  max-height: 12em;
+}
+
+.max-h-under-header {
+  max-height: calc(100vh - var(--template-head-height));
+}
+
+.min-h-0 {
+  min-height: 0px;
+}
+
+.min-h-3 {
+  min-height: 0.75rem;
+}
+
+.min-h-4 {
+  min-height: 1rem;
+}
+
+.min-h-6 {
+  min-height: 1.5rem;
+}
+
+.min-h-16 {
+  min-height: 4rem;
+}
+
+.min-h-full {
+  min-height: 100%;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.w-0 {
+  width: 0px;
+}
+
+.w-1 {
+  width: 0.25rem;
+}
+
+.w-2 {
+  width: 0.5rem;
+}
+
+.w-3 {
+  width: 0.75rem;
+}
+
+.w-4 {
+  width: 1rem;
+}
+
+.w-5 {
+  width: 1.25rem;
+}
+
+.w-6 {
+  width: 1.5rem;
+}
+
+.w-7 {
+  width: 1.75rem;
+}
+
+.w-8 {
+  width: 2rem;
+}
+
+.w-9 {
+  width: 2.25rem;
+}
+
+.w-10 {
+  width: 2.5rem;
+}
+
+.w-11 {
+  width: 2.75rem;
+}
+
+.w-12 {
+  width: 3rem;
+}
+
+.w-14 {
+  width: 3.5rem;
+}
+
+.w-15 {
+  width: 3.75rem;
+}
+
+.w-16 {
+  width: 4rem;
+}
+
+.w-20 {
+  width: 5rem;
+}
+
+.w-24 {
+  width: 6rem;
+}
+
+.w-28 {
+  width: 7rem;
+}
+
+.w-32 {
+  width: 8rem;
+}
+
+.w-36 {
+  width: 9rem;
+}
+
+.w-40 {
+  width: 10rem;
+}
+
+.w-44 {
+  width: 11rem;
+}
+
+.w-48 {
+  width: 12rem;
+}
+
+.w-52 {
+  width: 13rem;
+}
+
+.w-56 {
+  width: 14rem;
+}
+
+.w-60 {
+  width: 15rem;
+}
+
+.w-64 {
+  width: 16rem;
+}
+
+.w-72 {
+  width: 18rem;
+}
+
+.w-80 {
+  width: 20rem;
+}
+
+.w-96 {
+  width: 24rem;
+}
+
+.w-auto {
+  width: auto;
+}
+
+.w-px {
+  width: 1px;
+}
+
+.w-0\\\\.5 {
+  width: 0.125rem;
+}
+
+.w-1\\\\.5 {
+  width: 0.375rem;
+}
+
+.w-2\\\\.5 {
+  width: 0.375rem;
+}
+
+.w-3\\\\.5 {
+  width: 0.875rem;
+}
+
+.w-1\\\\/2 {
+  width: 50%;
+}
+
+.w-1\\\\/3 {
+  width: 33.333333%;
+}
+
+.w-2\\\\/3 {
+  width: 66.666667%;
+}
+
+.w-1\\\\/4 {
+  width: 25%;
+}
+
+.w-2\\\\/4 {
+  width: 50%;
+}
+
+.w-3\\\\/4 {
+  width: 75%;
+}
+
+.w-1\\\\/5 {
+  width: 20%;
+}
+
+.w-2\\\\/5 {
+  width: 40%;
+}
+
+.w-3\\\\/5 {
+  width: 60%;
+}
+
+.w-4\\\\/5 {
+  width: 80%;
+}
+
+.w-1\\\\/6 {
+  width: 16.666667%;
+}
+
+.w-2\\\\/6 {
+  width: 33.333333%;
+}
+
+.w-3\\\\/6 {
+  width: 50%;
+}
+
+.w-4\\\\/6 {
+  width: 66.666667%;
+}
+
+.w-5\\\\/6 {
+  width: 83.333333%;
+}
+
+.w-1\\\\/12 {
+  width: 8.333333%;
+}
+
+.w-2\\\\/12 {
+  width: 16.666667%;
+}
+
+.w-3\\\\/12 {
+  width: 25%;
+}
+
+.w-4\\\\/12 {
+  width: 33.333333%;
+}
+
+.w-5\\\\/12 {
+  width: 41.666667%;
+}
+
+.w-6\\\\/12 {
+  width: 50%;
+}
+
+.w-7\\\\/12 {
+  width: 58.333333%;
+}
+
+.w-8\\\\/12 {
+  width: 66.666667%;
+}
+
+.w-9\\\\/12 {
+  width: 75%;
+}
+
+.w-10\\\\/12 {
+  width: 83.333333%;
+}
+
+.w-11\\\\/12 {
+  width: 91.666667%;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.w-screen {
+  width: 100vw;
+}
+
+.w-min {
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+}
+
+.w-max {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.w-max-content {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.min-w-0 {
+  min-width: 0px;
+}
+
+.min-w-3 {
+  min-width: 0.75rem;
+}
+
+.min-w-4 {
+  min-width: 1rem;
+}
+
+.min-w-6 {
+  min-width: 1.5rem;
+}
+
+.min-w-16 {
+  min-width: 4rem;
+}
+
+.min-w-24 {
+  min-width: 6rem;
+}
+
+.min-w-48 {
+  min-width: 12rem;
+}
+
+.min-w-full {
+  min-width: 100%;
+}
+
+.min-w-min {
+  min-width: -webkit-min-content;
+  min-width: -moz-min-content;
+  min-width: min-content;
+}
+
+.min-w-max {
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+}
+
+.min-w-phoenix {
+  min-width: 1024px;
+}
+
+.min-w-popover {
+  min-width: 140px;
+}
+
+.min-w-toucan {
+  min-width: 1380px;
+}
+
+.max-w-0 {
+  max-width: 0rem;
+}
+
+.max-w-none {
+  max-width: none;
+}
+
+.max-w-xs {
+  max-width: 20rem;
+}
+
+.max-w-sm {
+  max-width: 24rem;
+}
+
+.max-w-md {
+  max-width: 28rem;
+}
+
+.max-w-lg {
+  max-width: 32rem;
+}
+
+.max-w-xl {
+  max-width: 36rem;
+}
+
+.max-w-2xl {
+  max-width: 42rem;
+}
+
+.max-w-3xl {
+  max-width: 48rem;
+}
+
+.max-w-4xl {
+  max-width: 56rem;
+}
+
+.max-w-5xl {
+  max-width: 64rem;
+}
+
+.max-w-6xl {
+  max-width: 72rem;
+}
+
+.max-w-7xl {
+  max-width: 80rem;
+}
+
+.max-w-full {
+  max-width: 100%;
+}
+
+.max-w-min {
+  max-width: -webkit-min-content;
+  max-width: -moz-min-content;
+  max-width: min-content;
+}
+
+.max-w-max {
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
+}
+
+.max-w-prose {
+  max-width: 65ch;
+}
+
+.max-w-screen-lg {
+  max-width: 1120px;
+}
+
+.max-w-screen-2xl {
+  max-width: 1536px;
+}
+
+.max-w-paragraph {
+  max-width: 34rem;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.flex-2 {
+  flex: 2 2 0%;
+}
+
+.flex-3 {
+  flex: 3 3 0%;
+}
+
+.flex-4 {
+  flex: 4 4 0%;
+}
+
+.flex-auto {
+  flex: 1 1 auto;
+}
+
+.flex-initial {
+  flex: 0 1 auto;
+}
+
+.flex-none {
+  flex: none;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
+.flex-shrink {
+  flex-shrink: 1;
+}
+
+.flex-grow-0 {
+  flex-grow: 0;
+}
+
+.flex-grow {
+  flex-grow: 1;
+}
+
+.table-auto {
+  table-layout: auto;
+}
+
+.table-fixed {
+  table-layout: fixed;
+}
+
+.border-collapse {
+  border-collapse: collapse;
+}
+
+.border-separate {
+  border-collapse: separate;
+}
+
+.origin-center {
+  transform-origin: center;
+}
+
+.origin-top {
+  transform-origin: top;
+}
+
+.origin-top-right {
+  transform-origin: top right;
+}
+
+.origin-right {
+  transform-origin: right;
+}
+
+.origin-bottom-right {
+  transform-origin: bottom right;
+}
+
+.origin-bottom {
+  transform-origin: bottom;
+}
+
+.origin-bottom-left {
+  transform-origin: bottom left;
+}
+
+.origin-left {
+  transform-origin: left;
+}
+
+.origin-top-left {
+  transform-origin: top left;
+}
+
+.transform {
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.transform-gpu {
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  transform: translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.transform-none {
+  transform: none;
+}
+
+.translate-x-0 {
+  --tw-translate-x: 0px;
+}
+
+.translate-x-1 {
+  --tw-translate-x: 0.25rem;
+}
+
+.translate-x-2 {
+  --tw-translate-x: 0.5rem;
+}
+
+.translate-x-3 {
+  --tw-translate-x: 0.75rem;
+}
+
+.translate-x-4 {
+  --tw-translate-x: 1rem;
+}
+
+.translate-x-5 {
+  --tw-translate-x: 1.25rem;
+}
+
+.translate-x-6 {
+  --tw-translate-x: 1.5rem;
+}
+
+.translate-x-7 {
+  --tw-translate-x: 1.75rem;
+}
+
+.translate-x-8 {
+  --tw-translate-x: 2rem;
+}
+
+.translate-x-9 {
+  --tw-translate-x: 2.25rem;
+}
+
+.translate-x-10 {
+  --tw-translate-x: 2.5rem;
+}
+
+.translate-x-11 {
+  --tw-translate-x: 2.75rem;
+}
+
+.translate-x-12 {
+  --tw-translate-x: 3rem;
+}
+
+.translate-x-14 {
+  --tw-translate-x: 3.5rem;
+}
+
+.translate-x-16 {
+  --tw-translate-x: 4rem;
+}
+
+.translate-x-20 {
+  --tw-translate-x: 5rem;
+}
+
+.translate-x-24 {
+  --tw-translate-x: 6rem;
+}
+
+.translate-x-28 {
+  --tw-translate-x: 7rem;
+}
+
+.translate-x-32 {
+  --tw-translate-x: 8rem;
+}
+
+.translate-x-36 {
+  --tw-translate-x: 9rem;
+}
+
+.translate-x-40 {
+  --tw-translate-x: 10rem;
+}
+
+.translate-x-44 {
+  --tw-translate-x: 11rem;
+}
+
+.translate-x-48 {
+  --tw-translate-x: 12rem;
+}
+
+.translate-x-52 {
+  --tw-translate-x: 13rem;
+}
+
+.translate-x-56 {
+  --tw-translate-x: 14rem;
+}
+
+.translate-x-60 {
+  --tw-translate-x: 15rem;
+}
+
+.translate-x-64 {
+  --tw-translate-x: 16rem;
+}
+
+.translate-x-72 {
+  --tw-translate-x: 18rem;
+}
+
+.translate-x-80 {
+  --tw-translate-x: 20rem;
+}
+
+.translate-x-96 {
+  --tw-translate-x: 24rem;
+}
+
+.translate-x-px {
+  --tw-translate-x: 1px;
+}
+
+.translate-x-0\\\\.5 {
+  --tw-translate-x: 0.125rem;
+}
+
+.translate-x-1\\\\.5 {
+  --tw-translate-x: 0.375rem;
+}
+
+.translate-x-2\\\\.5 {
+  --tw-translate-x: 0.625rem;
+}
+
+.translate-x-3\\\\.5 {
+  --tw-translate-x: 0.875rem;
+}
+
+.-translate-x-0 {
+  --tw-translate-x: 0px;
+}
+
+.-translate-x-1 {
+  --tw-translate-x: -0.25rem;
+}
+
+.-translate-x-2 {
+  --tw-translate-x: -0.5rem;
+}
+
+.-translate-x-3 {
+  --tw-translate-x: -0.75rem;
+}
+
+.-translate-x-4 {
+  --tw-translate-x: -1rem;
+}
+
+.-translate-x-5 {
+  --tw-translate-x: -1.25rem;
+}
+
+.-translate-x-6 {
+  --tw-translate-x: -1.5rem;
+}
+
+.-translate-x-7 {
+  --tw-translate-x: -1.75rem;
+}
+
+.-translate-x-8 {
+  --tw-translate-x: -2rem;
+}
+
+.-translate-x-9 {
+  --tw-translate-x: -2.25rem;
+}
+
+.-translate-x-10 {
+  --tw-translate-x: -2.5rem;
+}
+
+.-translate-x-11 {
+  --tw-translate-x: -2.75rem;
+}
+
+.-translate-x-12 {
+  --tw-translate-x: -3rem;
+}
+
+.-translate-x-14 {
+  --tw-translate-x: -3.5rem;
+}
+
+.-translate-x-16 {
+  --tw-translate-x: -4rem;
+}
+
+.-translate-x-20 {
+  --tw-translate-x: -5rem;
+}
+
+.-translate-x-24 {
+  --tw-translate-x: -6rem;
+}
+
+.-translate-x-28 {
+  --tw-translate-x: -7rem;
+}
+
+.-translate-x-32 {
+  --tw-translate-x: -8rem;
+}
+
+.-translate-x-36 {
+  --tw-translate-x: -9rem;
+}
+
+.-translate-x-40 {
+  --tw-translate-x: -10rem;
+}
+
+.-translate-x-44 {
+  --tw-translate-x: -11rem;
+}
+
+.-translate-x-48 {
+  --tw-translate-x: -12rem;
+}
+
+.-translate-x-52 {
+  --tw-translate-x: -13rem;
+}
+
+.-translate-x-56 {
+  --tw-translate-x: -14rem;
+}
+
+.-translate-x-60 {
+  --tw-translate-x: -15rem;
+}
+
+.-translate-x-64 {
+  --tw-translate-x: -16rem;
+}
+
+.-translate-x-72 {
+  --tw-translate-x: -18rem;
+}
+
+.-translate-x-80 {
+  --tw-translate-x: -20rem;
+}
+
+.-translate-x-96 {
+  --tw-translate-x: -24rem;
+}
+
+.-translate-x-px {
+  --tw-translate-x: -1px;
+}
+
+.-translate-x-0\\\\.5 {
+  --tw-translate-x: -0.125rem;
+}
+
+.-translate-x-1\\\\.5 {
+  --tw-translate-x: -0.375rem;
+}
+
+.-translate-x-2\\\\.5 {
+  --tw-translate-x: -0.625rem;
+}
+
+.-translate-x-3\\\\.5 {
+  --tw-translate-x: -0.875rem;
+}
+
+.translate-x-1\\\\/2 {
+  --tw-translate-x: 50%;
+}
+
+.translate-x-1\\\\/3 {
+  --tw-translate-x: 33.333333%;
+}
+
+.translate-x-2\\\\/3 {
+  --tw-translate-x: 66.666667%;
+}
+
+.translate-x-1\\\\/4 {
+  --tw-translate-x: 25%;
+}
+
+.translate-x-2\\\\/4 {
+  --tw-translate-x: 50%;
+}
+
+.translate-x-3\\\\/4 {
+  --tw-translate-x: 75%;
+}
+
+.translate-x-full {
+  --tw-translate-x: 100%;
+}
+
+.-translate-x-1\\\\/2 {
+  --tw-translate-x: -50%;
+}
+
+.-translate-x-1\\\\/3 {
+  --tw-translate-x: -33.333333%;
+}
+
+.-translate-x-2\\\\/3 {
+  --tw-translate-x: -66.666667%;
+}
+
+.-translate-x-1\\\\/4 {
+  --tw-translate-x: -25%;
+}
+
+.-translate-x-2\\\\/4 {
+  --tw-translate-x: -50%;
+}
+
+.-translate-x-3\\\\/4 {
+  --tw-translate-x: -75%;
+}
+
+.-translate-x-full {
+  --tw-translate-x: -100%;
+}
+
+.translate-y-0 {
+  --tw-translate-y: 0px;
+}
+
+.translate-y-1 {
+  --tw-translate-y: 0.25rem;
+}
+
+.translate-y-2 {
+  --tw-translate-y: 0.5rem;
+}
+
+.translate-y-3 {
+  --tw-translate-y: 0.75rem;
+}
+
+.translate-y-4 {
+  --tw-translate-y: 1rem;
+}
+
+.translate-y-5 {
+  --tw-translate-y: 1.25rem;
+}
+
+.translate-y-6 {
+  --tw-translate-y: 1.5rem;
+}
+
+.translate-y-7 {
+  --tw-translate-y: 1.75rem;
+}
+
+.translate-y-8 {
+  --tw-translate-y: 2rem;
+}
+
+.translate-y-9 {
+  --tw-translate-y: 2.25rem;
+}
+
+.translate-y-10 {
+  --tw-translate-y: 2.5rem;
+}
+
+.translate-y-11 {
+  --tw-translate-y: 2.75rem;
+}
+
+.translate-y-12 {
+  --tw-translate-y: 3rem;
+}
+
+.translate-y-14 {
+  --tw-translate-y: 3.5rem;
+}
+
+.translate-y-16 {
+  --tw-translate-y: 4rem;
+}
+
+.translate-y-20 {
+  --tw-translate-y: 5rem;
+}
+
+.translate-y-24 {
+  --tw-translate-y: 6rem;
+}
+
+.translate-y-28 {
+  --tw-translate-y: 7rem;
+}
+
+.translate-y-32 {
+  --tw-translate-y: 8rem;
+}
+
+.translate-y-36 {
+  --tw-translate-y: 9rem;
+}
+
+.translate-y-40 {
+  --tw-translate-y: 10rem;
+}
+
+.translate-y-44 {
+  --tw-translate-y: 11rem;
+}
+
+.translate-y-48 {
+  --tw-translate-y: 12rem;
+}
+
+.translate-y-52 {
+  --tw-translate-y: 13rem;
+}
+
+.translate-y-56 {
+  --tw-translate-y: 14rem;
+}
+
+.translate-y-60 {
+  --tw-translate-y: 15rem;
+}
+
+.translate-y-64 {
+  --tw-translate-y: 16rem;
+}
+
+.translate-y-72 {
+  --tw-translate-y: 18rem;
+}
+
+.translate-y-80 {
+  --tw-translate-y: 20rem;
+}
+
+.translate-y-96 {
+  --tw-translate-y: 24rem;
+}
+
+.translate-y-px {
+  --tw-translate-y: 1px;
+}
+
+.translate-y-0\\\\.5 {
+  --tw-translate-y: 0.125rem;
+}
+
+.translate-y-1\\\\.5 {
+  --tw-translate-y: 0.375rem;
+}
+
+.translate-y-2\\\\.5 {
+  --tw-translate-y: 0.625rem;
+}
+
+.translate-y-3\\\\.5 {
+  --tw-translate-y: 0.875rem;
+}
+
+.-translate-y-0 {
+  --tw-translate-y: 0px;
+}
+
+.-translate-y-1 {
+  --tw-translate-y: -0.25rem;
+}
+
+.-translate-y-2 {
+  --tw-translate-y: -0.5rem;
+}
+
+.-translate-y-3 {
+  --tw-translate-y: -0.75rem;
+}
+
+.-translate-y-4 {
+  --tw-translate-y: -1rem;
+}
+
+.-translate-y-5 {
+  --tw-translate-y: -1.25rem;
+}
+
+.-translate-y-6 {
+  --tw-translate-y: -1.5rem;
+}
+
+.-translate-y-7 {
+  --tw-translate-y: -1.75rem;
+}
+
+.-translate-y-8 {
+  --tw-translate-y: -2rem;
+}
+
+.-translate-y-9 {
+  --tw-translate-y: -2.25rem;
+}
+
+.-translate-y-10 {
+  --tw-translate-y: -2.5rem;
+}
+
+.-translate-y-11 {
+  --tw-translate-y: -2.75rem;
+}
+
+.-translate-y-12 {
+  --tw-translate-y: -3rem;
+}
+
+.-translate-y-14 {
+  --tw-translate-y: -3.5rem;
+}
+
+.-translate-y-16 {
+  --tw-translate-y: -4rem;
+}
+
+.-translate-y-20 {
+  --tw-translate-y: -5rem;
+}
+
+.-translate-y-24 {
+  --tw-translate-y: -6rem;
+}
+
+.-translate-y-28 {
+  --tw-translate-y: -7rem;
+}
+
+.-translate-y-32 {
+  --tw-translate-y: -8rem;
+}
+
+.-translate-y-36 {
+  --tw-translate-y: -9rem;
+}
+
+.-translate-y-40 {
+  --tw-translate-y: -10rem;
+}
+
+.-translate-y-44 {
+  --tw-translate-y: -11rem;
+}
+
+.-translate-y-48 {
+  --tw-translate-y: -12rem;
+}
+
+.-translate-y-52 {
+  --tw-translate-y: -13rem;
+}
+
+.-translate-y-56 {
+  --tw-translate-y: -14rem;
+}
+
+.-translate-y-60 {
+  --tw-translate-y: -15rem;
+}
+
+.-translate-y-64 {
+  --tw-translate-y: -16rem;
+}
+
+.-translate-y-72 {
+  --tw-translate-y: -18rem;
+}
+
+.-translate-y-80 {
+  --tw-translate-y: -20rem;
+}
+
+.-translate-y-96 {
+  --tw-translate-y: -24rem;
+}
+
+.-translate-y-px {
+  --tw-translate-y: -1px;
+}
+
+.-translate-y-0\\\\.5 {
+  --tw-translate-y: -0.125rem;
+}
+
+.-translate-y-1\\\\.5 {
+  --tw-translate-y: -0.375rem;
+}
+
+.-translate-y-2\\\\.5 {
+  --tw-translate-y: -0.625rem;
+}
+
+.-translate-y-3\\\\.5 {
+  --tw-translate-y: -0.875rem;
+}
+
+.translate-y-1\\\\/2 {
+  --tw-translate-y: 50%;
+}
+
+.translate-y-1\\\\/3 {
+  --tw-translate-y: 33.333333%;
+}
+
+.translate-y-2\\\\/3 {
+  --tw-translate-y: 66.666667%;
+}
+
+.translate-y-1\\\\/4 {
+  --tw-translate-y: 25%;
+}
+
+.translate-y-2\\\\/4 {
+  --tw-translate-y: 50%;
+}
+
+.translate-y-3\\\\/4 {
+  --tw-translate-y: 75%;
+}
+
+.translate-y-full {
+  --tw-translate-y: 100%;
+}
+
+.-translate-y-1\\\\/2 {
+  --tw-translate-y: -50%;
+}
+
+.-translate-y-1\\\\/3 {
+  --tw-translate-y: -33.333333%;
+}
+
+.-translate-y-2\\\\/3 {
+  --tw-translate-y: -66.666667%;
+}
+
+.-translate-y-1\\\\/4 {
+  --tw-translate-y: -25%;
+}
+
+.-translate-y-2\\\\/4 {
+  --tw-translate-y: -50%;
+}
+
+.-translate-y-3\\\\/4 {
+  --tw-translate-y: -75%;
+}
+
+.-translate-y-full {
+  --tw-translate-y: -100%;
+}
+
+.hover\\\\:translate-x-0:hover {
+  --tw-translate-x: 0px;
+}
+
+.hover\\\\:translate-x-1:hover {
+  --tw-translate-x: 0.25rem;
+}
+
+.hover\\\\:translate-x-2:hover {
+  --tw-translate-x: 0.5rem;
+}
+
+.hover\\\\:translate-x-3:hover {
+  --tw-translate-x: 0.75rem;
+}
+
+.hover\\\\:translate-x-4:hover {
+  --tw-translate-x: 1rem;
+}
+
+.hover\\\\:translate-x-5:hover {
+  --tw-translate-x: 1.25rem;
+}
+
+.hover\\\\:translate-x-6:hover {
+  --tw-translate-x: 1.5rem;
+}
+
+.hover\\\\:translate-x-7:hover {
+  --tw-translate-x: 1.75rem;
+}
+
+.hover\\\\:translate-x-8:hover {
+  --tw-translate-x: 2rem;
+}
+
+.hover\\\\:translate-x-9:hover {
+  --tw-translate-x: 2.25rem;
+}
+
+.hover\\\\:translate-x-10:hover {
+  --tw-translate-x: 2.5rem;
+}
+
+.hover\\\\:translate-x-11:hover {
+  --tw-translate-x: 2.75rem;
+}
+
+.hover\\\\:translate-x-12:hover {
+  --tw-translate-x: 3rem;
+}
+
+.hover\\\\:translate-x-14:hover {
+  --tw-translate-x: 3.5rem;
+}
+
+.hover\\\\:translate-x-16:hover {
+  --tw-translate-x: 4rem;
+}
+
+.hover\\\\:translate-x-20:hover {
+  --tw-translate-x: 5rem;
+}
+
+.hover\\\\:translate-x-24:hover {
+  --tw-translate-x: 6rem;
+}
+
+.hover\\\\:translate-x-28:hover {
+  --tw-translate-x: 7rem;
+}
+
+.hover\\\\:translate-x-32:hover {
+  --tw-translate-x: 8rem;
+}
+
+.hover\\\\:translate-x-36:hover {
+  --tw-translate-x: 9rem;
+}
+
+.hover\\\\:translate-x-40:hover {
+  --tw-translate-x: 10rem;
+}
+
+.hover\\\\:translate-x-44:hover {
+  --tw-translate-x: 11rem;
+}
+
+.hover\\\\:translate-x-48:hover {
+  --tw-translate-x: 12rem;
+}
+
+.hover\\\\:translate-x-52:hover {
+  --tw-translate-x: 13rem;
+}
+
+.hover\\\\:translate-x-56:hover {
+  --tw-translate-x: 14rem;
+}
+
+.hover\\\\:translate-x-60:hover {
+  --tw-translate-x: 15rem;
+}
+
+.hover\\\\:translate-x-64:hover {
+  --tw-translate-x: 16rem;
+}
+
+.hover\\\\:translate-x-72:hover {
+  --tw-translate-x: 18rem;
+}
+
+.hover\\\\:translate-x-80:hover {
+  --tw-translate-x: 20rem;
+}
+
+.hover\\\\:translate-x-96:hover {
+  --tw-translate-x: 24rem;
+}
+
+.hover\\\\:translate-x-px:hover {
+  --tw-translate-x: 1px;
+}
+
+.hover\\\\:translate-x-0\\\\.5:hover {
+  --tw-translate-x: 0.125rem;
+}
+
+.hover\\\\:translate-x-1\\\\.5:hover {
+  --tw-translate-x: 0.375rem;
+}
+
+.hover\\\\:translate-x-2\\\\.5:hover {
+  --tw-translate-x: 0.625rem;
+}
+
+.hover\\\\:translate-x-3\\\\.5:hover {
+  --tw-translate-x: 0.875rem;
+}
+
+.hover\\\\:-translate-x-0:hover {
+  --tw-translate-x: 0px;
+}
+
+.hover\\\\:-translate-x-1:hover {
+  --tw-translate-x: -0.25rem;
+}
+
+.hover\\\\:-translate-x-2:hover {
+  --tw-translate-x: -0.5rem;
+}
+
+.hover\\\\:-translate-x-3:hover {
+  --tw-translate-x: -0.75rem;
+}
+
+.hover\\\\:-translate-x-4:hover {
+  --tw-translate-x: -1rem;
+}
+
+.hover\\\\:-translate-x-5:hover {
+  --tw-translate-x: -1.25rem;
+}
+
+.hover\\\\:-translate-x-6:hover {
+  --tw-translate-x: -1.5rem;
+}
+
+.hover\\\\:-translate-x-7:hover {
+  --tw-translate-x: -1.75rem;
+}
+
+.hover\\\\:-translate-x-8:hover {
+  --tw-translate-x: -2rem;
+}
+
+.hover\\\\:-translate-x-9:hover {
+  --tw-translate-x: -2.25rem;
+}
+
+.hover\\\\:-translate-x-10:hover {
+  --tw-translate-x: -2.5rem;
+}
+
+.hover\\\\:-translate-x-11:hover {
+  --tw-translate-x: -2.75rem;
+}
+
+.hover\\\\:-translate-x-12:hover {
+  --tw-translate-x: -3rem;
+}
+
+.hover\\\\:-translate-x-14:hover {
+  --tw-translate-x: -3.5rem;
+}
+
+.hover\\\\:-translate-x-16:hover {
+  --tw-translate-x: -4rem;
+}
+
+.hover\\\\:-translate-x-20:hover {
+  --tw-translate-x: -5rem;
+}
+
+.hover\\\\:-translate-x-24:hover {
+  --tw-translate-x: -6rem;
+}
+
+.hover\\\\:-translate-x-28:hover {
+  --tw-translate-x: -7rem;
+}
+
+.hover\\\\:-translate-x-32:hover {
+  --tw-translate-x: -8rem;
+}
+
+.hover\\\\:-translate-x-36:hover {
+  --tw-translate-x: -9rem;
+}
+
+.hover\\\\:-translate-x-40:hover {
+  --tw-translate-x: -10rem;
+}
+
+.hover\\\\:-translate-x-44:hover {
+  --tw-translate-x: -11rem;
+}
+
+.hover\\\\:-translate-x-48:hover {
+  --tw-translate-x: -12rem;
+}
+
+.hover\\\\:-translate-x-52:hover {
+  --tw-translate-x: -13rem;
+}
+
+.hover\\\\:-translate-x-56:hover {
+  --tw-translate-x: -14rem;
+}
+
+.hover\\\\:-translate-x-60:hover {
+  --tw-translate-x: -15rem;
+}
+
+.hover\\\\:-translate-x-64:hover {
+  --tw-translate-x: -16rem;
+}
+
+.hover\\\\:-translate-x-72:hover {
+  --tw-translate-x: -18rem;
+}
+
+.hover\\\\:-translate-x-80:hover {
+  --tw-translate-x: -20rem;
+}
+
+.hover\\\\:-translate-x-96:hover {
+  --tw-translate-x: -24rem;
+}
+
+.hover\\\\:-translate-x-px:hover {
+  --tw-translate-x: -1px;
+}
+
+.hover\\\\:-translate-x-0\\\\.5:hover {
+  --tw-translate-x: -0.125rem;
+}
+
+.hover\\\\:-translate-x-1\\\\.5:hover {
+  --tw-translate-x: -0.375rem;
+}
+
+.hover\\\\:-translate-x-2\\\\.5:hover {
+  --tw-translate-x: -0.625rem;
+}
+
+.hover\\\\:-translate-x-3\\\\.5:hover {
+  --tw-translate-x: -0.875rem;
+}
+
+.hover\\\\:translate-x-1\\\\/2:hover {
+  --tw-translate-x: 50%;
+}
+
+.hover\\\\:translate-x-1\\\\/3:hover {
+  --tw-translate-x: 33.333333%;
+}
+
+.hover\\\\:translate-x-2\\\\/3:hover {
+  --tw-translate-x: 66.666667%;
+}
+
+.hover\\\\:translate-x-1\\\\/4:hover {
+  --tw-translate-x: 25%;
+}
+
+.hover\\\\:translate-x-2\\\\/4:hover {
+  --tw-translate-x: 50%;
+}
+
+.hover\\\\:translate-x-3\\\\/4:hover {
+  --tw-translate-x: 75%;
+}
+
+.hover\\\\:translate-x-full:hover {
+  --tw-translate-x: 100%;
+}
+
+.hover\\\\:-translate-x-1\\\\/2:hover {
+  --tw-translate-x: -50%;
+}
+
+.hover\\\\:-translate-x-1\\\\/3:hover {
+  --tw-translate-x: -33.333333%;
+}
+
+.hover\\\\:-translate-x-2\\\\/3:hover {
+  --tw-translate-x: -66.666667%;
+}
+
+.hover\\\\:-translate-x-1\\\\/4:hover {
+  --tw-translate-x: -25%;
+}
+
+.hover\\\\:-translate-x-2\\\\/4:hover {
+  --tw-translate-x: -50%;
+}
+
+.hover\\\\:-translate-x-3\\\\/4:hover {
+  --tw-translate-x: -75%;
+}
+
+.hover\\\\:-translate-x-full:hover {
+  --tw-translate-x: -100%;
+}
+
+.hover\\\\:translate-y-0:hover {
+  --tw-translate-y: 0px;
+}
+
+.hover\\\\:translate-y-1:hover {
+  --tw-translate-y: 0.25rem;
+}
+
+.hover\\\\:translate-y-2:hover {
+  --tw-translate-y: 0.5rem;
+}
+
+.hover\\\\:translate-y-3:hover {
+  --tw-translate-y: 0.75rem;
+}
+
+.hover\\\\:translate-y-4:hover {
+  --tw-translate-y: 1rem;
+}
+
+.hover\\\\:translate-y-5:hover {
+  --tw-translate-y: 1.25rem;
+}
+
+.hover\\\\:translate-y-6:hover {
+  --tw-translate-y: 1.5rem;
+}
+
+.hover\\\\:translate-y-7:hover {
+  --tw-translate-y: 1.75rem;
+}
+
+.hover\\\\:translate-y-8:hover {
+  --tw-translate-y: 2rem;
+}
+
+.hover\\\\:translate-y-9:hover {
+  --tw-translate-y: 2.25rem;
+}
+
+.hover\\\\:translate-y-10:hover {
+  --tw-translate-y: 2.5rem;
+}
+
+.hover\\\\:translate-y-11:hover {
+  --tw-translate-y: 2.75rem;
+}
+
+.hover\\\\:translate-y-12:hover {
+  --tw-translate-y: 3rem;
+}
+
+.hover\\\\:translate-y-14:hover {
+  --tw-translate-y: 3.5rem;
+}
+
+.hover\\\\:translate-y-16:hover {
+  --tw-translate-y: 4rem;
+}
+
+.hover\\\\:translate-y-20:hover {
+  --tw-translate-y: 5rem;
+}
+
+.hover\\\\:translate-y-24:hover {
+  --tw-translate-y: 6rem;
+}
+
+.hover\\\\:translate-y-28:hover {
+  --tw-translate-y: 7rem;
+}
+
+.hover\\\\:translate-y-32:hover {
+  --tw-translate-y: 8rem;
+}
+
+.hover\\\\:translate-y-36:hover {
+  --tw-translate-y: 9rem;
+}
+
+.hover\\\\:translate-y-40:hover {
+  --tw-translate-y: 10rem;
+}
+
+.hover\\\\:translate-y-44:hover {
+  --tw-translate-y: 11rem;
+}
+
+.hover\\\\:translate-y-48:hover {
+  --tw-translate-y: 12rem;
+}
+
+.hover\\\\:translate-y-52:hover {
+  --tw-translate-y: 13rem;
+}
+
+.hover\\\\:translate-y-56:hover {
+  --tw-translate-y: 14rem;
+}
+
+.hover\\\\:translate-y-60:hover {
+  --tw-translate-y: 15rem;
+}
+
+.hover\\\\:translate-y-64:hover {
+  --tw-translate-y: 16rem;
+}
+
+.hover\\\\:translate-y-72:hover {
+  --tw-translate-y: 18rem;
+}
+
+.hover\\\\:translate-y-80:hover {
+  --tw-translate-y: 20rem;
+}
+
+.hover\\\\:translate-y-96:hover {
+  --tw-translate-y: 24rem;
+}
+
+.hover\\\\:translate-y-px:hover {
+  --tw-translate-y: 1px;
+}
+
+.hover\\\\:translate-y-0\\\\.5:hover {
+  --tw-translate-y: 0.125rem;
+}
+
+.hover\\\\:translate-y-1\\\\.5:hover {
+  --tw-translate-y: 0.375rem;
+}
+
+.hover\\\\:translate-y-2\\\\.5:hover {
+  --tw-translate-y: 0.625rem;
+}
+
+.hover\\\\:translate-y-3\\\\.5:hover {
+  --tw-translate-y: 0.875rem;
+}
+
+.hover\\\\:-translate-y-0:hover {
+  --tw-translate-y: 0px;
+}
+
+.hover\\\\:-translate-y-1:hover {
+  --tw-translate-y: -0.25rem;
+}
+
+.hover\\\\:-translate-y-2:hover {
+  --tw-translate-y: -0.5rem;
+}
+
+.hover\\\\:-translate-y-3:hover {
+  --tw-translate-y: -0.75rem;
+}
+
+.hover\\\\:-translate-y-4:hover {
+  --tw-translate-y: -1rem;
+}
+
+.hover\\\\:-translate-y-5:hover {
+  --tw-translate-y: -1.25rem;
+}
+
+.hover\\\\:-translate-y-6:hover {
+  --tw-translate-y: -1.5rem;
+}
+
+.hover\\\\:-translate-y-7:hover {
+  --tw-translate-y: -1.75rem;
+}
+
+.hover\\\\:-translate-y-8:hover {
+  --tw-translate-y: -2rem;
+}
+
+.hover\\\\:-translate-y-9:hover {
+  --tw-translate-y: -2.25rem;
+}
+
+.hover\\\\:-translate-y-10:hover {
+  --tw-translate-y: -2.5rem;
+}
+
+.hover\\\\:-translate-y-11:hover {
+  --tw-translate-y: -2.75rem;
+}
+
+.hover\\\\:-translate-y-12:hover {
+  --tw-translate-y: -3rem;
+}
+
+.hover\\\\:-translate-y-14:hover {
+  --tw-translate-y: -3.5rem;
+}
+
+.hover\\\\:-translate-y-16:hover {
+  --tw-translate-y: -4rem;
+}
+
+.hover\\\\:-translate-y-20:hover {
+  --tw-translate-y: -5rem;
+}
+
+.hover\\\\:-translate-y-24:hover {
+  --tw-translate-y: -6rem;
+}
+
+.hover\\\\:-translate-y-28:hover {
+  --tw-translate-y: -7rem;
+}
+
+.hover\\\\:-translate-y-32:hover {
+  --tw-translate-y: -8rem;
+}
+
+.hover\\\\:-translate-y-36:hover {
+  --tw-translate-y: -9rem;
+}
+
+.hover\\\\:-translate-y-40:hover {
+  --tw-translate-y: -10rem;
+}
+
+.hover\\\\:-translate-y-44:hover {
+  --tw-translate-y: -11rem;
+}
+
+.hover\\\\:-translate-y-48:hover {
+  --tw-translate-y: -12rem;
+}
+
+.hover\\\\:-translate-y-52:hover {
+  --tw-translate-y: -13rem;
+}
+
+.hover\\\\:-translate-y-56:hover {
+  --tw-translate-y: -14rem;
+}
+
+.hover\\\\:-translate-y-60:hover {
+  --tw-translate-y: -15rem;
+}
+
+.hover\\\\:-translate-y-64:hover {
+  --tw-translate-y: -16rem;
+}
+
+.hover\\\\:-translate-y-72:hover {
+  --tw-translate-y: -18rem;
+}
+
+.hover\\\\:-translate-y-80:hover {
+  --tw-translate-y: -20rem;
+}
+
+.hover\\\\:-translate-y-96:hover {
+  --tw-translate-y: -24rem;
+}
+
+.hover\\\\:-translate-y-px:hover {
+  --tw-translate-y: -1px;
+}
+
+.hover\\\\:-translate-y-0\\\\.5:hover {
+  --tw-translate-y: -0.125rem;
+}
+
+.hover\\\\:-translate-y-1\\\\.5:hover {
+  --tw-translate-y: -0.375rem;
+}
+
+.hover\\\\:-translate-y-2\\\\.5:hover {
+  --tw-translate-y: -0.625rem;
+}
+
+.hover\\\\:-translate-y-3\\\\.5:hover {
+  --tw-translate-y: -0.875rem;
+}
+
+.hover\\\\:translate-y-1\\\\/2:hover {
+  --tw-translate-y: 50%;
+}
+
+.hover\\\\:translate-y-1\\\\/3:hover {
+  --tw-translate-y: 33.333333%;
+}
+
+.hover\\\\:translate-y-2\\\\/3:hover {
+  --tw-translate-y: 66.666667%;
+}
+
+.hover\\\\:translate-y-1\\\\/4:hover {
+  --tw-translate-y: 25%;
+}
+
+.hover\\\\:translate-y-2\\\\/4:hover {
+  --tw-translate-y: 50%;
+}
+
+.hover\\\\:translate-y-3\\\\/4:hover {
+  --tw-translate-y: 75%;
+}
+
+.hover\\\\:translate-y-full:hover {
+  --tw-translate-y: 100%;
+}
+
+.hover\\\\:-translate-y-1\\\\/2:hover {
+  --tw-translate-y: -50%;
+}
+
+.hover\\\\:-translate-y-1\\\\/3:hover {
+  --tw-translate-y: -33.333333%;
+}
+
+.hover\\\\:-translate-y-2\\\\/3:hover {
+  --tw-translate-y: -66.666667%;
+}
+
+.hover\\\\:-translate-y-1\\\\/4:hover {
+  --tw-translate-y: -25%;
+}
+
+.hover\\\\:-translate-y-2\\\\/4:hover {
+  --tw-translate-y: -50%;
+}
+
+.hover\\\\:-translate-y-3\\\\/4:hover {
+  --tw-translate-y: -75%;
+}
+
+.hover\\\\:-translate-y-full:hover {
+  --tw-translate-y: -100%;
+}
+
+.focus\\\\:translate-x-0:focus {
+  --tw-translate-x: 0px;
+}
+
+.focus\\\\:translate-x-1:focus {
+  --tw-translate-x: 0.25rem;
+}
+
+.focus\\\\:translate-x-2:focus {
+  --tw-translate-x: 0.5rem;
+}
+
+.focus\\\\:translate-x-3:focus {
+  --tw-translate-x: 0.75rem;
+}
+
+.focus\\\\:translate-x-4:focus {
+  --tw-translate-x: 1rem;
+}
+
+.focus\\\\:translate-x-5:focus {
+  --tw-translate-x: 1.25rem;
+}
+
+.focus\\\\:translate-x-6:focus {
+  --tw-translate-x: 1.5rem;
+}
+
+.focus\\\\:translate-x-7:focus {
+  --tw-translate-x: 1.75rem;
+}
+
+.focus\\\\:translate-x-8:focus {
+  --tw-translate-x: 2rem;
+}
+
+.focus\\\\:translate-x-9:focus {
+  --tw-translate-x: 2.25rem;
+}
+
+.focus\\\\:translate-x-10:focus {
+  --tw-translate-x: 2.5rem;
+}
+
+.focus\\\\:translate-x-11:focus {
+  --tw-translate-x: 2.75rem;
+}
+
+.focus\\\\:translate-x-12:focus {
+  --tw-translate-x: 3rem;
+}
+
+.focus\\\\:translate-x-14:focus {
+  --tw-translate-x: 3.5rem;
+}
+
+.focus\\\\:translate-x-16:focus {
+  --tw-translate-x: 4rem;
+}
+
+.focus\\\\:translate-x-20:focus {
+  --tw-translate-x: 5rem;
+}
+
+.focus\\\\:translate-x-24:focus {
+  --tw-translate-x: 6rem;
+}
+
+.focus\\\\:translate-x-28:focus {
+  --tw-translate-x: 7rem;
+}
+
+.focus\\\\:translate-x-32:focus {
+  --tw-translate-x: 8rem;
+}
+
+.focus\\\\:translate-x-36:focus {
+  --tw-translate-x: 9rem;
+}
+
+.focus\\\\:translate-x-40:focus {
+  --tw-translate-x: 10rem;
+}
+
+.focus\\\\:translate-x-44:focus {
+  --tw-translate-x: 11rem;
+}
+
+.focus\\\\:translate-x-48:focus {
+  --tw-translate-x: 12rem;
+}
+
+.focus\\\\:translate-x-52:focus {
+  --tw-translate-x: 13rem;
+}
+
+.focus\\\\:translate-x-56:focus {
+  --tw-translate-x: 14rem;
+}
+
+.focus\\\\:translate-x-60:focus {
+  --tw-translate-x: 15rem;
+}
+
+.focus\\\\:translate-x-64:focus {
+  --tw-translate-x: 16rem;
+}
+
+.focus\\\\:translate-x-72:focus {
+  --tw-translate-x: 18rem;
+}
+
+.focus\\\\:translate-x-80:focus {
+  --tw-translate-x: 20rem;
+}
+
+.focus\\\\:translate-x-96:focus {
+  --tw-translate-x: 24rem;
+}
+
+.focus\\\\:translate-x-px:focus {
+  --tw-translate-x: 1px;
+}
+
+.focus\\\\:translate-x-0\\\\.5:focus {
+  --tw-translate-x: 0.125rem;
+}
+
+.focus\\\\:translate-x-1\\\\.5:focus {
+  --tw-translate-x: 0.375rem;
+}
+
+.focus\\\\:translate-x-2\\\\.5:focus {
+  --tw-translate-x: 0.625rem;
+}
+
+.focus\\\\:translate-x-3\\\\.5:focus {
+  --tw-translate-x: 0.875rem;
+}
+
+.focus\\\\:-translate-x-0:focus {
+  --tw-translate-x: 0px;
+}
+
+.focus\\\\:-translate-x-1:focus {
+  --tw-translate-x: -0.25rem;
+}
+
+.focus\\\\:-translate-x-2:focus {
+  --tw-translate-x: -0.5rem;
+}
+
+.focus\\\\:-translate-x-3:focus {
+  --tw-translate-x: -0.75rem;
+}
+
+.focus\\\\:-translate-x-4:focus {
+  --tw-translate-x: -1rem;
+}
+
+.focus\\\\:-translate-x-5:focus {
+  --tw-translate-x: -1.25rem;
+}
+
+.focus\\\\:-translate-x-6:focus {
+  --tw-translate-x: -1.5rem;
+}
+
+.focus\\\\:-translate-x-7:focus {
+  --tw-translate-x: -1.75rem;
+}
+
+.focus\\\\:-translate-x-8:focus {
+  --tw-translate-x: -2rem;
+}
+
+.focus\\\\:-translate-x-9:focus {
+  --tw-translate-x: -2.25rem;
+}
+
+.focus\\\\:-translate-x-10:focus {
+  --tw-translate-x: -2.5rem;
+}
+
+.focus\\\\:-translate-x-11:focus {
+  --tw-translate-x: -2.75rem;
+}
+
+.focus\\\\:-translate-x-12:focus {
+  --tw-translate-x: -3rem;
+}
+
+.focus\\\\:-translate-x-14:focus {
+  --tw-translate-x: -3.5rem;
+}
+
+.focus\\\\:-translate-x-16:focus {
+  --tw-translate-x: -4rem;
+}
+
+.focus\\\\:-translate-x-20:focus {
+  --tw-translate-x: -5rem;
+}
+
+.focus\\\\:-translate-x-24:focus {
+  --tw-translate-x: -6rem;
+}
+
+.focus\\\\:-translate-x-28:focus {
+  --tw-translate-x: -7rem;
+}
+
+.focus\\\\:-translate-x-32:focus {
+  --tw-translate-x: -8rem;
+}
+
+.focus\\\\:-translate-x-36:focus {
+  --tw-translate-x: -9rem;
+}
+
+.focus\\\\:-translate-x-40:focus {
+  --tw-translate-x: -10rem;
+}
+
+.focus\\\\:-translate-x-44:focus {
+  --tw-translate-x: -11rem;
+}
+
+.focus\\\\:-translate-x-48:focus {
+  --tw-translate-x: -12rem;
+}
+
+.focus\\\\:-translate-x-52:focus {
+  --tw-translate-x: -13rem;
+}
+
+.focus\\\\:-translate-x-56:focus {
+  --tw-translate-x: -14rem;
+}
+
+.focus\\\\:-translate-x-60:focus {
+  --tw-translate-x: -15rem;
+}
+
+.focus\\\\:-translate-x-64:focus {
+  --tw-translate-x: -16rem;
+}
+
+.focus\\\\:-translate-x-72:focus {
+  --tw-translate-x: -18rem;
+}
+
+.focus\\\\:-translate-x-80:focus {
+  --tw-translate-x: -20rem;
+}
+
+.focus\\\\:-translate-x-96:focus {
+  --tw-translate-x: -24rem;
+}
+
+.focus\\\\:-translate-x-px:focus {
+  --tw-translate-x: -1px;
+}
+
+.focus\\\\:-translate-x-0\\\\.5:focus {
+  --tw-translate-x: -0.125rem;
+}
+
+.focus\\\\:-translate-x-1\\\\.5:focus {
+  --tw-translate-x: -0.375rem;
+}
+
+.focus\\\\:-translate-x-2\\\\.5:focus {
+  --tw-translate-x: -0.625rem;
+}
+
+.focus\\\\:-translate-x-3\\\\.5:focus {
+  --tw-translate-x: -0.875rem;
+}
+
+.focus\\\\:translate-x-1\\\\/2:focus {
+  --tw-translate-x: 50%;
+}
+
+.focus\\\\:translate-x-1\\\\/3:focus {
+  --tw-translate-x: 33.333333%;
+}
+
+.focus\\\\:translate-x-2\\\\/3:focus {
+  --tw-translate-x: 66.666667%;
+}
+
+.focus\\\\:translate-x-1\\\\/4:focus {
+  --tw-translate-x: 25%;
+}
+
+.focus\\\\:translate-x-2\\\\/4:focus {
+  --tw-translate-x: 50%;
+}
+
+.focus\\\\:translate-x-3\\\\/4:focus {
+  --tw-translate-x: 75%;
+}
+
+.focus\\\\:translate-x-full:focus {
+  --tw-translate-x: 100%;
+}
+
+.focus\\\\:-translate-x-1\\\\/2:focus {
+  --tw-translate-x: -50%;
+}
+
+.focus\\\\:-translate-x-1\\\\/3:focus {
+  --tw-translate-x: -33.333333%;
+}
+
+.focus\\\\:-translate-x-2\\\\/3:focus {
+  --tw-translate-x: -66.666667%;
+}
+
+.focus\\\\:-translate-x-1\\\\/4:focus {
+  --tw-translate-x: -25%;
+}
+
+.focus\\\\:-translate-x-2\\\\/4:focus {
+  --tw-translate-x: -50%;
+}
+
+.focus\\\\:-translate-x-3\\\\/4:focus {
+  --tw-translate-x: -75%;
+}
+
+.focus\\\\:-translate-x-full:focus {
+  --tw-translate-x: -100%;
+}
+
+.focus\\\\:translate-y-0:focus {
+  --tw-translate-y: 0px;
+}
+
+.focus\\\\:translate-y-1:focus {
+  --tw-translate-y: 0.25rem;
+}
+
+.focus\\\\:translate-y-2:focus {
+  --tw-translate-y: 0.5rem;
+}
+
+.focus\\\\:translate-y-3:focus {
+  --tw-translate-y: 0.75rem;
+}
+
+.focus\\\\:translate-y-4:focus {
+  --tw-translate-y: 1rem;
+}
+
+.focus\\\\:translate-y-5:focus {
+  --tw-translate-y: 1.25rem;
+}
+
+.focus\\\\:translate-y-6:focus {
+  --tw-translate-y: 1.5rem;
+}
+
+.focus\\\\:translate-y-7:focus {
+  --tw-translate-y: 1.75rem;
+}
+
+.focus\\\\:translate-y-8:focus {
+  --tw-translate-y: 2rem;
+}
+
+.focus\\\\:translate-y-9:focus {
+  --tw-translate-y: 2.25rem;
+}
+
+.focus\\\\:translate-y-10:focus {
+  --tw-translate-y: 2.5rem;
+}
+
+.focus\\\\:translate-y-11:focus {
+  --tw-translate-y: 2.75rem;
+}
+
+.focus\\\\:translate-y-12:focus {
+  --tw-translate-y: 3rem;
+}
+
+.focus\\\\:translate-y-14:focus {
+  --tw-translate-y: 3.5rem;
+}
+
+.focus\\\\:translate-y-16:focus {
+  --tw-translate-y: 4rem;
+}
+
+.focus\\\\:translate-y-20:focus {
+  --tw-translate-y: 5rem;
+}
+
+.focus\\\\:translate-y-24:focus {
+  --tw-translate-y: 6rem;
+}
+
+.focus\\\\:translate-y-28:focus {
+  --tw-translate-y: 7rem;
+}
+
+.focus\\\\:translate-y-32:focus {
+  --tw-translate-y: 8rem;
+}
+
+.focus\\\\:translate-y-36:focus {
+  --tw-translate-y: 9rem;
+}
+
+.focus\\\\:translate-y-40:focus {
+  --tw-translate-y: 10rem;
+}
+
+.focus\\\\:translate-y-44:focus {
+  --tw-translate-y: 11rem;
+}
+
+.focus\\\\:translate-y-48:focus {
+  --tw-translate-y: 12rem;
+}
+
+.focus\\\\:translate-y-52:focus {
+  --tw-translate-y: 13rem;
+}
+
+.focus\\\\:translate-y-56:focus {
+  --tw-translate-y: 14rem;
+}
+
+.focus\\\\:translate-y-60:focus {
+  --tw-translate-y: 15rem;
+}
+
+.focus\\\\:translate-y-64:focus {
+  --tw-translate-y: 16rem;
+}
+
+.focus\\\\:translate-y-72:focus {
+  --tw-translate-y: 18rem;
+}
+
+.focus\\\\:translate-y-80:focus {
+  --tw-translate-y: 20rem;
+}
+
+.focus\\\\:translate-y-96:focus {
+  --tw-translate-y: 24rem;
+}
+
+.focus\\\\:translate-y-px:focus {
+  --tw-translate-y: 1px;
+}
+
+.focus\\\\:translate-y-0\\\\.5:focus {
+  --tw-translate-y: 0.125rem;
+}
+
+.focus\\\\:translate-y-1\\\\.5:focus {
+  --tw-translate-y: 0.375rem;
+}
+
+.focus\\\\:translate-y-2\\\\.5:focus {
+  --tw-translate-y: 0.625rem;
+}
+
+.focus\\\\:translate-y-3\\\\.5:focus {
+  --tw-translate-y: 0.875rem;
+}
+
+.focus\\\\:-translate-y-0:focus {
+  --tw-translate-y: 0px;
+}
+
+.focus\\\\:-translate-y-1:focus {
+  --tw-translate-y: -0.25rem;
+}
+
+.focus\\\\:-translate-y-2:focus {
+  --tw-translate-y: -0.5rem;
+}
+
+.focus\\\\:-translate-y-3:focus {
+  --tw-translate-y: -0.75rem;
+}
+
+.focus\\\\:-translate-y-4:focus {
+  --tw-translate-y: -1rem;
+}
+
+.focus\\\\:-translate-y-5:focus {
+  --tw-translate-y: -1.25rem;
+}
+
+.focus\\\\:-translate-y-6:focus {
+  --tw-translate-y: -1.5rem;
+}
+
+.focus\\\\:-translate-y-7:focus {
+  --tw-translate-y: -1.75rem;
+}
+
+.focus\\\\:-translate-y-8:focus {
+  --tw-translate-y: -2rem;
+}
+
+.focus\\\\:-translate-y-9:focus {
+  --tw-translate-y: -2.25rem;
+}
+
+.focus\\\\:-translate-y-10:focus {
+  --tw-translate-y: -2.5rem;
+}
+
+.focus\\\\:-translate-y-11:focus {
+  --tw-translate-y: -2.75rem;
+}
+
+.focus\\\\:-translate-y-12:focus {
+  --tw-translate-y: -3rem;
+}
+
+.focus\\\\:-translate-y-14:focus {
+  --tw-translate-y: -3.5rem;
+}
+
+.focus\\\\:-translate-y-16:focus {
+  --tw-translate-y: -4rem;
+}
+
+.focus\\\\:-translate-y-20:focus {
+  --tw-translate-y: -5rem;
+}
+
+.focus\\\\:-translate-y-24:focus {
+  --tw-translate-y: -6rem;
+}
+
+.focus\\\\:-translate-y-28:focus {
+  --tw-translate-y: -7rem;
+}
+
+.focus\\\\:-translate-y-32:focus {
+  --tw-translate-y: -8rem;
+}
+
+.focus\\\\:-translate-y-36:focus {
+  --tw-translate-y: -9rem;
+}
+
+.focus\\\\:-translate-y-40:focus {
+  --tw-translate-y: -10rem;
+}
+
+.focus\\\\:-translate-y-44:focus {
+  --tw-translate-y: -11rem;
+}
+
+.focus\\\\:-translate-y-48:focus {
+  --tw-translate-y: -12rem;
+}
+
+.focus\\\\:-translate-y-52:focus {
+  --tw-translate-y: -13rem;
+}
+
+.focus\\\\:-translate-y-56:focus {
+  --tw-translate-y: -14rem;
+}
+
+.focus\\\\:-translate-y-60:focus {
+  --tw-translate-y: -15rem;
+}
+
+.focus\\\\:-translate-y-64:focus {
+  --tw-translate-y: -16rem;
+}
+
+.focus\\\\:-translate-y-72:focus {
+  --tw-translate-y: -18rem;
+}
+
+.focus\\\\:-translate-y-80:focus {
+  --tw-translate-y: -20rem;
+}
+
+.focus\\\\:-translate-y-96:focus {
+  --tw-translate-y: -24rem;
+}
+
+.focus\\\\:-translate-y-px:focus {
+  --tw-translate-y: -1px;
+}
+
+.focus\\\\:-translate-y-0\\\\.5:focus {
+  --tw-translate-y: -0.125rem;
+}
+
+.focus\\\\:-translate-y-1\\\\.5:focus {
+  --tw-translate-y: -0.375rem;
+}
+
+.focus\\\\:-translate-y-2\\\\.5:focus {
+  --tw-translate-y: -0.625rem;
+}
+
+.focus\\\\:-translate-y-3\\\\.5:focus {
+  --tw-translate-y: -0.875rem;
+}
+
+.focus\\\\:translate-y-1\\\\/2:focus {
+  --tw-translate-y: 50%;
+}
+
+.focus\\\\:translate-y-1\\\\/3:focus {
+  --tw-translate-y: 33.333333%;
+}
+
+.focus\\\\:translate-y-2\\\\/3:focus {
+  --tw-translate-y: 66.666667%;
+}
+
+.focus\\\\:translate-y-1\\\\/4:focus {
+  --tw-translate-y: 25%;
+}
+
+.focus\\\\:translate-y-2\\\\/4:focus {
+  --tw-translate-y: 50%;
+}
+
+.focus\\\\:translate-y-3\\\\/4:focus {
+  --tw-translate-y: 75%;
+}
+
+.focus\\\\:translate-y-full:focus {
+  --tw-translate-y: 100%;
+}
+
+.focus\\\\:-translate-y-1\\\\/2:focus {
+  --tw-translate-y: -50%;
+}
+
+.focus\\\\:-translate-y-1\\\\/3:focus {
+  --tw-translate-y: -33.333333%;
+}
+
+.focus\\\\:-translate-y-2\\\\/3:focus {
+  --tw-translate-y: -66.666667%;
+}
+
+.focus\\\\:-translate-y-1\\\\/4:focus {
+  --tw-translate-y: -25%;
+}
+
+.focus\\\\:-translate-y-2\\\\/4:focus {
+  --tw-translate-y: -50%;
+}
+
+.focus\\\\:-translate-y-3\\\\/4:focus {
+  --tw-translate-y: -75%;
+}
+
+.focus\\\\:-translate-y-full:focus {
+  --tw-translate-y: -100%;
+}
+
+.rotate-0 {
+  --tw-rotate: 0deg;
+}
+
+.rotate-1 {
+  --tw-rotate: 1deg;
+}
+
+.rotate-2 {
+  --tw-rotate: 2deg;
+}
+
+.rotate-3 {
+  --tw-rotate: 3deg;
+}
+
+.rotate-6 {
+  --tw-rotate: 6deg;
+}
+
+.rotate-12 {
+  --tw-rotate: 12deg;
+}
+
+.rotate-45 {
+  --tw-rotate: 45deg;
+}
+
+.rotate-90 {
+  --tw-rotate: 90deg;
+}
+
+.rotate-180 {
+  --tw-rotate: 180deg;
+}
+
+.-rotate-180 {
+  --tw-rotate: -180deg;
+}
+
+.-rotate-90 {
+  --tw-rotate: -90deg;
+}
+
+.-rotate-45 {
+  --tw-rotate: -45deg;
+}
+
+.-rotate-12 {
+  --tw-rotate: -12deg;
+}
+
+.-rotate-6 {
+  --tw-rotate: -6deg;
+}
+
+.-rotate-3 {
+  --tw-rotate: -3deg;
+}
+
+.-rotate-2 {
+  --tw-rotate: -2deg;
+}
+
+.-rotate-1 {
+  --tw-rotate: -1deg;
+}
+
+.-rotate-5 {
+  --tw-rotate: -5deg;
+}
+
+.active\\\\:rotate-0:active {
+  --tw-rotate: 0deg;
+}
+
+.active\\\\:rotate-1:active {
+  --tw-rotate: 1deg;
+}
+
+.active\\\\:rotate-2:active {
+  --tw-rotate: 2deg;
+}
+
+.active\\\\:rotate-3:active {
+  --tw-rotate: 3deg;
+}
+
+.active\\\\:rotate-6:active {
+  --tw-rotate: 6deg;
+}
+
+.active\\\\:rotate-12:active {
+  --tw-rotate: 12deg;
+}
+
+.active\\\\:rotate-45:active {
+  --tw-rotate: 45deg;
+}
+
+.active\\\\:rotate-90:active {
+  --tw-rotate: 90deg;
+}
+
+.active\\\\:rotate-180:active {
+  --tw-rotate: 180deg;
+}
+
+.active\\\\:-rotate-180:active {
+  --tw-rotate: -180deg;
+}
+
+.active\\\\:-rotate-90:active {
+  --tw-rotate: -90deg;
+}
+
+.active\\\\:-rotate-45:active {
+  --tw-rotate: -45deg;
+}
+
+.active\\\\:-rotate-12:active {
+  --tw-rotate: -12deg;
+}
+
+.active\\\\:-rotate-6:active {
+  --tw-rotate: -6deg;
+}
+
+.active\\\\:-rotate-3:active {
+  --tw-rotate: -3deg;
+}
+
+.active\\\\:-rotate-2:active {
+  --tw-rotate: -2deg;
+}
+
+.active\\\\:-rotate-1:active {
+  --tw-rotate: -1deg;
+}
+
+.active\\\\:-rotate-5:active {
+  --tw-rotate: -5deg;
+}
+
+.skew-x-0 {
+  --tw-skew-x: 0deg;
+}
+
+.skew-x-1 {
+  --tw-skew-x: 1deg;
+}
+
+.skew-x-2 {
+  --tw-skew-x: 2deg;
+}
+
+.skew-x-3 {
+  --tw-skew-x: 3deg;
+}
+
+.skew-x-6 {
+  --tw-skew-x: 6deg;
+}
+
+.skew-x-12 {
+  --tw-skew-x: 12deg;
+}
+
+.-skew-x-12 {
+  --tw-skew-x: -12deg;
+}
+
+.-skew-x-6 {
+  --tw-skew-x: -6deg;
+}
+
+.-skew-x-3 {
+  --tw-skew-x: -3deg;
+}
+
+.-skew-x-2 {
+  --tw-skew-x: -2deg;
+}
+
+.-skew-x-1 {
+  --tw-skew-x: -1deg;
+}
+
+.skew-y-0 {
+  --tw-skew-y: 0deg;
+}
+
+.skew-y-1 {
+  --tw-skew-y: 1deg;
+}
+
+.skew-y-2 {
+  --tw-skew-y: 2deg;
+}
+
+.skew-y-3 {
+  --tw-skew-y: 3deg;
+}
+
+.skew-y-6 {
+  --tw-skew-y: 6deg;
+}
+
+.skew-y-12 {
+  --tw-skew-y: 12deg;
+}
+
+.-skew-y-12 {
+  --tw-skew-y: -12deg;
+}
+
+.-skew-y-6 {
+  --tw-skew-y: -6deg;
+}
+
+.-skew-y-3 {
+  --tw-skew-y: -3deg;
+}
+
+.-skew-y-2 {
+  --tw-skew-y: -2deg;
+}
+
+.-skew-y-1 {
+  --tw-skew-y: -1deg;
+}
+
+.hover\\\\:skew-x-0:hover {
+  --tw-skew-x: 0deg;
+}
+
+.hover\\\\:skew-x-1:hover {
+  --tw-skew-x: 1deg;
+}
+
+.hover\\\\:skew-x-2:hover {
+  --tw-skew-x: 2deg;
+}
+
+.hover\\\\:skew-x-3:hover {
+  --tw-skew-x: 3deg;
+}
+
+.hover\\\\:skew-x-6:hover {
+  --tw-skew-x: 6deg;
+}
+
+.hover\\\\:skew-x-12:hover {
+  --tw-skew-x: 12deg;
+}
+
+.hover\\\\:-skew-x-12:hover {
+  --tw-skew-x: -12deg;
+}
+
+.hover\\\\:-skew-x-6:hover {
+  --tw-skew-x: -6deg;
+}
+
+.hover\\\\:-skew-x-3:hover {
+  --tw-skew-x: -3deg;
+}
+
+.hover\\\\:-skew-x-2:hover {
+  --tw-skew-x: -2deg;
+}
+
+.hover\\\\:-skew-x-1:hover {
+  --tw-skew-x: -1deg;
+}
+
+.hover\\\\:skew-y-0:hover {
+  --tw-skew-y: 0deg;
+}
+
+.hover\\\\:skew-y-1:hover {
+  --tw-skew-y: 1deg;
+}
+
+.hover\\\\:skew-y-2:hover {
+  --tw-skew-y: 2deg;
+}
+
+.hover\\\\:skew-y-3:hover {
+  --tw-skew-y: 3deg;
+}
+
+.hover\\\\:skew-y-6:hover {
+  --tw-skew-y: 6deg;
+}
+
+.hover\\\\:skew-y-12:hover {
+  --tw-skew-y: 12deg;
+}
+
+.hover\\\\:-skew-y-12:hover {
+  --tw-skew-y: -12deg;
+}
+
+.hover\\\\:-skew-y-6:hover {
+  --tw-skew-y: -6deg;
+}
+
+.hover\\\\:-skew-y-3:hover {
+  --tw-skew-y: -3deg;
+}
+
+.hover\\\\:-skew-y-2:hover {
+  --tw-skew-y: -2deg;
+}
+
+.hover\\\\:-skew-y-1:hover {
+  --tw-skew-y: -1deg;
+}
+
+.focus\\\\:skew-x-0:focus {
+  --tw-skew-x: 0deg;
+}
+
+.focus\\\\:skew-x-1:focus {
+  --tw-skew-x: 1deg;
+}
+
+.focus\\\\:skew-x-2:focus {
+  --tw-skew-x: 2deg;
+}
+
+.focus\\\\:skew-x-3:focus {
+  --tw-skew-x: 3deg;
+}
+
+.focus\\\\:skew-x-6:focus {
+  --tw-skew-x: 6deg;
+}
+
+.focus\\\\:skew-x-12:focus {
+  --tw-skew-x: 12deg;
+}
+
+.focus\\\\:-skew-x-12:focus {
+  --tw-skew-x: -12deg;
+}
+
+.focus\\\\:-skew-x-6:focus {
+  --tw-skew-x: -6deg;
+}
+
+.focus\\\\:-skew-x-3:focus {
+  --tw-skew-x: -3deg;
+}
+
+.focus\\\\:-skew-x-2:focus {
+  --tw-skew-x: -2deg;
+}
+
+.focus\\\\:-skew-x-1:focus {
+  --tw-skew-x: -1deg;
+}
+
+.focus\\\\:skew-y-0:focus {
+  --tw-skew-y: 0deg;
+}
+
+.focus\\\\:skew-y-1:focus {
+  --tw-skew-y: 1deg;
+}
+
+.focus\\\\:skew-y-2:focus {
+  --tw-skew-y: 2deg;
+}
+
+.focus\\\\:skew-y-3:focus {
+  --tw-skew-y: 3deg;
+}
+
+.focus\\\\:skew-y-6:focus {
+  --tw-skew-y: 6deg;
+}
+
+.focus\\\\:skew-y-12:focus {
+  --tw-skew-y: 12deg;
+}
+
+.focus\\\\:-skew-y-12:focus {
+  --tw-skew-y: -12deg;
+}
+
+.focus\\\\:-skew-y-6:focus {
+  --tw-skew-y: -6deg;
+}
+
+.focus\\\\:-skew-y-3:focus {
+  --tw-skew-y: -3deg;
+}
+
+.focus\\\\:-skew-y-2:focus {
+  --tw-skew-y: -2deg;
+}
+
+.focus\\\\:-skew-y-1:focus {
+  --tw-skew-y: -1deg;
+}
+
+.scale-0 {
+  --tw-scale-x: 0;
+  --tw-scale-y: 0;
+}
+
+.scale-50 {
+  --tw-scale-x: .5;
+  --tw-scale-y: .5;
+}
+
+.scale-75 {
+  --tw-scale-x: .75;
+  --tw-scale-y: .75;
+}
+
+.scale-90 {
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+}
+
+.scale-95 {
+  --tw-scale-x: .95;
+  --tw-scale-y: .95;
+}
+
+.scale-100 {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+}
+
+.scale-105 {
+  --tw-scale-x: 1.05;
+  --tw-scale-y: 1.05;
+}
+
+.scale-110 {
+  --tw-scale-x: 1.1;
+  --tw-scale-y: 1.1;
+}
+
+.scale-125 {
+  --tw-scale-x: 1.25;
+  --tw-scale-y: 1.25;
+}
+
+.scale-150 {
+  --tw-scale-x: 1.5;
+  --tw-scale-y: 1.5;
+}
+
+.hover\\\\:scale-0:hover {
+  --tw-scale-x: 0;
+  --tw-scale-y: 0;
+}
+
+.hover\\\\:scale-50:hover {
+  --tw-scale-x: .5;
+  --tw-scale-y: .5;
+}
+
+.hover\\\\:scale-75:hover {
+  --tw-scale-x: .75;
+  --tw-scale-y: .75;
+}
+
+.hover\\\\:scale-90:hover {
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+}
+
+.hover\\\\:scale-95:hover {
+  --tw-scale-x: .95;
+  --tw-scale-y: .95;
+}
+
+.hover\\\\:scale-100:hover {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+}
+
+.hover\\\\:scale-105:hover {
+  --tw-scale-x: 1.05;
+  --tw-scale-y: 1.05;
+}
+
+.hover\\\\:scale-110:hover {
+  --tw-scale-x: 1.1;
+  --tw-scale-y: 1.1;
+}
+
+.hover\\\\:scale-125:hover {
+  --tw-scale-x: 1.25;
+  --tw-scale-y: 1.25;
+}
+
+.hover\\\\:scale-150:hover {
+  --tw-scale-x: 1.5;
+  --tw-scale-y: 1.5;
+}
+
+.focus\\\\:scale-0:focus {
+  --tw-scale-x: 0;
+  --tw-scale-y: 0;
+}
+
+.focus\\\\:scale-50:focus {
+  --tw-scale-x: .5;
+  --tw-scale-y: .5;
+}
+
+.focus\\\\:scale-75:focus {
+  --tw-scale-x: .75;
+  --tw-scale-y: .75;
+}
+
+.focus\\\\:scale-90:focus {
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+}
+
+.focus\\\\:scale-95:focus {
+  --tw-scale-x: .95;
+  --tw-scale-y: .95;
+}
+
+.focus\\\\:scale-100:focus {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+}
+
+.focus\\\\:scale-105:focus {
+  --tw-scale-x: 1.05;
+  --tw-scale-y: 1.05;
+}
+
+.focus\\\\:scale-110:focus {
+  --tw-scale-x: 1.1;
+  --tw-scale-y: 1.1;
+}
+
+.focus\\\\:scale-125:focus {
+  --tw-scale-x: 1.25;
+  --tw-scale-y: 1.25;
+}
+
+.focus\\\\:scale-150:focus {
+  --tw-scale-x: 1.5;
+  --tw-scale-y: 1.5;
+}
+
+.active\\\\:scale-0:active {
+  --tw-scale-x: 0;
+  --tw-scale-y: 0;
+}
+
+.active\\\\:scale-50:active {
+  --tw-scale-x: .5;
+  --tw-scale-y: .5;
+}
+
+.active\\\\:scale-75:active {
+  --tw-scale-x: .75;
+  --tw-scale-y: .75;
+}
+
+.active\\\\:scale-90:active {
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+}
+
+.active\\\\:scale-95:active {
+  --tw-scale-x: .95;
+  --tw-scale-y: .95;
+}
+
+.active\\\\:scale-100:active {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+}
+
+.active\\\\:scale-105:active {
+  --tw-scale-x: 1.05;
+  --tw-scale-y: 1.05;
+}
+
+.active\\\\:scale-110:active {
+  --tw-scale-x: 1.1;
+  --tw-scale-y: 1.1;
+}
+
+.active\\\\:scale-125:active {
+  --tw-scale-x: 1.25;
+  --tw-scale-y: 1.25;
+}
+
+.active\\\\:scale-150:active {
+  --tw-scale-x: 1.5;
+  --tw-scale-y: 1.5;
+}
+
+.scale-x-0 {
+  --tw-scale-x: 0;
+}
+
+.scale-x-50 {
+  --tw-scale-x: .5;
+}
+
+.scale-x-75 {
+  --tw-scale-x: .75;
+}
+
+.scale-x-90 {
+  --tw-scale-x: .9;
+}
+
+.scale-x-95 {
+  --tw-scale-x: .95;
+}
+
+.scale-x-100 {
+  --tw-scale-x: 1;
+}
+
+.scale-x-105 {
+  --tw-scale-x: 1.05;
+}
+
+.scale-x-110 {
+  --tw-scale-x: 1.1;
+}
+
+.scale-x-125 {
+  --tw-scale-x: 1.25;
+}
+
+.scale-x-150 {
+  --tw-scale-x: 1.5;
+}
+
+.scale-y-0 {
+  --tw-scale-y: 0;
+}
+
+.scale-y-50 {
+  --tw-scale-y: .5;
+}
+
+.scale-y-75 {
+  --tw-scale-y: .75;
+}
+
+.scale-y-90 {
+  --tw-scale-y: .9;
+}
+
+.scale-y-95 {
+  --tw-scale-y: .95;
+}
+
+.scale-y-100 {
+  --tw-scale-y: 1;
+}
+
+.scale-y-105 {
+  --tw-scale-y: 1.05;
+}
+
+.scale-y-110 {
+  --tw-scale-y: 1.1;
+}
+
+.scale-y-125 {
+  --tw-scale-y: 1.25;
+}
+
+.scale-y-150 {
+  --tw-scale-y: 1.5;
+}
+
+.hover\\\\:scale-x-0:hover {
+  --tw-scale-x: 0;
+}
+
+.hover\\\\:scale-x-50:hover {
+  --tw-scale-x: .5;
+}
+
+.hover\\\\:scale-x-75:hover {
+  --tw-scale-x: .75;
+}
+
+.hover\\\\:scale-x-90:hover {
+  --tw-scale-x: .9;
+}
+
+.hover\\\\:scale-x-95:hover {
+  --tw-scale-x: .95;
+}
+
+.hover\\\\:scale-x-100:hover {
+  --tw-scale-x: 1;
+}
+
+.hover\\\\:scale-x-105:hover {
+  --tw-scale-x: 1.05;
+}
+
+.hover\\\\:scale-x-110:hover {
+  --tw-scale-x: 1.1;
+}
+
+.hover\\\\:scale-x-125:hover {
+  --tw-scale-x: 1.25;
+}
+
+.hover\\\\:scale-x-150:hover {
+  --tw-scale-x: 1.5;
+}
+
+.hover\\\\:scale-y-0:hover {
+  --tw-scale-y: 0;
+}
+
+.hover\\\\:scale-y-50:hover {
+  --tw-scale-y: .5;
+}
+
+.hover\\\\:scale-y-75:hover {
+  --tw-scale-y: .75;
+}
+
+.hover\\\\:scale-y-90:hover {
+  --tw-scale-y: .9;
+}
+
+.hover\\\\:scale-y-95:hover {
+  --tw-scale-y: .95;
+}
+
+.hover\\\\:scale-y-100:hover {
+  --tw-scale-y: 1;
+}
+
+.hover\\\\:scale-y-105:hover {
+  --tw-scale-y: 1.05;
+}
+
+.hover\\\\:scale-y-110:hover {
+  --tw-scale-y: 1.1;
+}
+
+.hover\\\\:scale-y-125:hover {
+  --tw-scale-y: 1.25;
+}
+
+.hover\\\\:scale-y-150:hover {
+  --tw-scale-y: 1.5;
+}
+
+.focus\\\\:scale-x-0:focus {
+  --tw-scale-x: 0;
+}
+
+.focus\\\\:scale-x-50:focus {
+  --tw-scale-x: .5;
+}
+
+.focus\\\\:scale-x-75:focus {
+  --tw-scale-x: .75;
+}
+
+.focus\\\\:scale-x-90:focus {
+  --tw-scale-x: .9;
+}
+
+.focus\\\\:scale-x-95:focus {
+  --tw-scale-x: .95;
+}
+
+.focus\\\\:scale-x-100:focus {
+  --tw-scale-x: 1;
+}
+
+.focus\\\\:scale-x-105:focus {
+  --tw-scale-x: 1.05;
+}
+
+.focus\\\\:scale-x-110:focus {
+  --tw-scale-x: 1.1;
+}
+
+.focus\\\\:scale-x-125:focus {
+  --tw-scale-x: 1.25;
+}
+
+.focus\\\\:scale-x-150:focus {
+  --tw-scale-x: 1.5;
+}
+
+.focus\\\\:scale-y-0:focus {
+  --tw-scale-y: 0;
+}
+
+.focus\\\\:scale-y-50:focus {
+  --tw-scale-y: .5;
+}
+
+.focus\\\\:scale-y-75:focus {
+  --tw-scale-y: .75;
+}
+
+.focus\\\\:scale-y-90:focus {
+  --tw-scale-y: .9;
+}
+
+.focus\\\\:scale-y-95:focus {
+  --tw-scale-y: .95;
+}
+
+.focus\\\\:scale-y-100:focus {
+  --tw-scale-y: 1;
+}
+
+.focus\\\\:scale-y-105:focus {
+  --tw-scale-y: 1.05;
+}
+
+.focus\\\\:scale-y-110:focus {
+  --tw-scale-y: 1.1;
+}
+
+.focus\\\\:scale-y-125:focus {
+  --tw-scale-y: 1.25;
+}
+
+.focus\\\\:scale-y-150:focus {
+  --tw-scale-y: 1.5;
+}
+
+.active\\\\:scale-x-0:active {
+  --tw-scale-x: 0;
+}
+
+.active\\\\:scale-x-50:active {
+  --tw-scale-x: .5;
+}
+
+.active\\\\:scale-x-75:active {
+  --tw-scale-x: .75;
+}
+
+.active\\\\:scale-x-90:active {
+  --tw-scale-x: .9;
+}
+
+.active\\\\:scale-x-95:active {
+  --tw-scale-x: .95;
+}
+
+.active\\\\:scale-x-100:active {
+  --tw-scale-x: 1;
+}
+
+.active\\\\:scale-x-105:active {
+  --tw-scale-x: 1.05;
+}
+
+.active\\\\:scale-x-110:active {
+  --tw-scale-x: 1.1;
+}
+
+.active\\\\:scale-x-125:active {
+  --tw-scale-x: 1.25;
+}
+
+.active\\\\:scale-x-150:active {
+  --tw-scale-x: 1.5;
+}
+
+.active\\\\:scale-y-0:active {
+  --tw-scale-y: 0;
+}
+
+.active\\\\:scale-y-50:active {
+  --tw-scale-y: .5;
+}
+
+.active\\\\:scale-y-75:active {
+  --tw-scale-y: .75;
+}
+
+.active\\\\:scale-y-90:active {
+  --tw-scale-y: .9;
+}
+
+.active\\\\:scale-y-95:active {
+  --tw-scale-y: .95;
+}
+
+.active\\\\:scale-y-100:active {
+  --tw-scale-y: 1;
+}
+
+.active\\\\:scale-y-105:active {
+  --tw-scale-y: 1.05;
+}
+
+.active\\\\:scale-y-110:active {
+  --tw-scale-y: 1.1;
+}
+
+.active\\\\:scale-y-125:active {
+  --tw-scale-y: 1.25;
+}
+
+.active\\\\:scale-y-150:active {
+  --tw-scale-y: 1.5;
+}
+
+@-webkit-keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@-webkit-keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@-webkit-keyframes pulse {
+  50% {
+    opacity: .5;
+  }
+}
+
+@keyframes pulse {
+  50% {
+    opacity: .5;
+  }
+}
+
+@-webkit-keyframes bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8,0,1,1);
+            animation-timing-function: cubic-bezier(0.8,0,1,1);
+  }
+
+  50% {
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0,0,0.2,1);
+            animation-timing-function: cubic-bezier(0,0,0.2,1);
+  }
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8,0,1,1);
+            animation-timing-function: cubic-bezier(0.8,0,1,1);
+  }
+
+  50% {
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0,0,0.2,1);
+            animation-timing-function: cubic-bezier(0,0,0.2,1);
+  }
+}
+
+@-webkit-keyframes fade-in {
+  0% {
+    opacity: 0%;
+  }
+
+  100% {
+    opacity: 100%;
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0%;
+  }
+
+  100% {
+    opacity: 100%;
+  }
+}
+
+.animate-none {
+  -webkit-animation: none;
+          animation: none;
+}
+
+.animate-spin {
+  -webkit-animation: spin 1s linear infinite;
+          animation: spin 1s linear infinite;
+}
+
+.animate-ping {
+  -webkit-animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+          animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+.animate-pulse {
+  -webkit-animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+          animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.animate-bounce {
+  -webkit-animation: bounce 1s infinite;
+          animation: bounce 1s infinite;
+}
+
+.animate-fade-in {
+  -webkit-animation: fade-in .25s linear;
+          animation: fade-in .25s linear;
+}
+
+.cursor-auto {
+  cursor: auto;
+}
+
+.cursor-default {
+  cursor: default;
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.cursor-wait {
+  cursor: wait;
+}
+
+.cursor-text {
+  cursor: text;
+}
+
+.cursor-move {
+  cursor: move;
+}
+
+.cursor-help {
+  cursor: help;
+}
+
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
+
+.cursor-col-resize {
+  cursor: col-resize;
+}
+
+.disabled\\\\:cursor-auto:disabled {
+  cursor: auto;
+}
+
+.disabled\\\\:cursor-default:disabled {
+  cursor: default;
+}
+
+.disabled\\\\:cursor-pointer:disabled {
+  cursor: pointer;
+}
+
+.disabled\\\\:cursor-wait:disabled {
+  cursor: wait;
+}
+
+.disabled\\\\:cursor-text:disabled {
+  cursor: text;
+}
+
+.disabled\\\\:cursor-move:disabled {
+  cursor: move;
+}
+
+.disabled\\\\:cursor-help:disabled {
+  cursor: help;
+}
+
+.disabled\\\\:cursor-not-allowed:disabled {
+  cursor: not-allowed;
+}
+
+.disabled\\\\:cursor-col-resize:disabled {
+  cursor: col-resize;
+}
+
+.select-none {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+
+.select-text {
+  -webkit-user-select: text;
+     -moz-user-select: text;
+      -ms-user-select: text;
+          user-select: text;
+}
+
+.select-all {
+  -webkit-user-select: all;
+     -moz-user-select: all;
+          user-select: all;
+}
+
+.select-auto {
+  -webkit-user-select: auto;
+     -moz-user-select: auto;
+      -ms-user-select: auto;
+          user-select: auto;
+}
+
+.resize-none {
+  resize: none;
+}
+
+.resize-y {
+  resize: vertical;
+}
+
+.resize-x {
+  resize: horizontal;
+}
+
+.resize {
+  resize: both;
+}
+
+.list-inside {
+  list-style-position: inside;
+}
+
+.list-outside {
+  list-style-position: outside;
+}
+
+.list-none {
+  list-style-type: none;
+}
+
+.list-disc {
+  list-style-type: disc;
+}
+
+.list-decimal {
+  list-style-type: decimal;
+}
+
+.appearance-none {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+}
+
+.auto-cols-auto {
+  grid-auto-columns: auto;
+}
+
+.auto-cols-min {
+  grid-auto-columns: -webkit-min-content;
+  grid-auto-columns: min-content;
+}
+
+.auto-cols-max {
+  grid-auto-columns: -webkit-max-content;
+  grid-auto-columns: max-content;
+}
+
+.auto-cols-fr {
+  grid-auto-columns: minmax(0, 1fr);
+}
+
+.grid-flow-row {
+  grid-auto-flow: row;
+}
+
+.grid-flow-col {
+  grid-auto-flow: column;
+}
+
+.grid-flow-row-dense {
+  grid-auto-flow: row dense;
+}
+
+.grid-flow-col-dense {
+  grid-auto-flow: column dense;
+}
+
+.auto-rows-auto {
+  grid-auto-rows: auto;
+}
+
+.auto-rows-min {
+  grid-auto-rows: -webkit-min-content;
+  grid-auto-rows: min-content;
+}
+
+.auto-rows-max {
+  grid-auto-rows: -webkit-max-content;
+  grid-auto-rows: max-content;
+}
+
+.auto-rows-fr {
+  grid-auto-rows: minmax(0, 1fr);
+}
+
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid-cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.grid-cols-5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.grid-cols-6 {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.grid-cols-7 {
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.grid-cols-8 {
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+}
+
+.grid-cols-9 {
+  grid-template-columns: repeat(9, minmax(0, 1fr));
+}
+
+.grid-cols-10 {
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+}
+
+.grid-cols-11 {
+  grid-template-columns: repeat(11, minmax(0, 1fr));
+}
+
+.grid-cols-12 {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+
+.grid-cols-none {
+  grid-template-columns: none;
+}
+
+.grid-cols-centered-2\\\\/3 {
+  grid-template-columns: 2fr 8fr 2fr;
+}
+
+.grid-cols-auto-2 {
+  grid-template-columns: auto auto;
+}
+
+.grid-cols-max-content-4 {
+  grid-template-columns: repeat(4, minmax(-webkit-max-content, 1fr));
+  grid-template-columns: repeat(4, minmax(max-content, 1fr));
+}
+
+.grid-cols-max-content-6 {
+  grid-template-columns: repeat(6, minmax(-webkit-max-content, 1fr));
+  grid-template-columns: repeat(6, minmax(max-content, 1fr));
+}
+
+.grid-rows-1 {
+  grid-template-rows: repeat(1, minmax(0, 1fr));
+}
+
+.grid-rows-2 {
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+}
+
+.grid-rows-3 {
+  grid-template-rows: repeat(3, minmax(0, 1fr));
+}
+
+.grid-rows-4 {
+  grid-template-rows: repeat(4, minmax(0, 1fr));
+}
+
+.grid-rows-5 {
+  grid-template-rows: repeat(5, minmax(0, 1fr));
+}
+
+.grid-rows-6 {
+  grid-template-rows: repeat(6, minmax(0, 1fr));
+}
+
+.grid-rows-none {
+  grid-template-rows: none;
+}
+
+.flex-row {
+  flex-direction: row;
+}
+
+.flex-row-reverse {
+  flex-direction: row-reverse;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.flex-col-reverse {
+  flex-direction: column-reverse;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.flex-wrap-reverse {
+  flex-wrap: wrap-reverse;
+}
+
+.flex-nowrap {
+  flex-wrap: nowrap;
+}
+
+.place-content-center {
+  place-content: center;
+}
+
+.place-content-start {
+  place-content: start;
+}
+
+.place-content-end {
+  place-content: end;
+}
+
+.place-content-between {
+  place-content: space-between;
+}
+
+.place-content-around {
+  place-content: space-around;
+}
+
+.place-content-evenly {
+  place-content: space-evenly;
+}
+
+.place-content-stretch {
+  place-content: stretch;
+}
+
+.place-items-start {
+  place-items: start;
+}
+
+.place-items-end {
+  place-items: end;
+}
+
+.place-items-center {
+  place-items: center;
+}
+
+.place-items-stretch {
+  place-items: stretch;
+}
+
+.content-center {
+  align-content: center;
+}
+
+.content-start {
+  align-content: flex-start;
+}
+
+.content-end {
+  align-content: flex-end;
+}
+
+.content-between {
+  align-content: space-between;
+}
+
+.content-around {
+  align-content: space-around;
+}
+
+.content-evenly {
+  align-content: space-evenly;
+}
+
+.items-start {
+  align-items: flex-start;
+}
+
+.items-end {
+  align-items: flex-end;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.items-baseline {
+  align-items: baseline;
+}
+
+.items-stretch {
+  align-items: stretch;
+}
+
+.justify-start {
+  justify-content: flex-start;
+}
+
+.justify-end {
+  justify-content: flex-end;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.justify-around {
+  justify-content: space-around;
+}
+
+.justify-evenly {
+  justify-content: space-evenly;
+}
+
+.justify-items-start {
+  justify-items: start;
+}
+
+.justify-items-end {
+  justify-items: end;
+}
+
+.justify-items-center {
+  justify-items: center;
+}
+
+.justify-items-stretch {
+  justify-items: stretch;
+}
+
+.gap-0 {
+  gap: 0px;
+}
+
+.gap-1 {
+  gap: 0.25rem;
+}
+
+.gap-2 {
+  gap: 0.5rem;
+}
+
+.gap-3 {
+  gap: 0.75rem;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.gap-5 {
+  gap: 1.25rem;
+}
+
+.gap-6 {
+  gap: 1.5rem;
+}
+
+.gap-7 {
+  gap: 1.75rem;
+}
+
+.gap-8 {
+  gap: 2rem;
+}
+
+.gap-9 {
+  gap: 2.25rem;
+}
+
+.gap-10 {
+  gap: 2.5rem;
+}
+
+.gap-11 {
+  gap: 2.75rem;
+}
+
+.gap-12 {
+  gap: 3rem;
+}
+
+.gap-14 {
+  gap: 3.5rem;
+}
+
+.gap-16 {
+  gap: 4rem;
+}
+
+.gap-20 {
+  gap: 5rem;
+}
+
+.gap-24 {
+  gap: 6rem;
+}
+
+.gap-28 {
+  gap: 7rem;
+}
+
+.gap-32 {
+  gap: 8rem;
+}
+
+.gap-36 {
+  gap: 9rem;
+}
+
+.gap-40 {
+  gap: 10rem;
+}
+
+.gap-44 {
+  gap: 11rem;
+}
+
+.gap-48 {
+  gap: 12rem;
+}
+
+.gap-52 {
+  gap: 13rem;
+}
+
+.gap-56 {
+  gap: 14rem;
+}
+
+.gap-60 {
+  gap: 15rem;
+}
+
+.gap-64 {
+  gap: 16rem;
+}
+
+.gap-72 {
+  gap: 18rem;
+}
+
+.gap-80 {
+  gap: 20rem;
+}
+
+.gap-96 {
+  gap: 24rem;
+}
+
+.gap-px {
+  gap: 1px;
+}
+
+.gap-0\\\\.5 {
+  gap: 0.125rem;
+}
+
+.gap-1\\\\.5 {
+  gap: 0.375rem;
+}
+
+.gap-2\\\\.5 {
+  gap: 0.625rem;
+}
+
+.gap-3\\\\.5 {
+  gap: 0.875rem;
+}
+
+.gap-x-0 {
+  -moz-column-gap: 0px;
+       column-gap: 0px;
+}
+
+.gap-x-1 {
+  -moz-column-gap: 0.25rem;
+       column-gap: 0.25rem;
+}
+
+.gap-x-2 {
+  -moz-column-gap: 0.5rem;
+       column-gap: 0.5rem;
+}
+
+.gap-x-3 {
+  -moz-column-gap: 0.75rem;
+       column-gap: 0.75rem;
+}
+
+.gap-x-4 {
+  -moz-column-gap: 1rem;
+       column-gap: 1rem;
+}
+
+.gap-x-5 {
+  -moz-column-gap: 1.25rem;
+       column-gap: 1.25rem;
+}
+
+.gap-x-6 {
+  -moz-column-gap: 1.5rem;
+       column-gap: 1.5rem;
+}
+
+.gap-x-7 {
+  -moz-column-gap: 1.75rem;
+       column-gap: 1.75rem;
+}
+
+.gap-x-8 {
+  -moz-column-gap: 2rem;
+       column-gap: 2rem;
+}
+
+.gap-x-9 {
+  -moz-column-gap: 2.25rem;
+       column-gap: 2.25rem;
+}
+
+.gap-x-10 {
+  -moz-column-gap: 2.5rem;
+       column-gap: 2.5rem;
+}
+
+.gap-x-11 {
+  -moz-column-gap: 2.75rem;
+       column-gap: 2.75rem;
+}
+
+.gap-x-12 {
+  -moz-column-gap: 3rem;
+       column-gap: 3rem;
+}
+
+.gap-x-14 {
+  -moz-column-gap: 3.5rem;
+       column-gap: 3.5rem;
+}
+
+.gap-x-16 {
+  -moz-column-gap: 4rem;
+       column-gap: 4rem;
+}
+
+.gap-x-20 {
+  -moz-column-gap: 5rem;
+       column-gap: 5rem;
+}
+
+.gap-x-24 {
+  -moz-column-gap: 6rem;
+       column-gap: 6rem;
+}
+
+.gap-x-28 {
+  -moz-column-gap: 7rem;
+       column-gap: 7rem;
+}
+
+.gap-x-32 {
+  -moz-column-gap: 8rem;
+       column-gap: 8rem;
+}
+
+.gap-x-36 {
+  -moz-column-gap: 9rem;
+       column-gap: 9rem;
+}
+
+.gap-x-40 {
+  -moz-column-gap: 10rem;
+       column-gap: 10rem;
+}
+
+.gap-x-44 {
+  -moz-column-gap: 11rem;
+       column-gap: 11rem;
+}
+
+.gap-x-48 {
+  -moz-column-gap: 12rem;
+       column-gap: 12rem;
+}
+
+.gap-x-52 {
+  -moz-column-gap: 13rem;
+       column-gap: 13rem;
+}
+
+.gap-x-56 {
+  -moz-column-gap: 14rem;
+       column-gap: 14rem;
+}
+
+.gap-x-60 {
+  -moz-column-gap: 15rem;
+       column-gap: 15rem;
+}
+
+.gap-x-64 {
+  -moz-column-gap: 16rem;
+       column-gap: 16rem;
+}
+
+.gap-x-72 {
+  -moz-column-gap: 18rem;
+       column-gap: 18rem;
+}
+
+.gap-x-80 {
+  -moz-column-gap: 20rem;
+       column-gap: 20rem;
+}
+
+.gap-x-96 {
+  -moz-column-gap: 24rem;
+       column-gap: 24rem;
+}
+
+.gap-x-px {
+  -moz-column-gap: 1px;
+       column-gap: 1px;
+}
+
+.gap-x-0\\\\.5 {
+  -moz-column-gap: 0.125rem;
+       column-gap: 0.125rem;
+}
+
+.gap-x-1\\\\.5 {
+  -moz-column-gap: 0.375rem;
+       column-gap: 0.375rem;
+}
+
+.gap-x-2\\\\.5 {
+  -moz-column-gap: 0.625rem;
+       column-gap: 0.625rem;
+}
+
+.gap-x-3\\\\.5 {
+  -moz-column-gap: 0.875rem;
+       column-gap: 0.875rem;
+}
+
+.gap-y-0 {
+  row-gap: 0px;
+}
+
+.gap-y-1 {
+  row-gap: 0.25rem;
+}
+
+.gap-y-2 {
+  row-gap: 0.5rem;
+}
+
+.gap-y-3 {
+  row-gap: 0.75rem;
+}
+
+.gap-y-4 {
+  row-gap: 1rem;
+}
+
+.gap-y-5 {
+  row-gap: 1.25rem;
+}
+
+.gap-y-6 {
+  row-gap: 1.5rem;
+}
+
+.gap-y-7 {
+  row-gap: 1.75rem;
+}
+
+.gap-y-8 {
+  row-gap: 2rem;
+}
+
+.gap-y-9 {
+  row-gap: 2.25rem;
+}
+
+.gap-y-10 {
+  row-gap: 2.5rem;
+}
+
+.gap-y-11 {
+  row-gap: 2.75rem;
+}
+
+.gap-y-12 {
+  row-gap: 3rem;
+}
+
+.gap-y-14 {
+  row-gap: 3.5rem;
+}
+
+.gap-y-16 {
+  row-gap: 4rem;
+}
+
+.gap-y-20 {
+  row-gap: 5rem;
+}
+
+.gap-y-24 {
+  row-gap: 6rem;
+}
+
+.gap-y-28 {
+  row-gap: 7rem;
+}
+
+.gap-y-32 {
+  row-gap: 8rem;
+}
+
+.gap-y-36 {
+  row-gap: 9rem;
+}
+
+.gap-y-40 {
+  row-gap: 10rem;
+}
+
+.gap-y-44 {
+  row-gap: 11rem;
+}
+
+.gap-y-48 {
+  row-gap: 12rem;
+}
+
+.gap-y-52 {
+  row-gap: 13rem;
+}
+
+.gap-y-56 {
+  row-gap: 14rem;
+}
+
+.gap-y-60 {
+  row-gap: 15rem;
+}
+
+.gap-y-64 {
+  row-gap: 16rem;
+}
+
+.gap-y-72 {
+  row-gap: 18rem;
+}
+
+.gap-y-80 {
+  row-gap: 20rem;
+}
+
+.gap-y-96 {
+  row-gap: 24rem;
+}
+
+.gap-y-px {
+  row-gap: 1px;
+}
+
+.gap-y-0\\\\.5 {
+  row-gap: 0.125rem;
+}
+
+.gap-y-1\\\\.5 {
+  row-gap: 0.375rem;
+}
+
+.gap-y-2\\\\.5 {
+  row-gap: 0.625rem;
+}
+
+.gap-y-3\\\\.5 {
+  row-gap: 0.875rem;
+}
+
+.space-x-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0px * var(--tw-space-x-reverse));
+  margin-left: calc(0px * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1rem * var(--tw-space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(1.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-7 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(1.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2rem * var(--tw-space-x-reverse));
+  margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-9 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(2.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-11 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(2.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-12 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(3rem * var(--tw-space-x-reverse));
+  margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-14 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(3.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(3.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-16 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(4rem * var(--tw-space-x-reverse));
+  margin-left: calc(4rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(5rem * var(--tw-space-x-reverse));
+  margin-left: calc(5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-24 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(6rem * var(--tw-space-x-reverse));
+  margin-left: calc(6rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-28 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(7rem * var(--tw-space-x-reverse));
+  margin-left: calc(7rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-32 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(8rem * var(--tw-space-x-reverse));
+  margin-left: calc(8rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-36 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(9rem * var(--tw-space-x-reverse));
+  margin-left: calc(9rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(10rem * var(--tw-space-x-reverse));
+  margin-left: calc(10rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-44 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(11rem * var(--tw-space-x-reverse));
+  margin-left: calc(11rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-48 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(12rem * var(--tw-space-x-reverse));
+  margin-left: calc(12rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-52 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(13rem * var(--tw-space-x-reverse));
+  margin-left: calc(13rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-56 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(14rem * var(--tw-space-x-reverse));
+  margin-left: calc(14rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(15rem * var(--tw-space-x-reverse));
+  margin-left: calc(15rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-64 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(16rem * var(--tw-space-x-reverse));
+  margin-left: calc(16rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-72 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(18rem * var(--tw-space-x-reverse));
+  margin-left: calc(18rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(20rem * var(--tw-space-x-reverse));
+  margin-left: calc(20rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-96 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(24rem * var(--tw-space-x-reverse));
+  margin-left: calc(24rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-px > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1px * var(--tw-space-x-reverse));
+  margin-left: calc(1px * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.125rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.125rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-1\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.375rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.375rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-2\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.625rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.625rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-3\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.875rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.875rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0px * var(--tw-space-x-reverse));
+  margin-left: calc(0px * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-7 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-9 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-11 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-12 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-3rem * var(--tw-space-x-reverse));
+  margin-left: calc(-3rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-14 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-3.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-3.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-16 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-4rem * var(--tw-space-x-reverse));
+  margin-left: calc(-4rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-24 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-6rem * var(--tw-space-x-reverse));
+  margin-left: calc(-6rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-28 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-7rem * var(--tw-space-x-reverse));
+  margin-left: calc(-7rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-32 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-8rem * var(--tw-space-x-reverse));
+  margin-left: calc(-8rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-36 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-9rem * var(--tw-space-x-reverse));
+  margin-left: calc(-9rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-10rem * var(--tw-space-x-reverse));
+  margin-left: calc(-10rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-44 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-11rem * var(--tw-space-x-reverse));
+  margin-left: calc(-11rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-48 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-12rem * var(--tw-space-x-reverse));
+  margin-left: calc(-12rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-52 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-13rem * var(--tw-space-x-reverse));
+  margin-left: calc(-13rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-56 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-14rem * var(--tw-space-x-reverse));
+  margin-left: calc(-14rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-15rem * var(--tw-space-x-reverse));
+  margin-left: calc(-15rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-64 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-16rem * var(--tw-space-x-reverse));
+  margin-left: calc(-16rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-72 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-18rem * var(--tw-space-x-reverse));
+  margin-left: calc(-18rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-20rem * var(--tw-space-x-reverse));
+  margin-left: calc(-20rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-96 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-24rem * var(--tw-space-x-reverse));
+  margin-left: calc(-24rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-px > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1px * var(--tw-space-x-reverse));
+  margin-left: calc(-1px * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.125rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.125rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-1\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.375rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.375rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-2\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.625rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.625rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-3\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.875rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.875rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0px * var(--tw-space-y-reverse));
+}
+
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
+}
+
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.75rem * var(--tw-space-y-reverse));
+}
+
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+
+.space-y-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.25rem * var(--tw-space-y-reverse));
+}
+
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-7 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.75rem * var(--tw-space-y-reverse));
+}
+
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+}
+
+.space-y-9 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2.25rem * var(--tw-space-y-reverse));
+}
+
+.space-y-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-11 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2.75rem * var(--tw-space-y-reverse));
+}
+
+.space-y-12 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(3rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(3rem * var(--tw-space-y-reverse));
+}
+
+.space-y-14 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(3.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(3.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-16 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(4rem * var(--tw-space-y-reverse));
+}
+
+.space-y-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-24 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(6rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(6rem * var(--tw-space-y-reverse));
+}
+
+.space-y-28 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(7rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(7rem * var(--tw-space-y-reverse));
+}
+
+.space-y-32 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(8rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(8rem * var(--tw-space-y-reverse));
+}
+
+.space-y-36 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(9rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(9rem * var(--tw-space-y-reverse));
+}
+
+.space-y-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(10rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(10rem * var(--tw-space-y-reverse));
+}
+
+.space-y-44 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(11rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(11rem * var(--tw-space-y-reverse));
+}
+
+.space-y-48 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(12rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(12rem * var(--tw-space-y-reverse));
+}
+
+.space-y-52 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(13rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(13rem * var(--tw-space-y-reverse));
+}
+
+.space-y-56 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(14rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(14rem * var(--tw-space-y-reverse));
+}
+
+.space-y-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(15rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(15rem * var(--tw-space-y-reverse));
+}
+
+.space-y-64 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(16rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(16rem * var(--tw-space-y-reverse));
+}
+
+.space-y-72 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(18rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(18rem * var(--tw-space-y-reverse));
+}
+
+.space-y-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(20rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(20rem * var(--tw-space-y-reverse));
+}
+
+.space-y-96 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(24rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(24rem * var(--tw-space-y-reverse));
+}
+
+.space-y-px > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1px * var(--tw-space-y-reverse));
+}
+
+.space-y-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.125rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.125rem * var(--tw-space-y-reverse));
+}
+
+.space-y-1\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.375rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.375rem * var(--tw-space-y-reverse));
+}
+
+.space-y-2\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.625rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.625rem * var(--tw-space-y-reverse));
+}
+
+.space-y-3\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.875rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.875rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0px * var(--tw-space-y-reverse));
+}
+
+.-space-y-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.25rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.75rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1.25rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-7 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1.75rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-9 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2.25rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-11 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2.75rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-12 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-3rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-3rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-14 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-3.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-3.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-16 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-4rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-4rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-24 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-6rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-6rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-28 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-7rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-7rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-32 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-8rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-8rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-36 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-9rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-9rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-10rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-10rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-44 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-11rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-11rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-48 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-12rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-12rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-52 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-13rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-13rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-56 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-14rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-14rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-15rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-15rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-64 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-16rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-16rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-72 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-18rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-18rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-20rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-20rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-96 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-24rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-24rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-px > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1px * var(--tw-space-y-reverse));
+}
+
+.-space-y-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.125rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.125rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-1\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.375rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.375rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-2\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.625rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.625rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-3\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.875rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.875rem * var(--tw-space-y-reverse));
+}
+
+.space-y-reverse > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 1;
+}
+
+.space-x-reverse > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 1;
+}
+
+.divide-x-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(0px * var(--tw-divide-x-reverse));
+  border-left-width: calc(0px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(2px * var(--tw-divide-x-reverse));
+  border-left-width: calc(2px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(4px * var(--tw-divide-x-reverse));
+  border-left-width: calc(4px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-x-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(8px * var(--tw-divide-x-reverse));
+  border-left-width: calc(8px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-x > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(1px * var(--tw-divide-x-reverse));
+  border-left-width: calc(1px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-y-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(0px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(0px * var(--tw-divide-y-reverse));
+}
+
+.divide-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(2px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(2px * var(--tw-divide-y-reverse));
+}
+
+.divide-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(4px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(4px * var(--tw-divide-y-reverse));
+}
+
+.divide-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(8px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(8px * var(--tw-divide-y-reverse));
+}
+
+.divide-y > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
+}
+
+.divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 1;
+}
+
+.divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 1;
+}
+
+.divide-solid > :not([hidden]) ~ :not([hidden]) {
+  border-style: solid;
+}
+
+.divide-dashed > :not([hidden]) ~ :not([hidden]) {
+  border-style: dashed;
+}
+
+.divide-dotted > :not([hidden]) ~ :not([hidden]) {
+  border-style: dotted;
+}
+
+.divide-double > :not([hidden]) ~ :not([hidden]) {
+  border-style: double;
+}
+
+.divide-none > :not([hidden]) ~ :not([hidden]) {
+  border-style: none;
+}
+
+.divide-current > :not([hidden]) ~ :not([hidden]) {
+  border-color: currentColor;
+}
+
+.divide-transparent > :not([hidden]) ~ :not([hidden]) {
+  border-color: transparent;
+}
+
+.divide-falcon > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--falcon);
+}
+
+.divide-basement > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--basement);
+}
+
+.divide-blue > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--blue);
+}
+
+.divide-body-and-labels > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--body-and-labels);
+}
+
+.divide-brand > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--brand);
+}
+
+.divide-code-base-64 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--code-base-64);
+}
+
+.divide-code-bg > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--code-bg);
+}
+
+.divide-code-outline > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--code-outline);
+}
+
+.divide-code-text > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--code-text);
+}
+
+.divide-critical > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--critical);
+}
+
+.divide-destructive-hover > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--destructive-hover);
+}
+
+.divide-destructive-idle > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--destructive-idle);
+}
+
+.divide-destructive-pressed > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--destructive-pressed);
+}
+
+.divide-disabled > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--disabled);
+}
+
+.divide-disc-operations > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--disc-operations);
+}
+
+.divide-dns-requests > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--dns-requests);
+}
+
+.divide-focus > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--focus);
+}
+
+.divide-graph-1 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-1);
+}
+
+.divide-graph-10 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-10);
+}
+
+.divide-graph-11 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-11);
+}
+
+.divide-graph-2 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-2);
+}
+
+.divide-graph-3 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-3);
+}
+
+.divide-graph-4 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-4);
+}
+
+.divide-graph-5 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-5);
+}
+
+.divide-graph-6 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-6);
+}
+
+.divide-graph-7 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-7);
+}
+
+.divide-graph-8 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-8);
+}
+
+.divide-graph-9 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-9);
+}
+
+.divide-graph-disabled > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-disabled);
+}
+
+.divide-ground-floor > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--ground-floor);
+}
+
+.divide-high > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--high);
+}
+
+.divide-informational > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--informational);
+}
+
+.divide-lines-dark > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--lines-dark);
+}
+
+.divide-lines-light > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--lines-light);
+}
+
+.divide-low > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--low);
+}
+
+.divide-medium > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--medium);
+}
+
+.divide-mezzanine > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--mezzanine);
+}
+
+.divide-nav-text-and-icons > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--nav-text-and-icons);
+}
+
+.divide-nav-text-secondary > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--nav-text-secondary);
+}
+
+.divide-network-operations > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--network-operations);
+}
+
+.divide-normal-hover > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--normal-hover);
+}
+
+.divide-normal-idle > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--normal-idle);
+}
+
+.divide-normal-pressed > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--normal-pressed);
+}
+
+.divide-overlay-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--overlay-0\\\\.5);
+}
+
+.divide-overlay-1 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--overlay-1);
+}
+
+.divide-overlay-2 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--overlay-2);
+}
+
+.divide-positive > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--positive);
+}
+
+.divide-primary-hover > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--primary-hover);
+}
+
+.divide-primary-idle > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--primary-idle);
+}
+
+.divide-primary-pressed > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--primary-pressed);
+}
+
+.divide-process-operations > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--process-operations);
+}
+
+.divide-purple > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--purple);
+}
+
+.divide-registry-operations > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--registry-operations);
+}
+
+.divide-selected > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--selected);
+}
+
+.divide-surface-2xl > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-2xl);
+}
+
+.divide-surface-base > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-base);
+}
+
+.divide-surface-inner > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-inner);
+}
+
+.divide-surface-lg > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-lg);
+}
+
+.divide-surface-md > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-md);
+}
+
+.divide-surface-xl > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-xl);
+}
+
+.divide-text-and-icons > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--text-and-icons);
+}
+
+.divide-titles-and-attributes > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--titles-and-attributes);
+}
+
+.divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0;
+}
+
+.divide-opacity-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.05;
+}
+
+.divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.1;
+}
+
+.divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.2;
+}
+
+.divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.25;
+}
+
+.divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.3;
+}
+
+.divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.4;
+}
+
+.divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.5;
+}
+
+.divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.6;
+}
+
+.divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.7;
+}
+
+.divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.75;
+}
+
+.divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.8;
+}
+
+.divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.9;
+}
+
+.divide-opacity-95 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.95;
+}
+
+.divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+}
+
+.place-self-auto {
+  place-self: auto;
+}
+
+.place-self-start {
+  place-self: start;
+}
+
+.place-self-end {
+  place-self: end;
+}
+
+.place-self-center {
+  place-self: center;
+}
+
+.place-self-stretch {
+  place-self: stretch;
+}
+
+.self-auto {
+  align-self: auto;
+}
+
+.self-start {
+  align-self: flex-start;
+}
+
+.self-end {
+  align-self: flex-end;
+}
+
+.self-center {
+  align-self: center;
+}
+
+.self-stretch {
+  align-self: stretch;
+}
+
+.self-baseline {
+  align-self: baseline;
+}
+
+.justify-self-auto {
+  justify-self: auto;
+}
+
+.justify-self-start {
+  justify-self: start;
+}
+
+.justify-self-end {
+  justify-self: end;
+}
+
+.justify-self-center {
+  justify-self: center;
+}
+
+.justify-self-stretch {
+  justify-self: stretch;
+}
+
+.overflow-auto {
+  overflow: auto;
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.overflow-visible {
+  overflow: visible;
+}
+
+.overflow-scroll {
+  overflow: scroll;
+}
+
+.overflow-x-auto {
+  overflow-x: auto;
+}
+
+.overflow-y-auto {
+  overflow-y: auto;
+}
+
+.overflow-x-hidden {
+  overflow-x: hidden;
+}
+
+.overflow-y-hidden {
+  overflow-y: hidden;
+}
+
+.overflow-x-visible {
+  overflow-x: visible;
+}
+
+.overflow-y-visible {
+  overflow-y: visible;
+}
+
+.overflow-x-scroll {
+  overflow-x: scroll;
+}
+
+.overflow-y-scroll {
+  overflow-y: scroll;
+}
+
+.overscroll-auto {
+  -ms-scroll-chaining: chained;
+      overscroll-behavior: auto;
+}
+
+.overscroll-contain {
+  -ms-scroll-chaining: none;
+      overscroll-behavior: contain;
+}
+
+.overscroll-none {
+  -ms-scroll-chaining: none;
+      overscroll-behavior: none;
+}
+
+.overscroll-y-auto {
+  overscroll-behavior-y: auto;
+}
+
+.overscroll-y-contain {
+  overscroll-behavior-y: contain;
+}
+
+.overscroll-y-none {
+  overscroll-behavior-y: none;
+}
+
+.overscroll-x-auto {
+  overscroll-behavior-x: auto;
+}
+
+.overscroll-x-contain {
+  overscroll-behavior-x: contain;
+}
+
+.overscroll-x-none {
+  overscroll-behavior-x: none;
+}
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overflow-ellipsis {
+  text-overflow: ellipsis;
+}
+
+.overflow-clip {
+  text-overflow: clip;
+}
+
+.whitespace-normal {
+  white-space: normal;
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+
+.whitespace-pre {
+  white-space: pre;
+}
+
+.whitespace-pre-line {
+  white-space: pre-line;
+}
+
+.whitespace-pre-wrap {
+  white-space: pre-wrap;
+}
+
+.break-normal {
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.break-words {
+  overflow-wrap: break-word;
+}
+
+.break-all {
+  word-break: break-all;
+}
+
+.rounded-none {
+  border-radius: 0px;
+}
+
+.rounded-sm {
+  border-radius: 0.125rem;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.rounded-md {
+  border-radius: 0.375rem;
+}
+
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
+.rounded-2xl {
+  border-radius: 1rem;
+}
+
+.rounded-3xl {
+  border-radius: 1.5rem;
+}
+
+.rounded-full {
+  border-radius: 9999px;
+}
+
+.focus\\\\:rounded-none:focus {
+  border-radius: 0px;
+}
+
+.focus\\\\:rounded-sm:focus {
+  border-radius: 0.125rem;
+}
+
+.focus\\\\:rounded:focus {
+  border-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-md:focus {
+  border-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-lg:focus {
+  border-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-xl:focus {
+  border-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-2xl:focus {
+  border-radius: 1rem;
+}
+
+.focus\\\\:rounded-3xl:focus {
+  border-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-full:focus {
+  border-radius: 9999px;
+}
+
+.first\\\\:rounded-none:first-child {
+  border-radius: 0px;
+}
+
+.first\\\\:rounded-sm:first-child {
+  border-radius: 0.125rem;
+}
+
+.first\\\\:rounded:first-child {
+  border-radius: 0.25rem;
+}
+
+.first\\\\:rounded-md:first-child {
+  border-radius: 0.375rem;
+}
+
+.first\\\\:rounded-lg:first-child {
+  border-radius: 0.5rem;
+}
+
+.first\\\\:rounded-xl:first-child {
+  border-radius: 0.75rem;
+}
+
+.first\\\\:rounded-2xl:first-child {
+  border-radius: 1rem;
+}
+
+.first\\\\:rounded-3xl:first-child {
+  border-radius: 1.5rem;
+}
+
+.first\\\\:rounded-full:first-child {
+  border-radius: 9999px;
+}
+
+.last\\\\:rounded-none:last-child {
+  border-radius: 0px;
+}
+
+.last\\\\:rounded-sm:last-child {
+  border-radius: 0.125rem;
+}
+
+.last\\\\:rounded:last-child {
+  border-radius: 0.25rem;
+}
+
+.last\\\\:rounded-md:last-child {
+  border-radius: 0.375rem;
+}
+
+.last\\\\:rounded-lg:last-child {
+  border-radius: 0.5rem;
+}
+
+.last\\\\:rounded-xl:last-child {
+  border-radius: 0.75rem;
+}
+
+.last\\\\:rounded-2xl:last-child {
+  border-radius: 1rem;
+}
+
+.last\\\\:rounded-3xl:last-child {
+  border-radius: 1.5rem;
+}
+
+.last\\\\:rounded-full:last-child {
+  border-radius: 9999px;
+}
+
+.rounded-t-none {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.rounded-t-sm {
+  border-top-left-radius: 0.125rem;
+  border-top-right-radius: 0.125rem;
+}
+
+.rounded-t {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.rounded-t-md {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+.rounded-t-lg {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.rounded-t-xl {
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.rounded-t-2xl {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.rounded-t-3xl {
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+}
+
+.rounded-t-full {
+  border-top-left-radius: 9999px;
+  border-top-right-radius: 9999px;
+}
+
+.rounded-r-none {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.rounded-r-sm {
+  border-top-right-radius: 0.125rem;
+  border-bottom-right-radius: 0.125rem;
+}
+
+.rounded-r {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.rounded-r-md {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.rounded-r-lg {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.rounded-r-xl {
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.rounded-r-2xl {
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.rounded-r-3xl {
+  border-top-right-radius: 1.5rem;
+  border-bottom-right-radius: 1.5rem;
+}
+
+.rounded-r-full {
+  border-top-right-radius: 9999px;
+  border-bottom-right-radius: 9999px;
+}
+
+.rounded-b-none {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.rounded-b-sm {
+  border-bottom-right-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.rounded-b {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.rounded-b-md {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.rounded-b-lg {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.rounded-b-xl {
+  border-bottom-right-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.rounded-b-2xl {
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.rounded-b-3xl {
+  border-bottom-right-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.rounded-b-full {
+  border-bottom-right-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.rounded-l-none {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.rounded-l-sm {
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.rounded-l {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.rounded-l-md {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.rounded-l-lg {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.rounded-l-xl {
+  border-top-left-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.rounded-l-2xl {
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.rounded-l-3xl {
+  border-top-left-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.rounded-l-full {
+  border-top-left-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.focus\\\\:rounded-t-none:focus {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.focus\\\\:rounded-t-sm:focus {
+  border-top-left-radius: 0.125rem;
+  border-top-right-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-t:focus {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-t-md:focus {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-t-lg:focus {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-t-xl:focus {
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-t-2xl:focus {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.focus\\\\:rounded-t-3xl:focus {
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-t-full:focus {
+  border-top-left-radius: 9999px;
+  border-top-right-radius: 9999px;
+}
+
+.focus\\\\:rounded-r-none:focus {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.focus\\\\:rounded-r-sm:focus {
+  border-top-right-radius: 0.125rem;
+  border-bottom-right-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-r:focus {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-r-md:focus {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-r-lg:focus {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-r-xl:focus {
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-r-2xl:focus {
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.focus\\\\:rounded-r-3xl:focus {
+  border-top-right-radius: 1.5rem;
+  border-bottom-right-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-r-full:focus {
+  border-top-right-radius: 9999px;
+  border-bottom-right-radius: 9999px;
+}
+
+.focus\\\\:rounded-b-none:focus {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.focus\\\\:rounded-b-sm:focus {
+  border-bottom-right-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-b:focus {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-b-md:focus {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-b-lg:focus {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-b-xl:focus {
+  border-bottom-right-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-b-2xl:focus {
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.focus\\\\:rounded-b-3xl:focus {
+  border-bottom-right-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-b-full:focus {
+  border-bottom-right-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.focus\\\\:rounded-l-none:focus {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.focus\\\\:rounded-l-sm:focus {
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-l:focus {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-l-md:focus {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-l-lg:focus {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-l-xl:focus {
+  border-top-left-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-l-2xl:focus {
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.focus\\\\:rounded-l-3xl:focus {
+  border-top-left-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-l-full:focus {
+  border-top-left-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.first\\\\:rounded-t-none:first-child {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.first\\\\:rounded-t-sm:first-child {
+  border-top-left-radius: 0.125rem;
+  border-top-right-radius: 0.125rem;
+}
+
+.first\\\\:rounded-t:first-child {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.first\\\\:rounded-t-md:first-child {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+.first\\\\:rounded-t-lg:first-child {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.first\\\\:rounded-t-xl:first-child {
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.first\\\\:rounded-t-2xl:first-child {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.first\\\\:rounded-t-3xl:first-child {
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+}
+
+.first\\\\:rounded-t-full:first-child {
+  border-top-left-radius: 9999px;
+  border-top-right-radius: 9999px;
+}
+
+.first\\\\:rounded-r-none:first-child {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.first\\\\:rounded-r-sm:first-child {
+  border-top-right-radius: 0.125rem;
+  border-bottom-right-radius: 0.125rem;
+}
+
+.first\\\\:rounded-r:first-child {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.first\\\\:rounded-r-md:first-child {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.first\\\\:rounded-r-lg:first-child {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.first\\\\:rounded-r-xl:first-child {
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.first\\\\:rounded-r-2xl:first-child {
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.first\\\\:rounded-r-3xl:first-child {
+  border-top-right-radius: 1.5rem;
+  border-bottom-right-radius: 1.5rem;
+}
+
+.first\\\\:rounded-r-full:first-child {
+  border-top-right-radius: 9999px;
+  border-bottom-right-radius: 9999px;
+}
+
+.first\\\\:rounded-b-none:first-child {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.first\\\\:rounded-b-sm:first-child {
+  border-bottom-right-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.first\\\\:rounded-b:first-child {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.first\\\\:rounded-b-md:first-child {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.first\\\\:rounded-b-lg:first-child {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.first\\\\:rounded-b-xl:first-child {
+  border-bottom-right-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.first\\\\:rounded-b-2xl:first-child {
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.first\\\\:rounded-b-3xl:first-child {
+  border-bottom-right-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.first\\\\:rounded-b-full:first-child {
+  border-bottom-right-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.first\\\\:rounded-l-none:first-child {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.first\\\\:rounded-l-sm:first-child {
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.first\\\\:rounded-l:first-child {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.first\\\\:rounded-l-md:first-child {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.first\\\\:rounded-l-lg:first-child {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.first\\\\:rounded-l-xl:first-child {
+  border-top-left-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.first\\\\:rounded-l-2xl:first-child {
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.first\\\\:rounded-l-3xl:first-child {
+  border-top-left-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.first\\\\:rounded-l-full:first-child {
+  border-top-left-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.last\\\\:rounded-t-none:last-child {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.last\\\\:rounded-t-sm:last-child {
+  border-top-left-radius: 0.125rem;
+  border-top-right-radius: 0.125rem;
+}
+
+.last\\\\:rounded-t:last-child {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.last\\\\:rounded-t-md:last-child {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+.last\\\\:rounded-t-lg:last-child {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.last\\\\:rounded-t-xl:last-child {
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.last\\\\:rounded-t-2xl:last-child {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.last\\\\:rounded-t-3xl:last-child {
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+}
+
+.last\\\\:rounded-t-full:last-child {
+  border-top-left-radius: 9999px;
+  border-top-right-radius: 9999px;
+}
+
+.last\\\\:rounded-r-none:last-child {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.last\\\\:rounded-r-sm:last-child {
+  border-top-right-radius: 0.125rem;
+  border-bottom-right-radius: 0.125rem;
+}
+
+.last\\\\:rounded-r:last-child {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.last\\\\:rounded-r-md:last-child {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.last\\\\:rounded-r-lg:last-child {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.last\\\\:rounded-r-xl:last-child {
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.last\\\\:rounded-r-2xl:last-child {
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.last\\\\:rounded-r-3xl:last-child {
+  border-top-right-radius: 1.5rem;
+  border-bottom-right-radius: 1.5rem;
+}
+
+.last\\\\:rounded-r-full:last-child {
+  border-top-right-radius: 9999px;
+  border-bottom-right-radius: 9999px;
+}
+
+.last\\\\:rounded-b-none:last-child {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.last\\\\:rounded-b-sm:last-child {
+  border-bottom-right-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.last\\\\:rounded-b:last-child {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.last\\\\:rounded-b-md:last-child {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.last\\\\:rounded-b-lg:last-child {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.last\\\\:rounded-b-xl:last-child {
+  border-bottom-right-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.last\\\\:rounded-b-2xl:last-child {
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.last\\\\:rounded-b-3xl:last-child {
+  border-bottom-right-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.last\\\\:rounded-b-full:last-child {
+  border-bottom-right-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.last\\\\:rounded-l-none:last-child {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.last\\\\:rounded-l-sm:last-child {
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.last\\\\:rounded-l:last-child {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.last\\\\:rounded-l-md:last-child {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.last\\\\:rounded-l-lg:last-child {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.last\\\\:rounded-l-xl:last-child {
+  border-top-left-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.last\\\\:rounded-l-2xl:last-child {
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.last\\\\:rounded-l-3xl:last-child {
+  border-top-left-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.last\\\\:rounded-l-full:last-child {
+  border-top-left-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.rounded-tl-none {
+  border-top-left-radius: 0px;
+}
+
+.rounded-tl-sm {
+  border-top-left-radius: 0.125rem;
+}
+
+.rounded-tl {
+  border-top-left-radius: 0.25rem;
+}
+
+.rounded-tl-md {
+  border-top-left-radius: 0.375rem;
+}
+
+.rounded-tl-lg {
+  border-top-left-radius: 0.5rem;
+}
+
+.rounded-tl-xl {
+  border-top-left-radius: 0.75rem;
+}
+
+.rounded-tl-2xl {
+  border-top-left-radius: 1rem;
+}
+
+.rounded-tl-3xl {
+  border-top-left-radius: 1.5rem;
+}
+
+.rounded-tl-full {
+  border-top-left-radius: 9999px;
+}
+
+.rounded-tr-none {
+  border-top-right-radius: 0px;
+}
+
+.rounded-tr-sm {
+  border-top-right-radius: 0.125rem;
+}
+
+.rounded-tr {
+  border-top-right-radius: 0.25rem;
+}
+
+.rounded-tr-md {
+  border-top-right-radius: 0.375rem;
+}
+
+.rounded-tr-lg {
+  border-top-right-radius: 0.5rem;
+}
+
+.rounded-tr-xl {
+  border-top-right-radius: 0.75rem;
+}
+
+.rounded-tr-2xl {
+  border-top-right-radius: 1rem;
+}
+
+.rounded-tr-3xl {
+  border-top-right-radius: 1.5rem;
+}
+
+.rounded-tr-full {
+  border-top-right-radius: 9999px;
+}
+
+.rounded-br-none {
+  border-bottom-right-radius: 0px;
+}
+
+.rounded-br-sm {
+  border-bottom-right-radius: 0.125rem;
+}
+
+.rounded-br {
+  border-bottom-right-radius: 0.25rem;
+}
+
+.rounded-br-md {
+  border-bottom-right-radius: 0.375rem;
+}
+
+.rounded-br-lg {
+  border-bottom-right-radius: 0.5rem;
+}
+
+.rounded-br-xl {
+  border-bottom-right-radius: 0.75rem;
+}
+
+.rounded-br-2xl {
+  border-bottom-right-radius: 1rem;
+}
+
+.rounded-br-3xl {
+  border-bottom-right-radius: 1.5rem;
+}
+
+.rounded-br-full {
+  border-bottom-right-radius: 9999px;
+}
+
+.rounded-bl-none {
+  border-bottom-left-radius: 0px;
+}
+
+.rounded-bl-sm {
+  border-bottom-left-radius: 0.125rem;
+}
+
+.rounded-bl {
+  border-bottom-left-radius: 0.25rem;
+}
+
+.rounded-bl-md {
+  border-bottom-left-radius: 0.375rem;
+}
+
+.rounded-bl-lg {
+  border-bottom-left-radius: 0.5rem;
+}
+
+.rounded-bl-xl {
+  border-bottom-left-radius: 0.75rem;
+}
+
+.rounded-bl-2xl {
+  border-bottom-left-radius: 1rem;
+}
+
+.rounded-bl-3xl {
+  border-bottom-left-radius: 1.5rem;
+}
+
+.rounded-bl-full {
+  border-bottom-left-radius: 9999px;
+}
+
+.focus\\\\:rounded-tl-none:focus {
+  border-top-left-radius: 0px;
+}
+
+.focus\\\\:rounded-tl-sm:focus {
+  border-top-left-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-tl:focus {
+  border-top-left-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-tl-md:focus {
+  border-top-left-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-tl-lg:focus {
+  border-top-left-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-tl-xl:focus {
+  border-top-left-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-tl-2xl:focus {
+  border-top-left-radius: 1rem;
+}
+
+.focus\\\\:rounded-tl-3xl:focus {
+  border-top-left-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-tl-full:focus {
+  border-top-left-radius: 9999px;
+}
+
+.focus\\\\:rounded-tr-none:focus {
+  border-top-right-radius: 0px;
+}
+
+.focus\\\\:rounded-tr-sm:focus {
+  border-top-right-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-tr:focus {
+  border-top-right-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-tr-md:focus {
+  border-top-right-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-tr-lg:focus {
+  border-top-right-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-tr-xl:focus {
+  border-top-right-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-tr-2xl:focus {
+  border-top-right-radius: 1rem;
+}
+
+.focus\\\\:rounded-tr-3xl:focus {
+  border-top-right-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-tr-full:focus {
+  border-top-right-radius: 9999px;
+}
+
+.focus\\\\:rounded-br-none:focus {
+  border-bottom-right-radius: 0px;
+}
+
+.focus\\\\:rounded-br-sm:focus {
+  border-bottom-right-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-br:focus {
+  border-bottom-right-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-br-md:focus {
+  border-bottom-right-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-br-lg:focus {
+  border-bottom-right-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-br-xl:focus {
+  border-bottom-right-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-br-2xl:focus {
+  border-bottom-right-radius: 1rem;
+}
+
+.focus\\\\:rounded-br-3xl:focus {
+  border-bottom-right-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-br-full:focus {
+  border-bottom-right-radius: 9999px;
+}
+
+.focus\\\\:rounded-bl-none:focus {
+  border-bottom-left-radius: 0px;
+}
+
+.focus\\\\:rounded-bl-sm:focus {
+  border-bottom-left-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-bl:focus {
+  border-bottom-left-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-bl-md:focus {
+  border-bottom-left-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-bl-lg:focus {
+  border-bottom-left-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-bl-xl:focus {
+  border-bottom-left-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-bl-2xl:focus {
+  border-bottom-left-radius: 1rem;
+}
+
+.focus\\\\:rounded-bl-3xl:focus {
+  border-bottom-left-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-bl-full:focus {
+  border-bottom-left-radius: 9999px;
+}
+
+.first\\\\:rounded-tl-none:first-child {
+  border-top-left-radius: 0px;
+}
+
+.first\\\\:rounded-tl-sm:first-child {
+  border-top-left-radius: 0.125rem;
+}
+
+.first\\\\:rounded-tl:first-child {
+  border-top-left-radius: 0.25rem;
+}
+
+.first\\\\:rounded-tl-md:first-child {
+  border-top-left-radius: 0.375rem;
+}
+
+.first\\\\:rounded-tl-lg:first-child {
+  border-top-left-radius: 0.5rem;
+}
+
+.first\\\\:rounded-tl-xl:first-child {
+  border-top-left-radius: 0.75rem;
+}
+
+.first\\\\:rounded-tl-2xl:first-child {
+  border-top-left-radius: 1rem;
+}
+
+.first\\\\:rounded-tl-3xl:first-child {
+  border-top-left-radius: 1.5rem;
+}
+
+.first\\\\:rounded-tl-full:first-child {
+  border-top-left-radius: 9999px;
+}
+
+.first\\\\:rounded-tr-none:first-child {
+  border-top-right-radius: 0px;
+}
+
+.first\\\\:rounded-tr-sm:first-child {
+  border-top-right-radius: 0.125rem;
+}
+
+.first\\\\:rounded-tr:first-child {
+  border-top-right-radius: 0.25rem;
+}
+
+.first\\\\:rounded-tr-md:first-child {
+  border-top-right-radius: 0.375rem;
+}
+
+.first\\\\:rounded-tr-lg:first-child {
+  border-top-right-radius: 0.5rem;
+}
+
+.first\\\\:rounded-tr-xl:first-child {
+  border-top-right-radius: 0.75rem;
+}
+
+.first\\\\:rounded-tr-2xl:first-child {
+  border-top-right-radius: 1rem;
+}
+
+.first\\\\:rounded-tr-3xl:first-child {
+  border-top-right-radius: 1.5rem;
+}
+
+.first\\\\:rounded-tr-full:first-child {
+  border-top-right-radius: 9999px;
+}
+
+.first\\\\:rounded-br-none:first-child {
+  border-bottom-right-radius: 0px;
+}
+
+.first\\\\:rounded-br-sm:first-child {
+  border-bottom-right-radius: 0.125rem;
+}
+
+.first\\\\:rounded-br:first-child {
+  border-bottom-right-radius: 0.25rem;
+}
+
+.first\\\\:rounded-br-md:first-child {
+  border-bottom-right-radius: 0.375rem;
+}
+
+.first\\\\:rounded-br-lg:first-child {
+  border-bottom-right-radius: 0.5rem;
+}
+
+.first\\\\:rounded-br-xl:first-child {
+  border-bottom-right-radius: 0.75rem;
+}
+
+.first\\\\:rounded-br-2xl:first-child {
+  border-bottom-right-radius: 1rem;
+}
+
+.first\\\\:rounded-br-3xl:first-child {
+  border-bottom-right-radius: 1.5rem;
+}
+
+.first\\\\:rounded-br-full:first-child {
+  border-bottom-right-radius: 9999px;
+}
+
+.first\\\\:rounded-bl-none:first-child {
+  border-bottom-left-radius: 0px;
+}
+
+.first\\\\:rounded-bl-sm:first-child {
+  border-bottom-left-radius: 0.125rem;
+}
+
+.first\\\\:rounded-bl:first-child {
+  border-bottom-left-radius: 0.25rem;
+}
+
+.first\\\\:rounded-bl-md:first-child {
+  border-bottom-left-radius: 0.375rem;
+}
+
+.first\\\\:rounded-bl-lg:first-child {
+  border-bottom-left-radius: 0.5rem;
+}
+
+.first\\\\:rounded-bl-xl:first-child {
+  border-bottom-left-radius: 0.75rem;
+}
+
+.first\\\\:rounded-bl-2xl:first-child {
+  border-bottom-left-radius: 1rem;
+}
+
+.first\\\\:rounded-bl-3xl:first-child {
+  border-bottom-left-radius: 1.5rem;
+}
+
+.first\\\\:rounded-bl-full:first-child {
+  border-bottom-left-radius: 9999px;
+}
+
+.last\\\\:rounded-tl-none:last-child {
+  border-top-left-radius: 0px;
+}
+
+.last\\\\:rounded-tl-sm:last-child {
+  border-top-left-radius: 0.125rem;
+}
+
+.last\\\\:rounded-tl:last-child {
+  border-top-left-radius: 0.25rem;
+}
+
+.last\\\\:rounded-tl-md:last-child {
+  border-top-left-radius: 0.375rem;
+}
+
+.last\\\\:rounded-tl-lg:last-child {
+  border-top-left-radius: 0.5rem;
+}
+
+.last\\\\:rounded-tl-xl:last-child {
+  border-top-left-radius: 0.75rem;
+}
+
+.last\\\\:rounded-tl-2xl:last-child {
+  border-top-left-radius: 1rem;
+}
+
+.last\\\\:rounded-tl-3xl:last-child {
+  border-top-left-radius: 1.5rem;
+}
+
+.last\\\\:rounded-tl-full:last-child {
+  border-top-left-radius: 9999px;
+}
+
+.last\\\\:rounded-tr-none:last-child {
+  border-top-right-radius: 0px;
+}
+
+.last\\\\:rounded-tr-sm:last-child {
+  border-top-right-radius: 0.125rem;
+}
+
+.last\\\\:rounded-tr:last-child {
+  border-top-right-radius: 0.25rem;
+}
+
+.last\\\\:rounded-tr-md:last-child {
+  border-top-right-radius: 0.375rem;
+}
+
+.last\\\\:rounded-tr-lg:last-child {
+  border-top-right-radius: 0.5rem;
+}
+
+.last\\\\:rounded-tr-xl:last-child {
+  border-top-right-radius: 0.75rem;
+}
+
+.last\\\\:rounded-tr-2xl:last-child {
+  border-top-right-radius: 1rem;
+}
+
+.last\\\\:rounded-tr-3xl:last-child {
+  border-top-right-radius: 1.5rem;
+}
+
+.last\\\\:rounded-tr-full:last-child {
+  border-top-right-radius: 9999px;
+}
+
+.last\\\\:rounded-br-none:last-child {
+  border-bottom-right-radius: 0px;
+}
+
+.last\\\\:rounded-br-sm:last-child {
+  border-bottom-right-radius: 0.125rem;
+}
+
+.last\\\\:rounded-br:last-child {
+  border-bottom-right-radius: 0.25rem;
+}
+
+.last\\\\:rounded-br-md:last-child {
+  border-bottom-right-radius: 0.375rem;
+}
+
+.last\\\\:rounded-br-lg:last-child {
+  border-bottom-right-radius: 0.5rem;
+}
+
+.last\\\\:rounded-br-xl:last-child {
+  border-bottom-right-radius: 0.75rem;
+}
+
+.last\\\\:rounded-br-2xl:last-child {
+  border-bottom-right-radius: 1rem;
+}
+
+.last\\\\:rounded-br-3xl:last-child {
+  border-bottom-right-radius: 1.5rem;
+}
+
+.last\\\\:rounded-br-full:last-child {
+  border-bottom-right-radius: 9999px;
+}
+
+.last\\\\:rounded-bl-none:last-child {
+  border-bottom-left-radius: 0px;
+}
+
+.last\\\\:rounded-bl-sm:last-child {
+  border-bottom-left-radius: 0.125rem;
+}
+
+.last\\\\:rounded-bl:last-child {
+  border-bottom-left-radius: 0.25rem;
+}
+
+.last\\\\:rounded-bl-md:last-child {
+  border-bottom-left-radius: 0.375rem;
+}
+
+.last\\\\:rounded-bl-lg:last-child {
+  border-bottom-left-radius: 0.5rem;
+}
+
+.last\\\\:rounded-bl-xl:last-child {
+  border-bottom-left-radius: 0.75rem;
+}
+
+.last\\\\:rounded-bl-2xl:last-child {
+  border-bottom-left-radius: 1rem;
+}
+
+.last\\\\:rounded-bl-3xl:last-child {
+  border-bottom-left-radius: 1.5rem;
+}
+
+.last\\\\:rounded-bl-full:last-child {
+  border-bottom-left-radius: 9999px;
+}
+
+.border-0 {
+  border-width: 0px;
+}
+
+.border-2 {
+  border-width: 2px;
+}
+
+.border-4 {
+  border-width: 4px;
+}
+
+.border-8 {
+  border-width: 8px;
+}
+
+.border {
+  border-width: 1px;
+}
+
+.first\\\\:border-0:first-child {
+  border-width: 0px;
+}
+
+.first\\\\:border-2:first-child {
+  border-width: 2px;
+}
+
+.first\\\\:border-4:first-child {
+  border-width: 4px;
+}
+
+.first\\\\:border-8:first-child {
+  border-width: 8px;
+}
+
+.first\\\\:border:first-child {
+  border-width: 1px;
+}
+
+.last\\\\:border-0:last-child {
+  border-width: 0px;
+}
+
+.last\\\\:border-2:last-child {
+  border-width: 2px;
+}
+
+.last\\\\:border-4:last-child {
+  border-width: 4px;
+}
+
+.last\\\\:border-8:last-child {
+  border-width: 8px;
+}
+
+.last\\\\:border:last-child {
+  border-width: 1px;
+}
+
+.active\\\\:border-0:active {
+  border-width: 0px;
+}
+
+.active\\\\:border-2:active {
+  border-width: 2px;
+}
+
+.active\\\\:border-4:active {
+  border-width: 4px;
+}
+
+.active\\\\:border-8:active {
+  border-width: 8px;
+}
+
+.active\\\\:border:active {
+  border-width: 1px;
+}
+
+.border-t-0 {
+  border-top-width: 0px;
+}
+
+.border-t-2 {
+  border-top-width: 2px;
+}
+
+.border-t-4 {
+  border-top-width: 4px;
+}
+
+.border-t-8 {
+  border-top-width: 8px;
+}
+
+.border-t {
+  border-top-width: 1px;
+}
+
+.border-r-0 {
+  border-right-width: 0px;
+}
+
+.border-r-2 {
+  border-right-width: 2px;
+}
+
+.border-r-4 {
+  border-right-width: 4px;
+}
+
+.border-r-8 {
+  border-right-width: 8px;
+}
+
+.border-r {
+  border-right-width: 1px;
+}
+
+.border-b-0 {
+  border-bottom-width: 0px;
+}
+
+.border-b-2 {
+  border-bottom-width: 2px;
+}
+
+.border-b-4 {
+  border-bottom-width: 4px;
+}
+
+.border-b-8 {
+  border-bottom-width: 8px;
+}
+
+.border-b {
+  border-bottom-width: 1px;
+}
+
+.border-l-0 {
+  border-left-width: 0px;
+}
+
+.border-l-2 {
+  border-left-width: 2px;
+}
+
+.border-l-4 {
+  border-left-width: 4px;
+}
+
+.border-l-8 {
+  border-left-width: 8px;
+}
+
+.border-l {
+  border-left-width: 1px;
+}
+
+.first\\\\:border-t-0:first-child {
+  border-top-width: 0px;
+}
+
+.first\\\\:border-t-2:first-child {
+  border-top-width: 2px;
+}
+
+.first\\\\:border-t-4:first-child {
+  border-top-width: 4px;
+}
+
+.first\\\\:border-t-8:first-child {
+  border-top-width: 8px;
+}
+
+.first\\\\:border-t:first-child {
+  border-top-width: 1px;
+}
+
+.first\\\\:border-r-0:first-child {
+  border-right-width: 0px;
+}
+
+.first\\\\:border-r-2:first-child {
+  border-right-width: 2px;
+}
+
+.first\\\\:border-r-4:first-child {
+  border-right-width: 4px;
+}
+
+.first\\\\:border-r-8:first-child {
+  border-right-width: 8px;
+}
+
+.first\\\\:border-r:first-child {
+  border-right-width: 1px;
+}
+
+.first\\\\:border-b-0:first-child {
+  border-bottom-width: 0px;
+}
+
+.first\\\\:border-b-2:first-child {
+  border-bottom-width: 2px;
+}
+
+.first\\\\:border-b-4:first-child {
+  border-bottom-width: 4px;
+}
+
+.first\\\\:border-b-8:first-child {
+  border-bottom-width: 8px;
+}
+
+.first\\\\:border-b:first-child {
+  border-bottom-width: 1px;
+}
+
+.first\\\\:border-l-0:first-child {
+  border-left-width: 0px;
+}
+
+.first\\\\:border-l-2:first-child {
+  border-left-width: 2px;
+}
+
+.first\\\\:border-l-4:first-child {
+  border-left-width: 4px;
+}
+
+.first\\\\:border-l-8:first-child {
+  border-left-width: 8px;
+}
+
+.first\\\\:border-l:first-child {
+  border-left-width: 1px;
+}
+
+.last\\\\:border-t-0:last-child {
+  border-top-width: 0px;
+}
+
+.last\\\\:border-t-2:last-child {
+  border-top-width: 2px;
+}
+
+.last\\\\:border-t-4:last-child {
+  border-top-width: 4px;
+}
+
+.last\\\\:border-t-8:last-child {
+  border-top-width: 8px;
+}
+
+.last\\\\:border-t:last-child {
+  border-top-width: 1px;
+}
+
+.last\\\\:border-r-0:last-child {
+  border-right-width: 0px;
+}
+
+.last\\\\:border-r-2:last-child {
+  border-right-width: 2px;
+}
+
+.last\\\\:border-r-4:last-child {
+  border-right-width: 4px;
+}
+
+.last\\\\:border-r-8:last-child {
+  border-right-width: 8px;
+}
+
+.last\\\\:border-r:last-child {
+  border-right-width: 1px;
+}
+
+.last\\\\:border-b-0:last-child {
+  border-bottom-width: 0px;
+}
+
+.last\\\\:border-b-2:last-child {
+  border-bottom-width: 2px;
+}
+
+.last\\\\:border-b-4:last-child {
+  border-bottom-width: 4px;
+}
+
+.last\\\\:border-b-8:last-child {
+  border-bottom-width: 8px;
+}
+
+.last\\\\:border-b:last-child {
+  border-bottom-width: 1px;
+}
+
+.last\\\\:border-l-0:last-child {
+  border-left-width: 0px;
+}
+
+.last\\\\:border-l-2:last-child {
+  border-left-width: 2px;
+}
+
+.last\\\\:border-l-4:last-child {
+  border-left-width: 4px;
+}
+
+.last\\\\:border-l-8:last-child {
+  border-left-width: 8px;
+}
+
+.last\\\\:border-l:last-child {
+  border-left-width: 1px;
+}
+
+.active\\\\:border-t-0:active {
+  border-top-width: 0px;
+}
+
+.active\\\\:border-t-2:active {
+  border-top-width: 2px;
+}
+
+.active\\\\:border-t-4:active {
+  border-top-width: 4px;
+}
+
+.active\\\\:border-t-8:active {
+  border-top-width: 8px;
+}
+
+.active\\\\:border-t:active {
+  border-top-width: 1px;
+}
+
+.active\\\\:border-r-0:active {
+  border-right-width: 0px;
+}
+
+.active\\\\:border-r-2:active {
+  border-right-width: 2px;
+}
+
+.active\\\\:border-r-4:active {
+  border-right-width: 4px;
+}
+
+.active\\\\:border-r-8:active {
+  border-right-width: 8px;
+}
+
+.active\\\\:border-r:active {
+  border-right-width: 1px;
+}
+
+.active\\\\:border-b-0:active {
+  border-bottom-width: 0px;
+}
+
+.active\\\\:border-b-2:active {
+  border-bottom-width: 2px;
+}
+
+.active\\\\:border-b-4:active {
+  border-bottom-width: 4px;
+}
+
+.active\\\\:border-b-8:active {
+  border-bottom-width: 8px;
+}
+
+.active\\\\:border-b:active {
+  border-bottom-width: 1px;
+}
+
+.active\\\\:border-l-0:active {
+  border-left-width: 0px;
+}
+
+.active\\\\:border-l-2:active {
+  border-left-width: 2px;
+}
+
+.active\\\\:border-l-4:active {
+  border-left-width: 4px;
+}
+
+.active\\\\:border-l-8:active {
+  border-left-width: 8px;
+}
+
+.active\\\\:border-l:active {
+  border-left-width: 1px;
+}
+
+.border-solid {
+  border-style: solid;
+}
+
+.border-dashed {
+  border-style: dashed;
+}
+
+.border-dotted {
+  border-style: dotted;
+}
+
+.border-double {
+  border-style: double;
+}
+
+.border-none {
+  border-style: none;
+}
+
+.border-current {
+  border-color: currentColor;
+}
+
+.border-transparent {
+  border-color: transparent;
+}
+
+.border-falcon {
+  border-color: var(--falcon);
+}
+
+.border-basement {
+  border-color: var(--basement);
+}
+
+.border-blue {
+  border-color: var(--blue);
+}
+
+.border-body-and-labels {
+  border-color: var(--body-and-labels);
+}
+
+.border-brand {
+  border-color: var(--brand);
+}
+
+.border-code-base-64 {
+  border-color: var(--code-base-64);
+}
+
+.border-code-bg {
+  border-color: var(--code-bg);
+}
+
+.border-code-outline {
+  border-color: var(--code-outline);
+}
+
+.border-code-text {
+  border-color: var(--code-text);
+}
+
+.border-critical {
+  border-color: var(--critical);
+}
+
+.border-destructive-hover {
+  border-color: var(--destructive-hover);
+}
+
+.border-destructive-idle {
+  border-color: var(--destructive-idle);
+}
+
+.border-destructive-pressed {
+  border-color: var(--destructive-pressed);
+}
+
+.border-disabled {
+  border-color: var(--disabled);
+}
+
+.border-disc-operations {
+  border-color: var(--disc-operations);
+}
+
+.border-dns-requests {
+  border-color: var(--dns-requests);
+}
+
+.border-focus {
+  border-color: var(--focus);
+}
+
+.border-graph-1 {
+  border-color: var(--graph-1);
+}
+
+.border-graph-10 {
+  border-color: var(--graph-10);
+}
+
+.border-graph-11 {
+  border-color: var(--graph-11);
+}
+
+.border-graph-2 {
+  border-color: var(--graph-2);
+}
+
+.border-graph-3 {
+  border-color: var(--graph-3);
+}
+
+.border-graph-4 {
+  border-color: var(--graph-4);
+}
+
+.border-graph-5 {
+  border-color: var(--graph-5);
+}
+
+.border-graph-6 {
+  border-color: var(--graph-6);
+}
+
+.border-graph-7 {
+  border-color: var(--graph-7);
+}
+
+.border-graph-8 {
+  border-color: var(--graph-8);
+}
+
+.border-graph-9 {
+  border-color: var(--graph-9);
+}
+
+.border-graph-disabled {
+  border-color: var(--graph-disabled);
+}
+
+.border-ground-floor {
+  border-color: var(--ground-floor);
+}
+
+.border-high {
+  border-color: var(--high);
+}
+
+.border-informational {
+  border-color: var(--informational);
+}
+
+.border-lines-dark {
+  border-color: var(--lines-dark);
+}
+
+.border-lines-light {
+  border-color: var(--lines-light);
+}
+
+.border-low {
+  border-color: var(--low);
+}
+
+.border-medium {
+  border-color: var(--medium);
+}
+
+.border-mezzanine {
+  border-color: var(--mezzanine);
+}
+
+.border-nav-text-and-icons {
+  border-color: var(--nav-text-and-icons);
+}
+
+.border-nav-text-secondary {
+  border-color: var(--nav-text-secondary);
+}
+
+.border-network-operations {
+  border-color: var(--network-operations);
+}
+
+.border-normal-hover {
+  border-color: var(--normal-hover);
+}
+
+.border-normal-idle {
+  border-color: var(--normal-idle);
+}
+
+.border-normal-pressed {
+  border-color: var(--normal-pressed);
+}
+
+.border-overlay-0\\\\.5 {
+  border-color: var(--overlay-0\\\\.5);
+}
+
+.border-overlay-1 {
+  border-color: var(--overlay-1);
+}
+
+.border-overlay-2 {
+  border-color: var(--overlay-2);
+}
+
+.border-positive {
+  border-color: var(--positive);
+}
+
+.border-primary-hover {
+  border-color: var(--primary-hover);
+}
+
+.border-primary-idle {
+  border-color: var(--primary-idle);
+}
+
+.border-primary-pressed {
+  border-color: var(--primary-pressed);
+}
+
+.border-process-operations {
+  border-color: var(--process-operations);
+}
+
+.border-purple {
+  border-color: var(--purple);
+}
+
+.border-registry-operations {
+  border-color: var(--registry-operations);
+}
+
+.border-selected {
+  border-color: var(--selected);
+}
+
+.border-surface-2xl {
+  border-color: var(--surface-2xl);
+}
+
+.border-surface-base {
+  border-color: var(--surface-base);
+}
+
+.border-surface-inner {
+  border-color: var(--surface-inner);
+}
+
+.border-surface-lg {
+  border-color: var(--surface-lg);
+}
+
+.border-surface-md {
+  border-color: var(--surface-md);
+}
+
+.border-surface-xl {
+  border-color: var(--surface-xl);
+}
+
+.border-text-and-icons {
+  border-color: var(--text-and-icons);
+}
+
+.border-titles-and-attributes {
+  border-color: var(--titles-and-attributes);
+}
+
+.hover\\\\:border-current:hover {
+  border-color: currentColor;
+}
+
+.hover\\\\:border-transparent:hover {
+  border-color: transparent;
+}
+
+.hover\\\\:border-falcon:hover {
+  border-color: var(--falcon);
+}
+
+.hover\\\\:border-basement:hover {
+  border-color: var(--basement);
+}
+
+.hover\\\\:border-blue:hover {
+  border-color: var(--blue);
+}
+
+.hover\\\\:border-body-and-labels:hover {
+  border-color: var(--body-and-labels);
+}
+
+.hover\\\\:border-brand:hover {
+  border-color: var(--brand);
+}
+
+.hover\\\\:border-code-base-64:hover {
+  border-color: var(--code-base-64);
+}
+
+.hover\\\\:border-code-bg:hover {
+  border-color: var(--code-bg);
+}
+
+.hover\\\\:border-code-outline:hover {
+  border-color: var(--code-outline);
+}
+
+.hover\\\\:border-code-text:hover {
+  border-color: var(--code-text);
+}
+
+.hover\\\\:border-critical:hover {
+  border-color: var(--critical);
+}
+
+.hover\\\\:border-destructive-hover:hover {
+  border-color: var(--destructive-hover);
+}
+
+.hover\\\\:border-destructive-idle:hover {
+  border-color: var(--destructive-idle);
+}
+
+.hover\\\\:border-destructive-pressed:hover {
+  border-color: var(--destructive-pressed);
+}
+
+.hover\\\\:border-disabled:hover {
+  border-color: var(--disabled);
+}
+
+.hover\\\\:border-disc-operations:hover {
+  border-color: var(--disc-operations);
+}
+
+.hover\\\\:border-dns-requests:hover {
+  border-color: var(--dns-requests);
+}
+
+.hover\\\\:border-focus:hover {
+  border-color: var(--focus);
+}
+
+.hover\\\\:border-graph-1:hover {
+  border-color: var(--graph-1);
+}
+
+.hover\\\\:border-graph-10:hover {
+  border-color: var(--graph-10);
+}
+
+.hover\\\\:border-graph-11:hover {
+  border-color: var(--graph-11);
+}
+
+.hover\\\\:border-graph-2:hover {
+  border-color: var(--graph-2);
+}
+
+.hover\\\\:border-graph-3:hover {
+  border-color: var(--graph-3);
+}
+
+.hover\\\\:border-graph-4:hover {
+  border-color: var(--graph-4);
+}
+
+.hover\\\\:border-graph-5:hover {
+  border-color: var(--graph-5);
+}
+
+.hover\\\\:border-graph-6:hover {
+  border-color: var(--graph-6);
+}
+
+.hover\\\\:border-graph-7:hover {
+  border-color: var(--graph-7);
+}
+
+.hover\\\\:border-graph-8:hover {
+  border-color: var(--graph-8);
+}
+
+.hover\\\\:border-graph-9:hover {
+  border-color: var(--graph-9);
+}
+
+.hover\\\\:border-graph-disabled:hover {
+  border-color: var(--graph-disabled);
+}
+
+.hover\\\\:border-ground-floor:hover {
+  border-color: var(--ground-floor);
+}
+
+.hover\\\\:border-high:hover {
+  border-color: var(--high);
+}
+
+.hover\\\\:border-informational:hover {
+  border-color: var(--informational);
+}
+
+.hover\\\\:border-lines-dark:hover {
+  border-color: var(--lines-dark);
+}
+
+.hover\\\\:border-lines-light:hover {
+  border-color: var(--lines-light);
+}
+
+.hover\\\\:border-low:hover {
+  border-color: var(--low);
+}
+
+.hover\\\\:border-medium:hover {
+  border-color: var(--medium);
+}
+
+.hover\\\\:border-mezzanine:hover {
+  border-color: var(--mezzanine);
+}
+
+.hover\\\\:border-nav-text-and-icons:hover {
+  border-color: var(--nav-text-and-icons);
+}
+
+.hover\\\\:border-nav-text-secondary:hover {
+  border-color: var(--nav-text-secondary);
+}
+
+.hover\\\\:border-network-operations:hover {
+  border-color: var(--network-operations);
+}
+
+.hover\\\\:border-normal-hover:hover {
+  border-color: var(--normal-hover);
+}
+
+.hover\\\\:border-normal-idle:hover {
+  border-color: var(--normal-idle);
+}
+
+.hover\\\\:border-normal-pressed:hover {
+  border-color: var(--normal-pressed);
+}
+
+.hover\\\\:border-overlay-0\\\\.5:hover {
+  border-color: var(--overlay-0\\\\.5);
+}
+
+.hover\\\\:border-overlay-1:hover {
+  border-color: var(--overlay-1);
+}
+
+.hover\\\\:border-overlay-2:hover {
+  border-color: var(--overlay-2);
+}
+
+.hover\\\\:border-positive:hover {
+  border-color: var(--positive);
+}
+
+.hover\\\\:border-primary-hover:hover {
+  border-color: var(--primary-hover);
+}
+
+.hover\\\\:border-primary-idle:hover {
+  border-color: var(--primary-idle);
+}
+
+.hover\\\\:border-primary-pressed:hover {
+  border-color: var(--primary-pressed);
+}
+
+.hover\\\\:border-process-operations:hover {
+  border-color: var(--process-operations);
+}
+
+.hover\\\\:border-purple:hover {
+  border-color: var(--purple);
+}
+
+.hover\\\\:border-registry-operations:hover {
+  border-color: var(--registry-operations);
+}
+
+.hover\\\\:border-selected:hover {
+  border-color: var(--selected);
+}
+
+.hover\\\\:border-surface-2xl:hover {
+  border-color: var(--surface-2xl);
+}
+
+.hover\\\\:border-surface-base:hover {
+  border-color: var(--surface-base);
+}
+
+.hover\\\\:border-surface-inner:hover {
+  border-color: var(--surface-inner);
+}
+
+.hover\\\\:border-surface-lg:hover {
+  border-color: var(--surface-lg);
+}
+
+.hover\\\\:border-surface-md:hover {
+  border-color: var(--surface-md);
+}
+
+.hover\\\\:border-surface-xl:hover {
+  border-color: var(--surface-xl);
+}
+
+.hover\\\\:border-text-and-icons:hover {
+  border-color: var(--text-and-icons);
+}
+
+.hover\\\\:border-titles-and-attributes:hover {
+  border-color: var(--titles-and-attributes);
+}
+
+.active\\\\:border-current:active {
+  border-color: currentColor;
+}
+
+.active\\\\:border-transparent:active {
+  border-color: transparent;
+}
+
+.active\\\\:border-falcon:active {
+  border-color: var(--falcon);
+}
+
+.active\\\\:border-basement:active {
+  border-color: var(--basement);
+}
+
+.active\\\\:border-blue:active {
+  border-color: var(--blue);
+}
+
+.active\\\\:border-body-and-labels:active {
+  border-color: var(--body-and-labels);
+}
+
+.active\\\\:border-brand:active {
+  border-color: var(--brand);
+}
+
+.active\\\\:border-code-base-64:active {
+  border-color: var(--code-base-64);
+}
+
+.active\\\\:border-code-bg:active {
+  border-color: var(--code-bg);
+}
+
+.active\\\\:border-code-outline:active {
+  border-color: var(--code-outline);
+}
+
+.active\\\\:border-code-text:active {
+  border-color: var(--code-text);
+}
+
+.active\\\\:border-critical:active {
+  border-color: var(--critical);
+}
+
+.active\\\\:border-destructive-hover:active {
+  border-color: var(--destructive-hover);
+}
+
+.active\\\\:border-destructive-idle:active {
+  border-color: var(--destructive-idle);
+}
+
+.active\\\\:border-destructive-pressed:active {
+  border-color: var(--destructive-pressed);
+}
+
+.active\\\\:border-disabled:active {
+  border-color: var(--disabled);
+}
+
+.active\\\\:border-disc-operations:active {
+  border-color: var(--disc-operations);
+}
+
+.active\\\\:border-dns-requests:active {
+  border-color: var(--dns-requests);
+}
+
+.active\\\\:border-focus:active {
+  border-color: var(--focus);
+}
+
+.active\\\\:border-graph-1:active {
+  border-color: var(--graph-1);
+}
+
+.active\\\\:border-graph-10:active {
+  border-color: var(--graph-10);
+}
+
+.active\\\\:border-graph-11:active {
+  border-color: var(--graph-11);
+}
+
+.active\\\\:border-graph-2:active {
+  border-color: var(--graph-2);
+}
+
+.active\\\\:border-graph-3:active {
+  border-color: var(--graph-3);
+}
+
+.active\\\\:border-graph-4:active {
+  border-color: var(--graph-4);
+}
+
+.active\\\\:border-graph-5:active {
+  border-color: var(--graph-5);
+}
+
+.active\\\\:border-graph-6:active {
+  border-color: var(--graph-6);
+}
+
+.active\\\\:border-graph-7:active {
+  border-color: var(--graph-7);
+}
+
+.active\\\\:border-graph-8:active {
+  border-color: var(--graph-8);
+}
+
+.active\\\\:border-graph-9:active {
+  border-color: var(--graph-9);
+}
+
+.active\\\\:border-graph-disabled:active {
+  border-color: var(--graph-disabled);
+}
+
+.active\\\\:border-ground-floor:active {
+  border-color: var(--ground-floor);
+}
+
+.active\\\\:border-high:active {
+  border-color: var(--high);
+}
+
+.active\\\\:border-informational:active {
+  border-color: var(--informational);
+}
+
+.active\\\\:border-lines-dark:active {
+  border-color: var(--lines-dark);
+}
+
+.active\\\\:border-lines-light:active {
+  border-color: var(--lines-light);
+}
+
+.active\\\\:border-low:active {
+  border-color: var(--low);
+}
+
+.active\\\\:border-medium:active {
+  border-color: var(--medium);
+}
+
+.active\\\\:border-mezzanine:active {
+  border-color: var(--mezzanine);
+}
+
+.active\\\\:border-nav-text-and-icons:active {
+  border-color: var(--nav-text-and-icons);
+}
+
+.active\\\\:border-nav-text-secondary:active {
+  border-color: var(--nav-text-secondary);
+}
+
+.active\\\\:border-network-operations:active {
+  border-color: var(--network-operations);
+}
+
+.active\\\\:border-normal-hover:active {
+  border-color: var(--normal-hover);
+}
+
+.active\\\\:border-normal-idle:active {
+  border-color: var(--normal-idle);
+}
+
+.active\\\\:border-normal-pressed:active {
+  border-color: var(--normal-pressed);
+}
+
+.active\\\\:border-overlay-0\\\\.5:active {
+  border-color: var(--overlay-0\\\\.5);
+}
+
+.active\\\\:border-overlay-1:active {
+  border-color: var(--overlay-1);
+}
+
+.active\\\\:border-overlay-2:active {
+  border-color: var(--overlay-2);
+}
+
+.active\\\\:border-positive:active {
+  border-color: var(--positive);
+}
+
+.active\\\\:border-primary-hover:active {
+  border-color: var(--primary-hover);
+}
+
+.active\\\\:border-primary-idle:active {
+  border-color: var(--primary-idle);
+}
+
+.active\\\\:border-primary-pressed:active {
+  border-color: var(--primary-pressed);
+}
+
+.active\\\\:border-process-operations:active {
+  border-color: var(--process-operations);
+}
+
+.active\\\\:border-purple:active {
+  border-color: var(--purple);
+}
+
+.active\\\\:border-registry-operations:active {
+  border-color: var(--registry-operations);
+}
+
+.active\\\\:border-selected:active {
+  border-color: var(--selected);
+}
+
+.active\\\\:border-surface-2xl:active {
+  border-color: var(--surface-2xl);
+}
+
+.active\\\\:border-surface-base:active {
+  border-color: var(--surface-base);
+}
+
+.active\\\\:border-surface-inner:active {
+  border-color: var(--surface-inner);
+}
+
+.active\\\\:border-surface-lg:active {
+  border-color: var(--surface-lg);
+}
+
+.active\\\\:border-surface-md:active {
+  border-color: var(--surface-md);
+}
+
+.active\\\\:border-surface-xl:active {
+  border-color: var(--surface-xl);
+}
+
+.active\\\\:border-text-and-icons:active {
+  border-color: var(--text-and-icons);
+}
+
+.active\\\\:border-titles-and-attributes:active {
+  border-color: var(--titles-and-attributes);
+}
+
+.border-opacity-0 {
+  --tw-border-opacity: 0;
+}
+
+.border-opacity-5 {
+  --tw-border-opacity: 0.05;
+}
+
+.border-opacity-10 {
+  --tw-border-opacity: 0.1;
+}
+
+.border-opacity-20 {
+  --tw-border-opacity: 0.2;
+}
+
+.border-opacity-25 {
+  --tw-border-opacity: 0.25;
+}
+
+.border-opacity-30 {
+  --tw-border-opacity: 0.3;
+}
+
+.border-opacity-40 {
+  --tw-border-opacity: 0.4;
+}
+
+.border-opacity-50 {
+  --tw-border-opacity: 0.5;
+}
+
+.border-opacity-60 {
+  --tw-border-opacity: 0.6;
+}
+
+.border-opacity-70 {
+  --tw-border-opacity: 0.7;
+}
+
+.border-opacity-75 {
+  --tw-border-opacity: 0.75;
+}
+
+.border-opacity-80 {
+  --tw-border-opacity: 0.8;
+}
+
+.border-opacity-90 {
+  --tw-border-opacity: 0.9;
+}
+
+.border-opacity-95 {
+  --tw-border-opacity: 0.95;
+}
+
+.border-opacity-100 {
+  --tw-border-opacity: 1;
+}
+
+.hover\\\\:border-opacity-0:hover {
+  --tw-border-opacity: 0;
+}
+
+.hover\\\\:border-opacity-5:hover {
+  --tw-border-opacity: 0.05;
+}
+
+.hover\\\\:border-opacity-10:hover {
+  --tw-border-opacity: 0.1;
+}
+
+.hover\\\\:border-opacity-20:hover {
+  --tw-border-opacity: 0.2;
+}
+
+.hover\\\\:border-opacity-25:hover {
+  --tw-border-opacity: 0.25;
+}
+
+.hover\\\\:border-opacity-30:hover {
+  --tw-border-opacity: 0.3;
+}
+
+.hover\\\\:border-opacity-40:hover {
+  --tw-border-opacity: 0.4;
+}
+
+.hover\\\\:border-opacity-50:hover {
+  --tw-border-opacity: 0.5;
+}
+
+.hover\\\\:border-opacity-60:hover {
+  --tw-border-opacity: 0.6;
+}
+
+.hover\\\\:border-opacity-70:hover {
+  --tw-border-opacity: 0.7;
+}
+
+.hover\\\\:border-opacity-75:hover {
+  --tw-border-opacity: 0.75;
+}
+
+.hover\\\\:border-opacity-80:hover {
+  --tw-border-opacity: 0.8;
+}
+
+.hover\\\\:border-opacity-90:hover {
+  --tw-border-opacity: 0.9;
+}
+
+.hover\\\\:border-opacity-95:hover {
+  --tw-border-opacity: 0.95;
+}
+
+.hover\\\\:border-opacity-100:hover {
+  --tw-border-opacity: 1;
+}
+
+.focus\\\\:border-opacity-0:focus {
+  --tw-border-opacity: 0;
+}
+
+.focus\\\\:border-opacity-5:focus {
+  --tw-border-opacity: 0.05;
+}
+
+.focus\\\\:border-opacity-10:focus {
+  --tw-border-opacity: 0.1;
+}
+
+.focus\\\\:border-opacity-20:focus {
+  --tw-border-opacity: 0.2;
+}
+
+.focus\\\\:border-opacity-25:focus {
+  --tw-border-opacity: 0.25;
+}
+
+.focus\\\\:border-opacity-30:focus {
+  --tw-border-opacity: 0.3;
+}
+
+.focus\\\\:border-opacity-40:focus {
+  --tw-border-opacity: 0.4;
+}
+
+.focus\\\\:border-opacity-50:focus {
+  --tw-border-opacity: 0.5;
+}
+
+.focus\\\\:border-opacity-60:focus {
+  --tw-border-opacity: 0.6;
+}
+
+.focus\\\\:border-opacity-70:focus {
+  --tw-border-opacity: 0.7;
+}
+
+.focus\\\\:border-opacity-75:focus {
+  --tw-border-opacity: 0.75;
+}
+
+.focus\\\\:border-opacity-80:focus {
+  --tw-border-opacity: 0.8;
+}
+
+.focus\\\\:border-opacity-90:focus {
+  --tw-border-opacity: 0.9;
+}
+
+.focus\\\\:border-opacity-95:focus {
+  --tw-border-opacity: 0.95;
+}
+
+.focus\\\\:border-opacity-100:focus {
+  --tw-border-opacity: 1;
+}
+
+.bg-current {
+  background-color: currentColor;
+}
+
+.bg-transparent {
+  background-color: transparent;
+}
+
+.bg-falcon {
+  background-color: var(--falcon);
+}
+
+.bg-basement {
+  background-color: var(--basement);
+}
+
+.bg-blue {
+  background-color: var(--blue);
+}
+
+.bg-body-and-labels {
+  background-color: var(--body-and-labels);
+}
+
+.bg-brand {
+  background-color: var(--brand);
+}
+
+.bg-code-base-64 {
+  background-color: var(--code-base-64);
+}
+
+.bg-code-bg {
+  background-color: var(--code-bg);
+}
+
+.bg-code-outline {
+  background-color: var(--code-outline);
+}
+
+.bg-code-text {
+  background-color: var(--code-text);
+}
+
+.bg-critical {
+  background-color: var(--critical);
+}
+
+.bg-destructive-hover {
+  background-color: var(--destructive-hover);
+}
+
+.bg-destructive-idle {
+  background-color: var(--destructive-idle);
+}
+
+.bg-destructive-pressed {
+  background-color: var(--destructive-pressed);
+}
+
+.bg-disabled {
+  background-color: var(--disabled);
+}
+
+.bg-disc-operations {
+  background-color: var(--disc-operations);
+}
+
+.bg-dns-requests {
+  background-color: var(--dns-requests);
+}
+
+.bg-focus {
+  background-color: var(--focus);
+}
+
+.bg-graph-1 {
+  background-color: var(--graph-1);
+}
+
+.bg-graph-10 {
+  background-color: var(--graph-10);
+}
+
+.bg-graph-11 {
+  background-color: var(--graph-11);
+}
+
+.bg-graph-2 {
+  background-color: var(--graph-2);
+}
+
+.bg-graph-3 {
+  background-color: var(--graph-3);
+}
+
+.bg-graph-4 {
+  background-color: var(--graph-4);
+}
+
+.bg-graph-5 {
+  background-color: var(--graph-5);
+}
+
+.bg-graph-6 {
+  background-color: var(--graph-6);
+}
+
+.bg-graph-7 {
+  background-color: var(--graph-7);
+}
+
+.bg-graph-8 {
+  background-color: var(--graph-8);
+}
+
+.bg-graph-9 {
+  background-color: var(--graph-9);
+}
+
+.bg-graph-disabled {
+  background-color: var(--graph-disabled);
+}
+
+.bg-ground-floor {
+  background-color: var(--ground-floor);
+}
+
+.bg-high {
+  background-color: var(--high);
+}
+
+.bg-informational {
+  background-color: var(--informational);
+}
+
+.bg-lines-dark {
+  background-color: var(--lines-dark);
+}
+
+.bg-lines-light {
+  background-color: var(--lines-light);
+}
+
+.bg-low {
+  background-color: var(--low);
+}
+
+.bg-medium {
+  background-color: var(--medium);
+}
+
+.bg-mezzanine {
+  background-color: var(--mezzanine);
+}
+
+.bg-nav-text-and-icons {
+  background-color: var(--nav-text-and-icons);
+}
+
+.bg-nav-text-secondary {
+  background-color: var(--nav-text-secondary);
+}
+
+.bg-network-operations {
+  background-color: var(--network-operations);
+}
+
+.bg-normal-hover {
+  background-color: var(--normal-hover);
+}
+
+.bg-normal-idle {
+  background-color: var(--normal-idle);
+}
+
+.bg-normal-pressed {
+  background-color: var(--normal-pressed);
+}
+
+.bg-overlay-0\\\\.5 {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.bg-overlay-1 {
+  background-color: var(--overlay-1);
+}
+
+.bg-overlay-2 {
+  background-color: var(--overlay-2);
+}
+
+.bg-positive {
+  background-color: var(--positive);
+}
+
+.bg-primary-hover {
+  background-color: var(--primary-hover);
+}
+
+.bg-primary-idle {
+  background-color: var(--primary-idle);
+}
+
+.bg-primary-pressed {
+  background-color: var(--primary-pressed);
+}
+
+.bg-process-operations {
+  background-color: var(--process-operations);
+}
+
+.bg-purple {
+  background-color: var(--purple);
+}
+
+.bg-registry-operations {
+  background-color: var(--registry-operations);
+}
+
+.bg-selected {
+  background-color: var(--selected);
+}
+
+.bg-surface-2xl {
+  background-color: var(--surface-2xl);
+}
+
+.bg-surface-base {
+  background-color: var(--surface-base);
+}
+
+.bg-surface-inner {
+  background-color: var(--surface-inner);
+}
+
+.bg-surface-lg {
+  background-color: var(--surface-lg);
+}
+
+.bg-surface-md {
+  background-color: var(--surface-md);
+}
+
+.bg-surface-xl {
+  background-color: var(--surface-xl);
+}
+
+.bg-text-and-icons {
+  background-color: var(--text-and-icons);
+}
+
+.bg-titles-and-attributes {
+  background-color: var(--titles-and-attributes);
+}
+
+.even\\\\:bg-current:nth-child(even) {
+  background-color: currentColor;
+}
+
+.even\\\\:bg-transparent:nth-child(even) {
+  background-color: transparent;
+}
+
+.even\\\\:bg-falcon:nth-child(even) {
+  background-color: var(--falcon);
+}
+
+.even\\\\:bg-basement:nth-child(even) {
+  background-color: var(--basement);
+}
+
+.even\\\\:bg-blue:nth-child(even) {
+  background-color: var(--blue);
+}
+
+.even\\\\:bg-body-and-labels:nth-child(even) {
+  background-color: var(--body-and-labels);
+}
+
+.even\\\\:bg-brand:nth-child(even) {
+  background-color: var(--brand);
+}
+
+.even\\\\:bg-code-base-64:nth-child(even) {
+  background-color: var(--code-base-64);
+}
+
+.even\\\\:bg-code-bg:nth-child(even) {
+  background-color: var(--code-bg);
+}
+
+.even\\\\:bg-code-outline:nth-child(even) {
+  background-color: var(--code-outline);
+}
+
+.even\\\\:bg-code-text:nth-child(even) {
+  background-color: var(--code-text);
+}
+
+.even\\\\:bg-critical:nth-child(even) {
+  background-color: var(--critical);
+}
+
+.even\\\\:bg-destructive-hover:nth-child(even) {
+  background-color: var(--destructive-hover);
+}
+
+.even\\\\:bg-destructive-idle:nth-child(even) {
+  background-color: var(--destructive-idle);
+}
+
+.even\\\\:bg-destructive-pressed:nth-child(even) {
+  background-color: var(--destructive-pressed);
+}
+
+.even\\\\:bg-disabled:nth-child(even) {
+  background-color: var(--disabled);
+}
+
+.even\\\\:bg-disc-operations:nth-child(even) {
+  background-color: var(--disc-operations);
+}
+
+.even\\\\:bg-dns-requests:nth-child(even) {
+  background-color: var(--dns-requests);
+}
+
+.even\\\\:bg-focus:nth-child(even) {
+  background-color: var(--focus);
+}
+
+.even\\\\:bg-graph-1:nth-child(even) {
+  background-color: var(--graph-1);
+}
+
+.even\\\\:bg-graph-10:nth-child(even) {
+  background-color: var(--graph-10);
+}
+
+.even\\\\:bg-graph-11:nth-child(even) {
+  background-color: var(--graph-11);
+}
+
+.even\\\\:bg-graph-2:nth-child(even) {
+  background-color: var(--graph-2);
+}
+
+.even\\\\:bg-graph-3:nth-child(even) {
+  background-color: var(--graph-3);
+}
+
+.even\\\\:bg-graph-4:nth-child(even) {
+  background-color: var(--graph-4);
+}
+
+.even\\\\:bg-graph-5:nth-child(even) {
+  background-color: var(--graph-5);
+}
+
+.even\\\\:bg-graph-6:nth-child(even) {
+  background-color: var(--graph-6);
+}
+
+.even\\\\:bg-graph-7:nth-child(even) {
+  background-color: var(--graph-7);
+}
+
+.even\\\\:bg-graph-8:nth-child(even) {
+  background-color: var(--graph-8);
+}
+
+.even\\\\:bg-graph-9:nth-child(even) {
+  background-color: var(--graph-9);
+}
+
+.even\\\\:bg-graph-disabled:nth-child(even) {
+  background-color: var(--graph-disabled);
+}
+
+.even\\\\:bg-ground-floor:nth-child(even) {
+  background-color: var(--ground-floor);
+}
+
+.even\\\\:bg-high:nth-child(even) {
+  background-color: var(--high);
+}
+
+.even\\\\:bg-informational:nth-child(even) {
+  background-color: var(--informational);
+}
+
+.even\\\\:bg-lines-dark:nth-child(even) {
+  background-color: var(--lines-dark);
+}
+
+.even\\\\:bg-lines-light:nth-child(even) {
+  background-color: var(--lines-light);
+}
+
+.even\\\\:bg-low:nth-child(even) {
+  background-color: var(--low);
+}
+
+.even\\\\:bg-medium:nth-child(even) {
+  background-color: var(--medium);
+}
+
+.even\\\\:bg-mezzanine:nth-child(even) {
+  background-color: var(--mezzanine);
+}
+
+.even\\\\:bg-nav-text-and-icons:nth-child(even) {
+  background-color: var(--nav-text-and-icons);
+}
+
+.even\\\\:bg-nav-text-secondary:nth-child(even) {
+  background-color: var(--nav-text-secondary);
+}
+
+.even\\\\:bg-network-operations:nth-child(even) {
+  background-color: var(--network-operations);
+}
+
+.even\\\\:bg-normal-hover:nth-child(even) {
+  background-color: var(--normal-hover);
+}
+
+.even\\\\:bg-normal-idle:nth-child(even) {
+  background-color: var(--normal-idle);
+}
+
+.even\\\\:bg-normal-pressed:nth-child(even) {
+  background-color: var(--normal-pressed);
+}
+
+.even\\\\:bg-overlay-0\\\\.5:nth-child(even) {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.even\\\\:bg-overlay-1:nth-child(even) {
+  background-color: var(--overlay-1);
+}
+
+.even\\\\:bg-overlay-2:nth-child(even) {
+  background-color: var(--overlay-2);
+}
+
+.even\\\\:bg-positive:nth-child(even) {
+  background-color: var(--positive);
+}
+
+.even\\\\:bg-primary-hover:nth-child(even) {
+  background-color: var(--primary-hover);
+}
+
+.even\\\\:bg-primary-idle:nth-child(even) {
+  background-color: var(--primary-idle);
+}
+
+.even\\\\:bg-primary-pressed:nth-child(even) {
+  background-color: var(--primary-pressed);
+}
+
+.even\\\\:bg-process-operations:nth-child(even) {
+  background-color: var(--process-operations);
+}
+
+.even\\\\:bg-purple:nth-child(even) {
+  background-color: var(--purple);
+}
+
+.even\\\\:bg-registry-operations:nth-child(even) {
+  background-color: var(--registry-operations);
+}
+
+.even\\\\:bg-selected:nth-child(even) {
+  background-color: var(--selected);
+}
+
+.even\\\\:bg-surface-2xl:nth-child(even) {
+  background-color: var(--surface-2xl);
+}
+
+.even\\\\:bg-surface-base:nth-child(even) {
+  background-color: var(--surface-base);
+}
+
+.even\\\\:bg-surface-inner:nth-child(even) {
+  background-color: var(--surface-inner);
+}
+
+.even\\\\:bg-surface-lg:nth-child(even) {
+  background-color: var(--surface-lg);
+}
+
+.even\\\\:bg-surface-md:nth-child(even) {
+  background-color: var(--surface-md);
+}
+
+.even\\\\:bg-surface-xl:nth-child(even) {
+  background-color: var(--surface-xl);
+}
+
+.even\\\\:bg-text-and-icons:nth-child(even) {
+  background-color: var(--text-and-icons);
+}
+
+.even\\\\:bg-titles-and-attributes:nth-child(even) {
+  background-color: var(--titles-and-attributes);
+}
+
+.group:hover .group-hover\\\\:bg-current {
+  background-color: currentColor;
+}
+
+.group:hover .group-hover\\\\:bg-transparent {
+  background-color: transparent;
+}
+
+.group:hover .group-hover\\\\:bg-falcon {
+  background-color: var(--falcon);
+}
+
+.group:hover .group-hover\\\\:bg-basement {
+  background-color: var(--basement);
+}
+
+.group:hover .group-hover\\\\:bg-blue {
+  background-color: var(--blue);
+}
+
+.group:hover .group-hover\\\\:bg-body-and-labels {
+  background-color: var(--body-and-labels);
+}
+
+.group:hover .group-hover\\\\:bg-brand {
+  background-color: var(--brand);
+}
+
+.group:hover .group-hover\\\\:bg-code-base-64 {
+  background-color: var(--code-base-64);
+}
+
+.group:hover .group-hover\\\\:bg-code-bg {
+  background-color: var(--code-bg);
+}
+
+.group:hover .group-hover\\\\:bg-code-outline {
+  background-color: var(--code-outline);
+}
+
+.group:hover .group-hover\\\\:bg-code-text {
+  background-color: var(--code-text);
+}
+
+.group:hover .group-hover\\\\:bg-critical {
+  background-color: var(--critical);
+}
+
+.group:hover .group-hover\\\\:bg-destructive-hover {
+  background-color: var(--destructive-hover);
+}
+
+.group:hover .group-hover\\\\:bg-destructive-idle {
+  background-color: var(--destructive-idle);
+}
+
+.group:hover .group-hover\\\\:bg-destructive-pressed {
+  background-color: var(--destructive-pressed);
+}
+
+.group:hover .group-hover\\\\:bg-disabled {
+  background-color: var(--disabled);
+}
+
+.group:hover .group-hover\\\\:bg-disc-operations {
+  background-color: var(--disc-operations);
+}
+
+.group:hover .group-hover\\\\:bg-dns-requests {
+  background-color: var(--dns-requests);
+}
+
+.group:hover .group-hover\\\\:bg-focus {
+  background-color: var(--focus);
+}
+
+.group:hover .group-hover\\\\:bg-graph-1 {
+  background-color: var(--graph-1);
+}
+
+.group:hover .group-hover\\\\:bg-graph-10 {
+  background-color: var(--graph-10);
+}
+
+.group:hover .group-hover\\\\:bg-graph-11 {
+  background-color: var(--graph-11);
+}
+
+.group:hover .group-hover\\\\:bg-graph-2 {
+  background-color: var(--graph-2);
+}
+
+.group:hover .group-hover\\\\:bg-graph-3 {
+  background-color: var(--graph-3);
+}
+
+.group:hover .group-hover\\\\:bg-graph-4 {
+  background-color: var(--graph-4);
+}
+
+.group:hover .group-hover\\\\:bg-graph-5 {
+  background-color: var(--graph-5);
+}
+
+.group:hover .group-hover\\\\:bg-graph-6 {
+  background-color: var(--graph-6);
+}
+
+.group:hover .group-hover\\\\:bg-graph-7 {
+  background-color: var(--graph-7);
+}
+
+.group:hover .group-hover\\\\:bg-graph-8 {
+  background-color: var(--graph-8);
+}
+
+.group:hover .group-hover\\\\:bg-graph-9 {
+  background-color: var(--graph-9);
+}
+
+.group:hover .group-hover\\\\:bg-graph-disabled {
+  background-color: var(--graph-disabled);
+}
+
+.group:hover .group-hover\\\\:bg-ground-floor {
+  background-color: var(--ground-floor);
+}
+
+.group:hover .group-hover\\\\:bg-high {
+  background-color: var(--high);
+}
+
+.group:hover .group-hover\\\\:bg-informational {
+  background-color: var(--informational);
+}
+
+.group:hover .group-hover\\\\:bg-lines-dark {
+  background-color: var(--lines-dark);
+}
+
+.group:hover .group-hover\\\\:bg-lines-light {
+  background-color: var(--lines-light);
+}
+
+.group:hover .group-hover\\\\:bg-low {
+  background-color: var(--low);
+}
+
+.group:hover .group-hover\\\\:bg-medium {
+  background-color: var(--medium);
+}
+
+.group:hover .group-hover\\\\:bg-mezzanine {
+  background-color: var(--mezzanine);
+}
+
+.group:hover .group-hover\\\\:bg-nav-text-and-icons {
+  background-color: var(--nav-text-and-icons);
+}
+
+.group:hover .group-hover\\\\:bg-nav-text-secondary {
+  background-color: var(--nav-text-secondary);
+}
+
+.group:hover .group-hover\\\\:bg-network-operations {
+  background-color: var(--network-operations);
+}
+
+.group:hover .group-hover\\\\:bg-normal-hover {
+  background-color: var(--normal-hover);
+}
+
+.group:hover .group-hover\\\\:bg-normal-idle {
+  background-color: var(--normal-idle);
+}
+
+.group:hover .group-hover\\\\:bg-normal-pressed {
+  background-color: var(--normal-pressed);
+}
+
+.group:hover .group-hover\\\\:bg-overlay-0\\\\.5 {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.group:hover .group-hover\\\\:bg-overlay-1 {
+  background-color: var(--overlay-1);
+}
+
+.group:hover .group-hover\\\\:bg-overlay-2 {
+  background-color: var(--overlay-2);
+}
+
+.group:hover .group-hover\\\\:bg-positive {
+  background-color: var(--positive);
+}
+
+.group:hover .group-hover\\\\:bg-primary-hover {
+  background-color: var(--primary-hover);
+}
+
+.group:hover .group-hover\\\\:bg-primary-idle {
+  background-color: var(--primary-idle);
+}
+
+.group:hover .group-hover\\\\:bg-primary-pressed {
+  background-color: var(--primary-pressed);
+}
+
+.group:hover .group-hover\\\\:bg-process-operations {
+  background-color: var(--process-operations);
+}
+
+.group:hover .group-hover\\\\:bg-purple {
+  background-color: var(--purple);
+}
+
+.group:hover .group-hover\\\\:bg-registry-operations {
+  background-color: var(--registry-operations);
+}
+
+.group:hover .group-hover\\\\:bg-selected {
+  background-color: var(--selected);
+}
+
+.group:hover .group-hover\\\\:bg-surface-2xl {
+  background-color: var(--surface-2xl);
+}
+
+.group:hover .group-hover\\\\:bg-surface-base {
+  background-color: var(--surface-base);
+}
+
+.group:hover .group-hover\\\\:bg-surface-inner {
+  background-color: var(--surface-inner);
+}
+
+.group:hover .group-hover\\\\:bg-surface-lg {
+  background-color: var(--surface-lg);
+}
+
+.group:hover .group-hover\\\\:bg-surface-md {
+  background-color: var(--surface-md);
+}
+
+.group:hover .group-hover\\\\:bg-surface-xl {
+  background-color: var(--surface-xl);
+}
+
+.group:hover .group-hover\\\\:bg-text-and-icons {
+  background-color: var(--text-and-icons);
+}
+
+.group:hover .group-hover\\\\:bg-titles-and-attributes {
+  background-color: var(--titles-and-attributes);
+}
+
+.hover\\\\:bg-current:hover {
+  background-color: currentColor;
+}
+
+.hover\\\\:bg-transparent:hover {
+  background-color: transparent;
+}
+
+.hover\\\\:bg-falcon:hover {
+  background-color: var(--falcon);
+}
+
+.hover\\\\:bg-basement:hover {
+  background-color: var(--basement);
+}
+
+.hover\\\\:bg-blue:hover {
+  background-color: var(--blue);
+}
+
+.hover\\\\:bg-body-and-labels:hover {
+  background-color: var(--body-and-labels);
+}
+
+.hover\\\\:bg-brand:hover {
+  background-color: var(--brand);
+}
+
+.hover\\\\:bg-code-base-64:hover {
+  background-color: var(--code-base-64);
+}
+
+.hover\\\\:bg-code-bg:hover {
+  background-color: var(--code-bg);
+}
+
+.hover\\\\:bg-code-outline:hover {
+  background-color: var(--code-outline);
+}
+
+.hover\\\\:bg-code-text:hover {
+  background-color: var(--code-text);
+}
+
+.hover\\\\:bg-critical:hover {
+  background-color: var(--critical);
+}
+
+.hover\\\\:bg-destructive-hover:hover {
+  background-color: var(--destructive-hover);
+}
+
+.hover\\\\:bg-destructive-idle:hover {
+  background-color: var(--destructive-idle);
+}
+
+.hover\\\\:bg-destructive-pressed:hover {
+  background-color: var(--destructive-pressed);
+}
+
+.hover\\\\:bg-disabled:hover {
+  background-color: var(--disabled);
+}
+
+.hover\\\\:bg-disc-operations:hover {
+  background-color: var(--disc-operations);
+}
+
+.hover\\\\:bg-dns-requests:hover {
+  background-color: var(--dns-requests);
+}
+
+.hover\\\\:bg-focus:hover {
+  background-color: var(--focus);
+}
+
+.hover\\\\:bg-graph-1:hover {
+  background-color: var(--graph-1);
+}
+
+.hover\\\\:bg-graph-10:hover {
+  background-color: var(--graph-10);
+}
+
+.hover\\\\:bg-graph-11:hover {
+  background-color: var(--graph-11);
+}
+
+.hover\\\\:bg-graph-2:hover {
+  background-color: var(--graph-2);
+}
+
+.hover\\\\:bg-graph-3:hover {
+  background-color: var(--graph-3);
+}
+
+.hover\\\\:bg-graph-4:hover {
+  background-color: var(--graph-4);
+}
+
+.hover\\\\:bg-graph-5:hover {
+  background-color: var(--graph-5);
+}
+
+.hover\\\\:bg-graph-6:hover {
+  background-color: var(--graph-6);
+}
+
+.hover\\\\:bg-graph-7:hover {
+  background-color: var(--graph-7);
+}
+
+.hover\\\\:bg-graph-8:hover {
+  background-color: var(--graph-8);
+}
+
+.hover\\\\:bg-graph-9:hover {
+  background-color: var(--graph-9);
+}
+
+.hover\\\\:bg-graph-disabled:hover {
+  background-color: var(--graph-disabled);
+}
+
+.hover\\\\:bg-ground-floor:hover {
+  background-color: var(--ground-floor);
+}
+
+.hover\\\\:bg-high:hover {
+  background-color: var(--high);
+}
+
+.hover\\\\:bg-informational:hover {
+  background-color: var(--informational);
+}
+
+.hover\\\\:bg-lines-dark:hover {
+  background-color: var(--lines-dark);
+}
+
+.hover\\\\:bg-lines-light:hover {
+  background-color: var(--lines-light);
+}
+
+.hover\\\\:bg-low:hover {
+  background-color: var(--low);
+}
+
+.hover\\\\:bg-medium:hover {
+  background-color: var(--medium);
+}
+
+.hover\\\\:bg-mezzanine:hover {
+  background-color: var(--mezzanine);
+}
+
+.hover\\\\:bg-nav-text-and-icons:hover {
+  background-color: var(--nav-text-and-icons);
+}
+
+.hover\\\\:bg-nav-text-secondary:hover {
+  background-color: var(--nav-text-secondary);
+}
+
+.hover\\\\:bg-network-operations:hover {
+  background-color: var(--network-operations);
+}
+
+.hover\\\\:bg-normal-hover:hover {
+  background-color: var(--normal-hover);
+}
+
+.hover\\\\:bg-normal-idle:hover {
+  background-color: var(--normal-idle);
+}
+
+.hover\\\\:bg-normal-pressed:hover {
+  background-color: var(--normal-pressed);
+}
+
+.hover\\\\:bg-overlay-0\\\\.5:hover {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.hover\\\\:bg-overlay-1:hover {
+  background-color: var(--overlay-1);
+}
+
+.hover\\\\:bg-overlay-2:hover {
+  background-color: var(--overlay-2);
+}
+
+.hover\\\\:bg-positive:hover {
+  background-color: var(--positive);
+}
+
+.hover\\\\:bg-primary-hover:hover {
+  background-color: var(--primary-hover);
+}
+
+.hover\\\\:bg-primary-idle:hover {
+  background-color: var(--primary-idle);
+}
+
+.hover\\\\:bg-primary-pressed:hover {
+  background-color: var(--primary-pressed);
+}
+
+.hover\\\\:bg-process-operations:hover {
+  background-color: var(--process-operations);
+}
+
+.hover\\\\:bg-purple:hover {
+  background-color: var(--purple);
+}
+
+.hover\\\\:bg-registry-operations:hover {
+  background-color: var(--registry-operations);
+}
+
+.hover\\\\:bg-selected:hover {
+  background-color: var(--selected);
+}
+
+.hover\\\\:bg-surface-2xl:hover {
+  background-color: var(--surface-2xl);
+}
+
+.hover\\\\:bg-surface-base:hover {
+  background-color: var(--surface-base);
+}
+
+.hover\\\\:bg-surface-inner:hover {
+  background-color: var(--surface-inner);
+}
+
+.hover\\\\:bg-surface-lg:hover {
+  background-color: var(--surface-lg);
+}
+
+.hover\\\\:bg-surface-md:hover {
+  background-color: var(--surface-md);
+}
+
+.hover\\\\:bg-surface-xl:hover {
+  background-color: var(--surface-xl);
+}
+
+.hover\\\\:bg-text-and-icons:hover {
+  background-color: var(--text-and-icons);
+}
+
+.hover\\\\:bg-titles-and-attributes:hover {
+  background-color: var(--titles-and-attributes);
+}
+
+.focus\\\\:bg-current:focus {
+  background-color: currentColor;
+}
+
+.focus\\\\:bg-transparent:focus {
+  background-color: transparent;
+}
+
+.focus\\\\:bg-falcon:focus {
+  background-color: var(--falcon);
+}
+
+.focus\\\\:bg-basement:focus {
+  background-color: var(--basement);
+}
+
+.focus\\\\:bg-blue:focus {
+  background-color: var(--blue);
+}
+
+.focus\\\\:bg-body-and-labels:focus {
+  background-color: var(--body-and-labels);
+}
+
+.focus\\\\:bg-brand:focus {
+  background-color: var(--brand);
+}
+
+.focus\\\\:bg-code-base-64:focus {
+  background-color: var(--code-base-64);
+}
+
+.focus\\\\:bg-code-bg:focus {
+  background-color: var(--code-bg);
+}
+
+.focus\\\\:bg-code-outline:focus {
+  background-color: var(--code-outline);
+}
+
+.focus\\\\:bg-code-text:focus {
+  background-color: var(--code-text);
+}
+
+.focus\\\\:bg-critical:focus {
+  background-color: var(--critical);
+}
+
+.focus\\\\:bg-destructive-hover:focus {
+  background-color: var(--destructive-hover);
+}
+
+.focus\\\\:bg-destructive-idle:focus {
+  background-color: var(--destructive-idle);
+}
+
+.focus\\\\:bg-destructive-pressed:focus {
+  background-color: var(--destructive-pressed);
+}
+
+.focus\\\\:bg-disabled:focus {
+  background-color: var(--disabled);
+}
+
+.focus\\\\:bg-disc-operations:focus {
+  background-color: var(--disc-operations);
+}
+
+.focus\\\\:bg-dns-requests:focus {
+  background-color: var(--dns-requests);
+}
+
+.focus\\\\:bg-focus:focus {
+  background-color: var(--focus);
+}
+
+.focus\\\\:bg-graph-1:focus {
+  background-color: var(--graph-1);
+}
+
+.focus\\\\:bg-graph-10:focus {
+  background-color: var(--graph-10);
+}
+
+.focus\\\\:bg-graph-11:focus {
+  background-color: var(--graph-11);
+}
+
+.focus\\\\:bg-graph-2:focus {
+  background-color: var(--graph-2);
+}
+
+.focus\\\\:bg-graph-3:focus {
+  background-color: var(--graph-3);
+}
+
+.focus\\\\:bg-graph-4:focus {
+  background-color: var(--graph-4);
+}
+
+.focus\\\\:bg-graph-5:focus {
+  background-color: var(--graph-5);
+}
+
+.focus\\\\:bg-graph-6:focus {
+  background-color: var(--graph-6);
+}
+
+.focus\\\\:bg-graph-7:focus {
+  background-color: var(--graph-7);
+}
+
+.focus\\\\:bg-graph-8:focus {
+  background-color: var(--graph-8);
+}
+
+.focus\\\\:bg-graph-9:focus {
+  background-color: var(--graph-9);
+}
+
+.focus\\\\:bg-graph-disabled:focus {
+  background-color: var(--graph-disabled);
+}
+
+.focus\\\\:bg-ground-floor:focus {
+  background-color: var(--ground-floor);
+}
+
+.focus\\\\:bg-high:focus {
+  background-color: var(--high);
+}
+
+.focus\\\\:bg-informational:focus {
+  background-color: var(--informational);
+}
+
+.focus\\\\:bg-lines-dark:focus {
+  background-color: var(--lines-dark);
+}
+
+.focus\\\\:bg-lines-light:focus {
+  background-color: var(--lines-light);
+}
+
+.focus\\\\:bg-low:focus {
+  background-color: var(--low);
+}
+
+.focus\\\\:bg-medium:focus {
+  background-color: var(--medium);
+}
+
+.focus\\\\:bg-mezzanine:focus {
+  background-color: var(--mezzanine);
+}
+
+.focus\\\\:bg-nav-text-and-icons:focus {
+  background-color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:bg-nav-text-secondary:focus {
+  background-color: var(--nav-text-secondary);
+}
+
+.focus\\\\:bg-network-operations:focus {
+  background-color: var(--network-operations);
+}
+
+.focus\\\\:bg-normal-hover:focus {
+  background-color: var(--normal-hover);
+}
+
+.focus\\\\:bg-normal-idle:focus {
+  background-color: var(--normal-idle);
+}
+
+.focus\\\\:bg-normal-pressed:focus {
+  background-color: var(--normal-pressed);
+}
+
+.focus\\\\:bg-overlay-0\\\\.5:focus {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:bg-overlay-1:focus {
+  background-color: var(--overlay-1);
+}
+
+.focus\\\\:bg-overlay-2:focus {
+  background-color: var(--overlay-2);
+}
+
+.focus\\\\:bg-positive:focus {
+  background-color: var(--positive);
+}
+
+.focus\\\\:bg-primary-hover:focus {
+  background-color: var(--primary-hover);
+}
+
+.focus\\\\:bg-primary-idle:focus {
+  background-color: var(--primary-idle);
+}
+
+.focus\\\\:bg-primary-pressed:focus {
+  background-color: var(--primary-pressed);
+}
+
+.focus\\\\:bg-process-operations:focus {
+  background-color: var(--process-operations);
+}
+
+.focus\\\\:bg-purple:focus {
+  background-color: var(--purple);
+}
+
+.focus\\\\:bg-registry-operations:focus {
+  background-color: var(--registry-operations);
+}
+
+.focus\\\\:bg-selected:focus {
+  background-color: var(--selected);
+}
+
+.focus\\\\:bg-surface-2xl:focus {
+  background-color: var(--surface-2xl);
+}
+
+.focus\\\\:bg-surface-base:focus {
+  background-color: var(--surface-base);
+}
+
+.focus\\\\:bg-surface-inner:focus {
+  background-color: var(--surface-inner);
+}
+
+.focus\\\\:bg-surface-lg:focus {
+  background-color: var(--surface-lg);
+}
+
+.focus\\\\:bg-surface-md:focus {
+  background-color: var(--surface-md);
+}
+
+.focus\\\\:bg-surface-xl:focus {
+  background-color: var(--surface-xl);
+}
+
+.focus\\\\:bg-text-and-icons:focus {
+  background-color: var(--text-and-icons);
+}
+
+.focus\\\\:bg-titles-and-attributes:focus {
+  background-color: var(--titles-and-attributes);
+}
+
+.focus-within\\\\:bg-current:focus-within {
+  background-color: currentColor;
+}
+
+.focus-within\\\\:bg-transparent:focus-within {
+  background-color: transparent;
+}
+
+.focus-within\\\\:bg-falcon:focus-within {
+  background-color: var(--falcon);
+}
+
+.focus-within\\\\:bg-basement:focus-within {
+  background-color: var(--basement);
+}
+
+.focus-within\\\\:bg-blue:focus-within {
+  background-color: var(--blue);
+}
+
+.focus-within\\\\:bg-body-and-labels:focus-within {
+  background-color: var(--body-and-labels);
+}
+
+.focus-within\\\\:bg-brand:focus-within {
+  background-color: var(--brand);
+}
+
+.focus-within\\\\:bg-code-base-64:focus-within {
+  background-color: var(--code-base-64);
+}
+
+.focus-within\\\\:bg-code-bg:focus-within {
+  background-color: var(--code-bg);
+}
+
+.focus-within\\\\:bg-code-outline:focus-within {
+  background-color: var(--code-outline);
+}
+
+.focus-within\\\\:bg-code-text:focus-within {
+  background-color: var(--code-text);
+}
+
+.focus-within\\\\:bg-critical:focus-within {
+  background-color: var(--critical);
+}
+
+.focus-within\\\\:bg-destructive-hover:focus-within {
+  background-color: var(--destructive-hover);
+}
+
+.focus-within\\\\:bg-destructive-idle:focus-within {
+  background-color: var(--destructive-idle);
+}
+
+.focus-within\\\\:bg-destructive-pressed:focus-within {
+  background-color: var(--destructive-pressed);
+}
+
+.focus-within\\\\:bg-disabled:focus-within {
+  background-color: var(--disabled);
+}
+
+.focus-within\\\\:bg-disc-operations:focus-within {
+  background-color: var(--disc-operations);
+}
+
+.focus-within\\\\:bg-dns-requests:focus-within {
+  background-color: var(--dns-requests);
+}
+
+.focus-within\\\\:bg-focus:focus-within {
+  background-color: var(--focus);
+}
+
+.focus-within\\\\:bg-graph-1:focus-within {
+  background-color: var(--graph-1);
+}
+
+.focus-within\\\\:bg-graph-10:focus-within {
+  background-color: var(--graph-10);
+}
+
+.focus-within\\\\:bg-graph-11:focus-within {
+  background-color: var(--graph-11);
+}
+
+.focus-within\\\\:bg-graph-2:focus-within {
+  background-color: var(--graph-2);
+}
+
+.focus-within\\\\:bg-graph-3:focus-within {
+  background-color: var(--graph-3);
+}
+
+.focus-within\\\\:bg-graph-4:focus-within {
+  background-color: var(--graph-4);
+}
+
+.focus-within\\\\:bg-graph-5:focus-within {
+  background-color: var(--graph-5);
+}
+
+.focus-within\\\\:bg-graph-6:focus-within {
+  background-color: var(--graph-6);
+}
+
+.focus-within\\\\:bg-graph-7:focus-within {
+  background-color: var(--graph-7);
+}
+
+.focus-within\\\\:bg-graph-8:focus-within {
+  background-color: var(--graph-8);
+}
+
+.focus-within\\\\:bg-graph-9:focus-within {
+  background-color: var(--graph-9);
+}
+
+.focus-within\\\\:bg-graph-disabled:focus-within {
+  background-color: var(--graph-disabled);
+}
+
+.focus-within\\\\:bg-ground-floor:focus-within {
+  background-color: var(--ground-floor);
+}
+
+.focus-within\\\\:bg-high:focus-within {
+  background-color: var(--high);
+}
+
+.focus-within\\\\:bg-informational:focus-within {
+  background-color: var(--informational);
+}
+
+.focus-within\\\\:bg-lines-dark:focus-within {
+  background-color: var(--lines-dark);
+}
+
+.focus-within\\\\:bg-lines-light:focus-within {
+  background-color: var(--lines-light);
+}
+
+.focus-within\\\\:bg-low:focus-within {
+  background-color: var(--low);
+}
+
+.focus-within\\\\:bg-medium:focus-within {
+  background-color: var(--medium);
+}
+
+.focus-within\\\\:bg-mezzanine:focus-within {
+  background-color: var(--mezzanine);
+}
+
+.focus-within\\\\:bg-nav-text-and-icons:focus-within {
+  background-color: var(--nav-text-and-icons);
+}
+
+.focus-within\\\\:bg-nav-text-secondary:focus-within {
+  background-color: var(--nav-text-secondary);
+}
+
+.focus-within\\\\:bg-network-operations:focus-within {
+  background-color: var(--network-operations);
+}
+
+.focus-within\\\\:bg-normal-hover:focus-within {
+  background-color: var(--normal-hover);
+}
+
+.focus-within\\\\:bg-normal-idle:focus-within {
+  background-color: var(--normal-idle);
+}
+
+.focus-within\\\\:bg-normal-pressed:focus-within {
+  background-color: var(--normal-pressed);
+}
+
+.focus-within\\\\:bg-overlay-0\\\\.5:focus-within {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.focus-within\\\\:bg-overlay-1:focus-within {
+  background-color: var(--overlay-1);
+}
+
+.focus-within\\\\:bg-overlay-2:focus-within {
+  background-color: var(--overlay-2);
+}
+
+.focus-within\\\\:bg-positive:focus-within {
+  background-color: var(--positive);
+}
+
+.focus-within\\\\:bg-primary-hover:focus-within {
+  background-color: var(--primary-hover);
+}
+
+.focus-within\\\\:bg-primary-idle:focus-within {
+  background-color: var(--primary-idle);
+}
+
+.focus-within\\\\:bg-primary-pressed:focus-within {
+  background-color: var(--primary-pressed);
+}
+
+.focus-within\\\\:bg-process-operations:focus-within {
+  background-color: var(--process-operations);
+}
+
+.focus-within\\\\:bg-purple:focus-within {
+  background-color: var(--purple);
+}
+
+.focus-within\\\\:bg-registry-operations:focus-within {
+  background-color: var(--registry-operations);
+}
+
+.focus-within\\\\:bg-selected:focus-within {
+  background-color: var(--selected);
+}
+
+.focus-within\\\\:bg-surface-2xl:focus-within {
+  background-color: var(--surface-2xl);
+}
+
+.focus-within\\\\:bg-surface-base:focus-within {
+  background-color: var(--surface-base);
+}
+
+.focus-within\\\\:bg-surface-inner:focus-within {
+  background-color: var(--surface-inner);
+}
+
+.focus-within\\\\:bg-surface-lg:focus-within {
+  background-color: var(--surface-lg);
+}
+
+.focus-within\\\\:bg-surface-md:focus-within {
+  background-color: var(--surface-md);
+}
+
+.focus-within\\\\:bg-surface-xl:focus-within {
+  background-color: var(--surface-xl);
+}
+
+.focus-within\\\\:bg-text-and-icons:focus-within {
+  background-color: var(--text-and-icons);
+}
+
+.focus-within\\\\:bg-titles-and-attributes:focus-within {
+  background-color: var(--titles-and-attributes);
+}
+
+.focus-visible\\\\:bg-current:focus-visible {
+  background-color: currentColor;
+}
+
+.focus-visible\\\\:bg-transparent:focus-visible {
+  background-color: transparent;
+}
+
+.focus-visible\\\\:bg-falcon:focus-visible {
+  background-color: var(--falcon);
+}
+
+.focus-visible\\\\:bg-basement:focus-visible {
+  background-color: var(--basement);
+}
+
+.focus-visible\\\\:bg-blue:focus-visible {
+  background-color: var(--blue);
+}
+
+.focus-visible\\\\:bg-body-and-labels:focus-visible {
+  background-color: var(--body-and-labels);
+}
+
+.focus-visible\\\\:bg-brand:focus-visible {
+  background-color: var(--brand);
+}
+
+.focus-visible\\\\:bg-code-base-64:focus-visible {
+  background-color: var(--code-base-64);
+}
+
+.focus-visible\\\\:bg-code-bg:focus-visible {
+  background-color: var(--code-bg);
+}
+
+.focus-visible\\\\:bg-code-outline:focus-visible {
+  background-color: var(--code-outline);
+}
+
+.focus-visible\\\\:bg-code-text:focus-visible {
+  background-color: var(--code-text);
+}
+
+.focus-visible\\\\:bg-critical:focus-visible {
+  background-color: var(--critical);
+}
+
+.focus-visible\\\\:bg-destructive-hover:focus-visible {
+  background-color: var(--destructive-hover);
+}
+
+.focus-visible\\\\:bg-destructive-idle:focus-visible {
+  background-color: var(--destructive-idle);
+}
+
+.focus-visible\\\\:bg-destructive-pressed:focus-visible {
+  background-color: var(--destructive-pressed);
+}
+
+.focus-visible\\\\:bg-disabled:focus-visible {
+  background-color: var(--disabled);
+}
+
+.focus-visible\\\\:bg-disc-operations:focus-visible {
+  background-color: var(--disc-operations);
+}
+
+.focus-visible\\\\:bg-dns-requests:focus-visible {
+  background-color: var(--dns-requests);
+}
+
+.focus-visible\\\\:bg-focus:focus-visible {
+  background-color: var(--focus);
+}
+
+.focus-visible\\\\:bg-graph-1:focus-visible {
+  background-color: var(--graph-1);
+}
+
+.focus-visible\\\\:bg-graph-10:focus-visible {
+  background-color: var(--graph-10);
+}
+
+.focus-visible\\\\:bg-graph-11:focus-visible {
+  background-color: var(--graph-11);
+}
+
+.focus-visible\\\\:bg-graph-2:focus-visible {
+  background-color: var(--graph-2);
+}
+
+.focus-visible\\\\:bg-graph-3:focus-visible {
+  background-color: var(--graph-3);
+}
+
+.focus-visible\\\\:bg-graph-4:focus-visible {
+  background-color: var(--graph-4);
+}
+
+.focus-visible\\\\:bg-graph-5:focus-visible {
+  background-color: var(--graph-5);
+}
+
+.focus-visible\\\\:bg-graph-6:focus-visible {
+  background-color: var(--graph-6);
+}
+
+.focus-visible\\\\:bg-graph-7:focus-visible {
+  background-color: var(--graph-7);
+}
+
+.focus-visible\\\\:bg-graph-8:focus-visible {
+  background-color: var(--graph-8);
+}
+
+.focus-visible\\\\:bg-graph-9:focus-visible {
+  background-color: var(--graph-9);
+}
+
+.focus-visible\\\\:bg-graph-disabled:focus-visible {
+  background-color: var(--graph-disabled);
+}
+
+.focus-visible\\\\:bg-ground-floor:focus-visible {
+  background-color: var(--ground-floor);
+}
+
+.focus-visible\\\\:bg-high:focus-visible {
+  background-color: var(--high);
+}
+
+.focus-visible\\\\:bg-informational:focus-visible {
+  background-color: var(--informational);
+}
+
+.focus-visible\\\\:bg-lines-dark:focus-visible {
+  background-color: var(--lines-dark);
+}
+
+.focus-visible\\\\:bg-lines-light:focus-visible {
+  background-color: var(--lines-light);
+}
+
+.focus-visible\\\\:bg-low:focus-visible {
+  background-color: var(--low);
+}
+
+.focus-visible\\\\:bg-medium:focus-visible {
+  background-color: var(--medium);
+}
+
+.focus-visible\\\\:bg-mezzanine:focus-visible {
+  background-color: var(--mezzanine);
+}
+
+.focus-visible\\\\:bg-nav-text-and-icons:focus-visible {
+  background-color: var(--nav-text-and-icons);
+}
+
+.focus-visible\\\\:bg-nav-text-secondary:focus-visible {
+  background-color: var(--nav-text-secondary);
+}
+
+.focus-visible\\\\:bg-network-operations:focus-visible {
+  background-color: var(--network-operations);
+}
+
+.focus-visible\\\\:bg-normal-hover:focus-visible {
+  background-color: var(--normal-hover);
+}
+
+.focus-visible\\\\:bg-normal-idle:focus-visible {
+  background-color: var(--normal-idle);
+}
+
+.focus-visible\\\\:bg-normal-pressed:focus-visible {
+  background-color: var(--normal-pressed);
+}
+
+.focus-visible\\\\:bg-overlay-0\\\\.5:focus-visible {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.focus-visible\\\\:bg-overlay-1:focus-visible {
+  background-color: var(--overlay-1);
+}
+
+.focus-visible\\\\:bg-overlay-2:focus-visible {
+  background-color: var(--overlay-2);
+}
+
+.focus-visible\\\\:bg-positive:focus-visible {
+  background-color: var(--positive);
+}
+
+.focus-visible\\\\:bg-primary-hover:focus-visible {
+  background-color: var(--primary-hover);
+}
+
+.focus-visible\\\\:bg-primary-idle:focus-visible {
+  background-color: var(--primary-idle);
+}
+
+.focus-visible\\\\:bg-primary-pressed:focus-visible {
+  background-color: var(--primary-pressed);
+}
+
+.focus-visible\\\\:bg-process-operations:focus-visible {
+  background-color: var(--process-operations);
+}
+
+.focus-visible\\\\:bg-purple:focus-visible {
+  background-color: var(--purple);
+}
+
+.focus-visible\\\\:bg-registry-operations:focus-visible {
+  background-color: var(--registry-operations);
+}
+
+.focus-visible\\\\:bg-selected:focus-visible {
+  background-color: var(--selected);
+}
+
+.focus-visible\\\\:bg-surface-2xl:focus-visible {
+  background-color: var(--surface-2xl);
+}
+
+.focus-visible\\\\:bg-surface-base:focus-visible {
+  background-color: var(--surface-base);
+}
+
+.focus-visible\\\\:bg-surface-inner:focus-visible {
+  background-color: var(--surface-inner);
+}
+
+.focus-visible\\\\:bg-surface-lg:focus-visible {
+  background-color: var(--surface-lg);
+}
+
+.focus-visible\\\\:bg-surface-md:focus-visible {
+  background-color: var(--surface-md);
+}
+
+.focus-visible\\\\:bg-surface-xl:focus-visible {
+  background-color: var(--surface-xl);
+}
+
+.focus-visible\\\\:bg-text-and-icons:focus-visible {
+  background-color: var(--text-and-icons);
+}
+
+.focus-visible\\\\:bg-titles-and-attributes:focus-visible {
+  background-color: var(--titles-and-attributes);
+}
+
+.active\\\\:bg-current:active {
+  background-color: currentColor;
+}
+
+.active\\\\:bg-transparent:active {
+  background-color: transparent;
+}
+
+.active\\\\:bg-falcon:active {
+  background-color: var(--falcon);
+}
+
+.active\\\\:bg-basement:active {
+  background-color: var(--basement);
+}
+
+.active\\\\:bg-blue:active {
+  background-color: var(--blue);
+}
+
+.active\\\\:bg-body-and-labels:active {
+  background-color: var(--body-and-labels);
+}
+
+.active\\\\:bg-brand:active {
+  background-color: var(--brand);
+}
+
+.active\\\\:bg-code-base-64:active {
+  background-color: var(--code-base-64);
+}
+
+.active\\\\:bg-code-bg:active {
+  background-color: var(--code-bg);
+}
+
+.active\\\\:bg-code-outline:active {
+  background-color: var(--code-outline);
+}
+
+.active\\\\:bg-code-text:active {
+  background-color: var(--code-text);
+}
+
+.active\\\\:bg-critical:active {
+  background-color: var(--critical);
+}
+
+.active\\\\:bg-destructive-hover:active {
+  background-color: var(--destructive-hover);
+}
+
+.active\\\\:bg-destructive-idle:active {
+  background-color: var(--destructive-idle);
+}
+
+.active\\\\:bg-destructive-pressed:active {
+  background-color: var(--destructive-pressed);
+}
+
+.active\\\\:bg-disabled:active {
+  background-color: var(--disabled);
+}
+
+.active\\\\:bg-disc-operations:active {
+  background-color: var(--disc-operations);
+}
+
+.active\\\\:bg-dns-requests:active {
+  background-color: var(--dns-requests);
+}
+
+.active\\\\:bg-focus:active {
+  background-color: var(--focus);
+}
+
+.active\\\\:bg-graph-1:active {
+  background-color: var(--graph-1);
+}
+
+.active\\\\:bg-graph-10:active {
+  background-color: var(--graph-10);
+}
+
+.active\\\\:bg-graph-11:active {
+  background-color: var(--graph-11);
+}
+
+.active\\\\:bg-graph-2:active {
+  background-color: var(--graph-2);
+}
+
+.active\\\\:bg-graph-3:active {
+  background-color: var(--graph-3);
+}
+
+.active\\\\:bg-graph-4:active {
+  background-color: var(--graph-4);
+}
+
+.active\\\\:bg-graph-5:active {
+  background-color: var(--graph-5);
+}
+
+.active\\\\:bg-graph-6:active {
+  background-color: var(--graph-6);
+}
+
+.active\\\\:bg-graph-7:active {
+  background-color: var(--graph-7);
+}
+
+.active\\\\:bg-graph-8:active {
+  background-color: var(--graph-8);
+}
+
+.active\\\\:bg-graph-9:active {
+  background-color: var(--graph-9);
+}
+
+.active\\\\:bg-graph-disabled:active {
+  background-color: var(--graph-disabled);
+}
+
+.active\\\\:bg-ground-floor:active {
+  background-color: var(--ground-floor);
+}
+
+.active\\\\:bg-high:active {
+  background-color: var(--high);
+}
+
+.active\\\\:bg-informational:active {
+  background-color: var(--informational);
+}
+
+.active\\\\:bg-lines-dark:active {
+  background-color: var(--lines-dark);
+}
+
+.active\\\\:bg-lines-light:active {
+  background-color: var(--lines-light);
+}
+
+.active\\\\:bg-low:active {
+  background-color: var(--low);
+}
+
+.active\\\\:bg-medium:active {
+  background-color: var(--medium);
+}
+
+.active\\\\:bg-mezzanine:active {
+  background-color: var(--mezzanine);
+}
+
+.active\\\\:bg-nav-text-and-icons:active {
+  background-color: var(--nav-text-and-icons);
+}
+
+.active\\\\:bg-nav-text-secondary:active {
+  background-color: var(--nav-text-secondary);
+}
+
+.active\\\\:bg-network-operations:active {
+  background-color: var(--network-operations);
+}
+
+.active\\\\:bg-normal-hover:active {
+  background-color: var(--normal-hover);
+}
+
+.active\\\\:bg-normal-idle:active {
+  background-color: var(--normal-idle);
+}
+
+.active\\\\:bg-normal-pressed:active {
+  background-color: var(--normal-pressed);
+}
+
+.active\\\\:bg-overlay-0\\\\.5:active {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.active\\\\:bg-overlay-1:active {
+  background-color: var(--overlay-1);
+}
+
+.active\\\\:bg-overlay-2:active {
+  background-color: var(--overlay-2);
+}
+
+.active\\\\:bg-positive:active {
+  background-color: var(--positive);
+}
+
+.active\\\\:bg-primary-hover:active {
+  background-color: var(--primary-hover);
+}
+
+.active\\\\:bg-primary-idle:active {
+  background-color: var(--primary-idle);
+}
+
+.active\\\\:bg-primary-pressed:active {
+  background-color: var(--primary-pressed);
+}
+
+.active\\\\:bg-process-operations:active {
+  background-color: var(--process-operations);
+}
+
+.active\\\\:bg-purple:active {
+  background-color: var(--purple);
+}
+
+.active\\\\:bg-registry-operations:active {
+  background-color: var(--registry-operations);
+}
+
+.active\\\\:bg-selected:active {
+  background-color: var(--selected);
+}
+
+.active\\\\:bg-surface-2xl:active {
+  background-color: var(--surface-2xl);
+}
+
+.active\\\\:bg-surface-base:active {
+  background-color: var(--surface-base);
+}
+
+.active\\\\:bg-surface-inner:active {
+  background-color: var(--surface-inner);
+}
+
+.active\\\\:bg-surface-lg:active {
+  background-color: var(--surface-lg);
+}
+
+.active\\\\:bg-surface-md:active {
+  background-color: var(--surface-md);
+}
+
+.active\\\\:bg-surface-xl:active {
+  background-color: var(--surface-xl);
+}
+
+.active\\\\:bg-text-and-icons:active {
+  background-color: var(--text-and-icons);
+}
+
+.active\\\\:bg-titles-and-attributes:active {
+  background-color: var(--titles-and-attributes);
+}
+
+.disabled\\\\:bg-current:disabled {
+  background-color: currentColor;
+}
+
+.disabled\\\\:bg-transparent:disabled {
+  background-color: transparent;
+}
+
+.disabled\\\\:bg-falcon:disabled {
+  background-color: var(--falcon);
+}
+
+.disabled\\\\:bg-basement:disabled {
+  background-color: var(--basement);
+}
+
+.disabled\\\\:bg-blue:disabled {
+  background-color: var(--blue);
+}
+
+.disabled\\\\:bg-body-and-labels:disabled {
+  background-color: var(--body-and-labels);
+}
+
+.disabled\\\\:bg-brand:disabled {
+  background-color: var(--brand);
+}
+
+.disabled\\\\:bg-code-base-64:disabled {
+  background-color: var(--code-base-64);
+}
+
+.disabled\\\\:bg-code-bg:disabled {
+  background-color: var(--code-bg);
+}
+
+.disabled\\\\:bg-code-outline:disabled {
+  background-color: var(--code-outline);
+}
+
+.disabled\\\\:bg-code-text:disabled {
+  background-color: var(--code-text);
+}
+
+.disabled\\\\:bg-critical:disabled {
+  background-color: var(--critical);
+}
+
+.disabled\\\\:bg-destructive-hover:disabled {
+  background-color: var(--destructive-hover);
+}
+
+.disabled\\\\:bg-destructive-idle:disabled {
+  background-color: var(--destructive-idle);
+}
+
+.disabled\\\\:bg-destructive-pressed:disabled {
+  background-color: var(--destructive-pressed);
+}
+
+.disabled\\\\:bg-disabled:disabled {
+  background-color: var(--disabled);
+}
+
+.disabled\\\\:bg-disc-operations:disabled {
+  background-color: var(--disc-operations);
+}
+
+.disabled\\\\:bg-dns-requests:disabled {
+  background-color: var(--dns-requests);
+}
+
+.disabled\\\\:bg-focus:disabled {
+  background-color: var(--focus);
+}
+
+.disabled\\\\:bg-graph-1:disabled {
+  background-color: var(--graph-1);
+}
+
+.disabled\\\\:bg-graph-10:disabled {
+  background-color: var(--graph-10);
+}
+
+.disabled\\\\:bg-graph-11:disabled {
+  background-color: var(--graph-11);
+}
+
+.disabled\\\\:bg-graph-2:disabled {
+  background-color: var(--graph-2);
+}
+
+.disabled\\\\:bg-graph-3:disabled {
+  background-color: var(--graph-3);
+}
+
+.disabled\\\\:bg-graph-4:disabled {
+  background-color: var(--graph-4);
+}
+
+.disabled\\\\:bg-graph-5:disabled {
+  background-color: var(--graph-5);
+}
+
+.disabled\\\\:bg-graph-6:disabled {
+  background-color: var(--graph-6);
+}
+
+.disabled\\\\:bg-graph-7:disabled {
+  background-color: var(--graph-7);
+}
+
+.disabled\\\\:bg-graph-8:disabled {
+  background-color: var(--graph-8);
+}
+
+.disabled\\\\:bg-graph-9:disabled {
+  background-color: var(--graph-9);
+}
+
+.disabled\\\\:bg-graph-disabled:disabled {
+  background-color: var(--graph-disabled);
+}
+
+.disabled\\\\:bg-ground-floor:disabled {
+  background-color: var(--ground-floor);
+}
+
+.disabled\\\\:bg-high:disabled {
+  background-color: var(--high);
+}
+
+.disabled\\\\:bg-informational:disabled {
+  background-color: var(--informational);
+}
+
+.disabled\\\\:bg-lines-dark:disabled {
+  background-color: var(--lines-dark);
+}
+
+.disabled\\\\:bg-lines-light:disabled {
+  background-color: var(--lines-light);
+}
+
+.disabled\\\\:bg-low:disabled {
+  background-color: var(--low);
+}
+
+.disabled\\\\:bg-medium:disabled {
+  background-color: var(--medium);
+}
+
+.disabled\\\\:bg-mezzanine:disabled {
+  background-color: var(--mezzanine);
+}
+
+.disabled\\\\:bg-nav-text-and-icons:disabled {
+  background-color: var(--nav-text-and-icons);
+}
+
+.disabled\\\\:bg-nav-text-secondary:disabled {
+  background-color: var(--nav-text-secondary);
+}
+
+.disabled\\\\:bg-network-operations:disabled {
+  background-color: var(--network-operations);
+}
+
+.disabled\\\\:bg-normal-hover:disabled {
+  background-color: var(--normal-hover);
+}
+
+.disabled\\\\:bg-normal-idle:disabled {
+  background-color: var(--normal-idle);
+}
+
+.disabled\\\\:bg-normal-pressed:disabled {
+  background-color: var(--normal-pressed);
+}
+
+.disabled\\\\:bg-overlay-0\\\\.5:disabled {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.disabled\\\\:bg-overlay-1:disabled {
+  background-color: var(--overlay-1);
+}
+
+.disabled\\\\:bg-overlay-2:disabled {
+  background-color: var(--overlay-2);
+}
+
+.disabled\\\\:bg-positive:disabled {
+  background-color: var(--positive);
+}
+
+.disabled\\\\:bg-primary-hover:disabled {
+  background-color: var(--primary-hover);
+}
+
+.disabled\\\\:bg-primary-idle:disabled {
+  background-color: var(--primary-idle);
+}
+
+.disabled\\\\:bg-primary-pressed:disabled {
+  background-color: var(--primary-pressed);
+}
+
+.disabled\\\\:bg-process-operations:disabled {
+  background-color: var(--process-operations);
+}
+
+.disabled\\\\:bg-purple:disabled {
+  background-color: var(--purple);
+}
+
+.disabled\\\\:bg-registry-operations:disabled {
+  background-color: var(--registry-operations);
+}
+
+.disabled\\\\:bg-selected:disabled {
+  background-color: var(--selected);
+}
+
+.disabled\\\\:bg-surface-2xl:disabled {
+  background-color: var(--surface-2xl);
+}
+
+.disabled\\\\:bg-surface-base:disabled {
+  background-color: var(--surface-base);
+}
+
+.disabled\\\\:bg-surface-inner:disabled {
+  background-color: var(--surface-inner);
+}
+
+.disabled\\\\:bg-surface-lg:disabled {
+  background-color: var(--surface-lg);
+}
+
+.disabled\\\\:bg-surface-md:disabled {
+  background-color: var(--surface-md);
+}
+
+.disabled\\\\:bg-surface-xl:disabled {
+  background-color: var(--surface-xl);
+}
+
+.disabled\\\\:bg-text-and-icons:disabled {
+  background-color: var(--text-and-icons);
+}
+
+.disabled\\\\:bg-titles-and-attributes:disabled {
+  background-color: var(--titles-and-attributes);
+}
+
+.bg-opacity-0 {
+  --tw-bg-opacity: 0;
+}
+
+.bg-opacity-5 {
+  --tw-bg-opacity: 0.05;
+}
+
+.bg-opacity-10 {
+  --tw-bg-opacity: 0.1;
+}
+
+.bg-opacity-20 {
+  --tw-bg-opacity: 0.2;
+}
+
+.bg-opacity-25 {
+  --tw-bg-opacity: 0.25;
+}
+
+.bg-opacity-30 {
+  --tw-bg-opacity: 0.3;
+}
+
+.bg-opacity-40 {
+  --tw-bg-opacity: 0.4;
+}
+
+.bg-opacity-50 {
+  --tw-bg-opacity: 0.5;
+}
+
+.bg-opacity-60 {
+  --tw-bg-opacity: 0.6;
+}
+
+.bg-opacity-70 {
+  --tw-bg-opacity: 0.7;
+}
+
+.bg-opacity-75 {
+  --tw-bg-opacity: 0.75;
+}
+
+.bg-opacity-80 {
+  --tw-bg-opacity: 0.8;
+}
+
+.bg-opacity-90 {
+  --tw-bg-opacity: 0.9;
+}
+
+.bg-opacity-95 {
+  --tw-bg-opacity: 0.95;
+}
+
+.bg-opacity-100 {
+  --tw-bg-opacity: 1;
+}
+
+.hover\\\\:bg-opacity-0:hover {
+  --tw-bg-opacity: 0;
+}
+
+.hover\\\\:bg-opacity-5:hover {
+  --tw-bg-opacity: 0.05;
+}
+
+.hover\\\\:bg-opacity-10:hover {
+  --tw-bg-opacity: 0.1;
+}
+
+.hover\\\\:bg-opacity-20:hover {
+  --tw-bg-opacity: 0.2;
+}
+
+.hover\\\\:bg-opacity-25:hover {
+  --tw-bg-opacity: 0.25;
+}
+
+.hover\\\\:bg-opacity-30:hover {
+  --tw-bg-opacity: 0.3;
+}
+
+.hover\\\\:bg-opacity-40:hover {
+  --tw-bg-opacity: 0.4;
+}
+
+.hover\\\\:bg-opacity-50:hover {
+  --tw-bg-opacity: 0.5;
+}
+
+.hover\\\\:bg-opacity-60:hover {
+  --tw-bg-opacity: 0.6;
+}
+
+.hover\\\\:bg-opacity-70:hover {
+  --tw-bg-opacity: 0.7;
+}
+
+.hover\\\\:bg-opacity-75:hover {
+  --tw-bg-opacity: 0.75;
+}
+
+.hover\\\\:bg-opacity-80:hover {
+  --tw-bg-opacity: 0.8;
+}
+
+.hover\\\\:bg-opacity-90:hover {
+  --tw-bg-opacity: 0.9;
+}
+
+.hover\\\\:bg-opacity-95:hover {
+  --tw-bg-opacity: 0.95;
+}
+
+.hover\\\\:bg-opacity-100:hover {
+  --tw-bg-opacity: 1;
+}
+
+.focus\\\\:bg-opacity-0:focus {
+  --tw-bg-opacity: 0;
+}
+
+.focus\\\\:bg-opacity-5:focus {
+  --tw-bg-opacity: 0.05;
+}
+
+.focus\\\\:bg-opacity-10:focus {
+  --tw-bg-opacity: 0.1;
+}
+
+.focus\\\\:bg-opacity-20:focus {
+  --tw-bg-opacity: 0.2;
+}
+
+.focus\\\\:bg-opacity-25:focus {
+  --tw-bg-opacity: 0.25;
+}
+
+.focus\\\\:bg-opacity-30:focus {
+  --tw-bg-opacity: 0.3;
+}
+
+.focus\\\\:bg-opacity-40:focus {
+  --tw-bg-opacity: 0.4;
+}
+
+.focus\\\\:bg-opacity-50:focus {
+  --tw-bg-opacity: 0.5;
+}
+
+.focus\\\\:bg-opacity-60:focus {
+  --tw-bg-opacity: 0.6;
+}
+
+.focus\\\\:bg-opacity-70:focus {
+  --tw-bg-opacity: 0.7;
+}
+
+.focus\\\\:bg-opacity-75:focus {
+  --tw-bg-opacity: 0.75;
+}
+
+.focus\\\\:bg-opacity-80:focus {
+  --tw-bg-opacity: 0.8;
+}
+
+.focus\\\\:bg-opacity-90:focus {
+  --tw-bg-opacity: 0.9;
+}
+
+.focus\\\\:bg-opacity-95:focus {
+  --tw-bg-opacity: 0.95;
+}
+
+.focus\\\\:bg-opacity-100:focus {
+  --tw-bg-opacity: 1;
+}
+
+.bg-none {
+  background-image: none;
+}
+
+.bg-gradient-to-t {
+  background-image: linear-gradient(to top, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-tr {
+  background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-r {
+  background-image: linear-gradient(to right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-br {
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-b {
+  background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-bl {
+  background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-l {
+  background-image: linear-gradient(to left, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-tl {
+  background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+}
+
+.from-current {
+  --tw-gradient-from: currentColor;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-transparent {
+  --tw-gradient-from: transparent;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.from-falcon {
+  --tw-gradient-from: var(--falcon);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-basement {
+  --tw-gradient-from: var(--basement);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-blue {
+  --tw-gradient-from: var(--blue);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-body-and-labels {
+  --tw-gradient-from: var(--body-and-labels);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-brand {
+  --tw-gradient-from: var(--brand);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-code-base-64 {
+  --tw-gradient-from: var(--code-base-64);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-code-bg {
+  --tw-gradient-from: var(--code-bg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-code-outline {
+  --tw-gradient-from: var(--code-outline);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-code-text {
+  --tw-gradient-from: var(--code-text);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-critical {
+  --tw-gradient-from: var(--critical);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-destructive-hover {
+  --tw-gradient-from: var(--destructive-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-destructive-idle {
+  --tw-gradient-from: var(--destructive-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-destructive-pressed {
+  --tw-gradient-from: var(--destructive-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-disabled {
+  --tw-gradient-from: var(--disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-disc-operations {
+  --tw-gradient-from: var(--disc-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-dns-requests {
+  --tw-gradient-from: var(--dns-requests);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-focus {
+  --tw-gradient-from: var(--focus);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-1 {
+  --tw-gradient-from: var(--graph-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-10 {
+  --tw-gradient-from: var(--graph-10);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-11 {
+  --tw-gradient-from: var(--graph-11);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-2 {
+  --tw-gradient-from: var(--graph-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-3 {
+  --tw-gradient-from: var(--graph-3);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-4 {
+  --tw-gradient-from: var(--graph-4);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-5 {
+  --tw-gradient-from: var(--graph-5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-6 {
+  --tw-gradient-from: var(--graph-6);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-7 {
+  --tw-gradient-from: var(--graph-7);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-8 {
+  --tw-gradient-from: var(--graph-8);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-9 {
+  --tw-gradient-from: var(--graph-9);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-disabled {
+  --tw-gradient-from: var(--graph-disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-ground-floor {
+  --tw-gradient-from: var(--ground-floor);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-high {
+  --tw-gradient-from: var(--high);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-informational {
+  --tw-gradient-from: var(--informational);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-lines-dark {
+  --tw-gradient-from: var(--lines-dark);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-lines-light {
+  --tw-gradient-from: var(--lines-light);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-low {
+  --tw-gradient-from: var(--low);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-medium {
+  --tw-gradient-from: var(--medium);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-mezzanine {
+  --tw-gradient-from: var(--mezzanine);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-nav-text-and-icons {
+  --tw-gradient-from: var(--nav-text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-nav-text-secondary {
+  --tw-gradient-from: var(--nav-text-secondary);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-network-operations {
+  --tw-gradient-from: var(--network-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-normal-hover {
+  --tw-gradient-from: var(--normal-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-normal-idle {
+  --tw-gradient-from: var(--normal-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-normal-pressed {
+  --tw-gradient-from: var(--normal-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-overlay-0\\\\.5 {
+  --tw-gradient-from: var(--overlay-0\\\\.5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-overlay-1 {
+  --tw-gradient-from: var(--overlay-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-overlay-2 {
+  --tw-gradient-from: var(--overlay-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-positive {
+  --tw-gradient-from: var(--positive);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-primary-hover {
+  --tw-gradient-from: var(--primary-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-primary-idle {
+  --tw-gradient-from: var(--primary-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-primary-pressed {
+  --tw-gradient-from: var(--primary-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-process-operations {
+  --tw-gradient-from: var(--process-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-purple {
+  --tw-gradient-from: var(--purple);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-registry-operations {
+  --tw-gradient-from: var(--registry-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-selected {
+  --tw-gradient-from: var(--selected);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-2xl {
+  --tw-gradient-from: var(--surface-2xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-base {
+  --tw-gradient-from: var(--surface-base);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-inner {
+  --tw-gradient-from: var(--surface-inner);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-lg {
+  --tw-gradient-from: var(--surface-lg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-md {
+  --tw-gradient-from: var(--surface-md);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-xl {
+  --tw-gradient-from: var(--surface-xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-text-and-icons {
+  --tw-gradient-from: var(--text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-titles-and-attributes {
+  --tw-gradient-from: var(--titles-and-attributes);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-current:hover {
+  --tw-gradient-from: currentColor;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-transparent:hover {
+  --tw-gradient-from: transparent;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.hover\\\\:from-falcon:hover {
+  --tw-gradient-from: var(--falcon);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-basement:hover {
+  --tw-gradient-from: var(--basement);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-blue:hover {
+  --tw-gradient-from: var(--blue);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-body-and-labels:hover {
+  --tw-gradient-from: var(--body-and-labels);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-brand:hover {
+  --tw-gradient-from: var(--brand);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-code-base-64:hover {
+  --tw-gradient-from: var(--code-base-64);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-code-bg:hover {
+  --tw-gradient-from: var(--code-bg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-code-outline:hover {
+  --tw-gradient-from: var(--code-outline);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-code-text:hover {
+  --tw-gradient-from: var(--code-text);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-critical:hover {
+  --tw-gradient-from: var(--critical);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-destructive-hover:hover {
+  --tw-gradient-from: var(--destructive-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-destructive-idle:hover {
+  --tw-gradient-from: var(--destructive-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-destructive-pressed:hover {
+  --tw-gradient-from: var(--destructive-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-disabled:hover {
+  --tw-gradient-from: var(--disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-disc-operations:hover {
+  --tw-gradient-from: var(--disc-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-dns-requests:hover {
+  --tw-gradient-from: var(--dns-requests);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-focus:hover {
+  --tw-gradient-from: var(--focus);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-1:hover {
+  --tw-gradient-from: var(--graph-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-10:hover {
+  --tw-gradient-from: var(--graph-10);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-11:hover {
+  --tw-gradient-from: var(--graph-11);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-2:hover {
+  --tw-gradient-from: var(--graph-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-3:hover {
+  --tw-gradient-from: var(--graph-3);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-4:hover {
+  --tw-gradient-from: var(--graph-4);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-5:hover {
+  --tw-gradient-from: var(--graph-5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-6:hover {
+  --tw-gradient-from: var(--graph-6);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-7:hover {
+  --tw-gradient-from: var(--graph-7);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-8:hover {
+  --tw-gradient-from: var(--graph-8);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-9:hover {
+  --tw-gradient-from: var(--graph-9);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-disabled:hover {
+  --tw-gradient-from: var(--graph-disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-ground-floor:hover {
+  --tw-gradient-from: var(--ground-floor);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-high:hover {
+  --tw-gradient-from: var(--high);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-informational:hover {
+  --tw-gradient-from: var(--informational);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-lines-dark:hover {
+  --tw-gradient-from: var(--lines-dark);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-lines-light:hover {
+  --tw-gradient-from: var(--lines-light);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-low:hover {
+  --tw-gradient-from: var(--low);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-medium:hover {
+  --tw-gradient-from: var(--medium);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-mezzanine:hover {
+  --tw-gradient-from: var(--mezzanine);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-nav-text-and-icons:hover {
+  --tw-gradient-from: var(--nav-text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-nav-text-secondary:hover {
+  --tw-gradient-from: var(--nav-text-secondary);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-network-operations:hover {
+  --tw-gradient-from: var(--network-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-normal-hover:hover {
+  --tw-gradient-from: var(--normal-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-normal-idle:hover {
+  --tw-gradient-from: var(--normal-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-normal-pressed:hover {
+  --tw-gradient-from: var(--normal-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-overlay-0\\\\.5:hover {
+  --tw-gradient-from: var(--overlay-0\\\\.5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-overlay-1:hover {
+  --tw-gradient-from: var(--overlay-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-overlay-2:hover {
+  --tw-gradient-from: var(--overlay-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-positive:hover {
+  --tw-gradient-from: var(--positive);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-primary-hover:hover {
+  --tw-gradient-from: var(--primary-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-primary-idle:hover {
+  --tw-gradient-from: var(--primary-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-primary-pressed:hover {
+  --tw-gradient-from: var(--primary-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-process-operations:hover {
+  --tw-gradient-from: var(--process-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-purple:hover {
+  --tw-gradient-from: var(--purple);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-registry-operations:hover {
+  --tw-gradient-from: var(--registry-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-selected:hover {
+  --tw-gradient-from: var(--selected);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-2xl:hover {
+  --tw-gradient-from: var(--surface-2xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-base:hover {
+  --tw-gradient-from: var(--surface-base);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-inner:hover {
+  --tw-gradient-from: var(--surface-inner);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-lg:hover {
+  --tw-gradient-from: var(--surface-lg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-md:hover {
+  --tw-gradient-from: var(--surface-md);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-xl:hover {
+  --tw-gradient-from: var(--surface-xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-text-and-icons:hover {
+  --tw-gradient-from: var(--text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-titles-and-attributes:hover {
+  --tw-gradient-from: var(--titles-and-attributes);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-current:focus {
+  --tw-gradient-from: currentColor;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-transparent:focus {
+  --tw-gradient-from: transparent;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.focus\\\\:from-falcon:focus {
+  --tw-gradient-from: var(--falcon);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-basement:focus {
+  --tw-gradient-from: var(--basement);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-blue:focus {
+  --tw-gradient-from: var(--blue);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-body-and-labels:focus {
+  --tw-gradient-from: var(--body-and-labels);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-brand:focus {
+  --tw-gradient-from: var(--brand);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-code-base-64:focus {
+  --tw-gradient-from: var(--code-base-64);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-code-bg:focus {
+  --tw-gradient-from: var(--code-bg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-code-outline:focus {
+  --tw-gradient-from: var(--code-outline);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-code-text:focus {
+  --tw-gradient-from: var(--code-text);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-critical:focus {
+  --tw-gradient-from: var(--critical);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-destructive-hover:focus {
+  --tw-gradient-from: var(--destructive-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-destructive-idle:focus {
+  --tw-gradient-from: var(--destructive-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-destructive-pressed:focus {
+  --tw-gradient-from: var(--destructive-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-disabled:focus {
+  --tw-gradient-from: var(--disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-disc-operations:focus {
+  --tw-gradient-from: var(--disc-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-dns-requests:focus {
+  --tw-gradient-from: var(--dns-requests);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-focus:focus {
+  --tw-gradient-from: var(--focus);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-1:focus {
+  --tw-gradient-from: var(--graph-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-10:focus {
+  --tw-gradient-from: var(--graph-10);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-11:focus {
+  --tw-gradient-from: var(--graph-11);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-2:focus {
+  --tw-gradient-from: var(--graph-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-3:focus {
+  --tw-gradient-from: var(--graph-3);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-4:focus {
+  --tw-gradient-from: var(--graph-4);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-5:focus {
+  --tw-gradient-from: var(--graph-5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-6:focus {
+  --tw-gradient-from: var(--graph-6);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-7:focus {
+  --tw-gradient-from: var(--graph-7);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-8:focus {
+  --tw-gradient-from: var(--graph-8);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-9:focus {
+  --tw-gradient-from: var(--graph-9);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-disabled:focus {
+  --tw-gradient-from: var(--graph-disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-ground-floor:focus {
+  --tw-gradient-from: var(--ground-floor);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-high:focus {
+  --tw-gradient-from: var(--high);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-informational:focus {
+  --tw-gradient-from: var(--informational);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-lines-dark:focus {
+  --tw-gradient-from: var(--lines-dark);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-lines-light:focus {
+  --tw-gradient-from: var(--lines-light);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-low:focus {
+  --tw-gradient-from: var(--low);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-medium:focus {
+  --tw-gradient-from: var(--medium);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-mezzanine:focus {
+  --tw-gradient-from: var(--mezzanine);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-nav-text-and-icons:focus {
+  --tw-gradient-from: var(--nav-text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-nav-text-secondary:focus {
+  --tw-gradient-from: var(--nav-text-secondary);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-network-operations:focus {
+  --tw-gradient-from: var(--network-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-normal-hover:focus {
+  --tw-gradient-from: var(--normal-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-normal-idle:focus {
+  --tw-gradient-from: var(--normal-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-normal-pressed:focus {
+  --tw-gradient-from: var(--normal-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-overlay-0\\\\.5:focus {
+  --tw-gradient-from: var(--overlay-0\\\\.5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-overlay-1:focus {
+  --tw-gradient-from: var(--overlay-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-overlay-2:focus {
+  --tw-gradient-from: var(--overlay-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-positive:focus {
+  --tw-gradient-from: var(--positive);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-primary-hover:focus {
+  --tw-gradient-from: var(--primary-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-primary-idle:focus {
+  --tw-gradient-from: var(--primary-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-primary-pressed:focus {
+  --tw-gradient-from: var(--primary-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-process-operations:focus {
+  --tw-gradient-from: var(--process-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-purple:focus {
+  --tw-gradient-from: var(--purple);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-registry-operations:focus {
+  --tw-gradient-from: var(--registry-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-selected:focus {
+  --tw-gradient-from: var(--selected);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-2xl:focus {
+  --tw-gradient-from: var(--surface-2xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-base:focus {
+  --tw-gradient-from: var(--surface-base);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-inner:focus {
+  --tw-gradient-from: var(--surface-inner);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-lg:focus {
+  --tw-gradient-from: var(--surface-lg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-md:focus {
+  --tw-gradient-from: var(--surface-md);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-xl:focus {
+  --tw-gradient-from: var(--surface-xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-text-and-icons:focus {
+  --tw-gradient-from: var(--text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-titles-and-attributes:focus {
+  --tw-gradient-from: var(--titles-and-attributes);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-current {
+  --tw-gradient-stops: var(--tw-gradient-from), currentColor, var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-transparent {
+  --tw-gradient-stops: var(--tw-gradient-from), transparent, var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.via-falcon {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--falcon), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-basement {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--basement), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-blue {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--blue), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-body-and-labels {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--body-and-labels), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-brand {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--brand), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-code-base-64 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-base-64), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-code-bg {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-bg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-code-outline {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-outline), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-code-text {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-text), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-critical {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--critical), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-destructive-hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-destructive-idle {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-destructive-pressed {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-disabled {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-disc-operations {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disc-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-dns-requests {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--dns-requests), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--focus), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-1 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-10 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-10), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-11 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-11), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-2 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-3 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-3), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-4 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-4), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-5 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-6 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-6), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-7 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-7), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-8 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-8), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-9 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-9), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-disabled {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-ground-floor {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--ground-floor), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-high {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--high), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-informational {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--informational), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-lines-dark {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-dark), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-lines-light {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-light), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-low {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--low), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-medium {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--medium), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-mezzanine {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--mezzanine), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-nav-text-and-icons {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-nav-text-secondary {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-secondary), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-network-operations {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--network-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-normal-hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-normal-idle {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-normal-pressed {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-overlay-0\\\\.5 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-0\\\\.5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-overlay-1 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-overlay-2 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-positive {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--positive), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-primary-hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-primary-idle {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-primary-pressed {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-process-operations {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--process-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-purple {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--purple), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-registry-operations {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--registry-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-selected {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--selected), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-2xl {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-2xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-base {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-base), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-inner {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-inner), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-lg {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-lg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-md {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-md), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-xl {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-text-and-icons {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-titles-and-attributes {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--titles-and-attributes), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-current:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), currentColor, var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-transparent:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), transparent, var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.hover\\\\:via-falcon:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--falcon), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-basement:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--basement), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-blue:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--blue), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-body-and-labels:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--body-and-labels), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-brand:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--brand), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-code-base-64:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-base-64), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-code-bg:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-bg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-code-outline:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-outline), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-code-text:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-text), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-critical:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--critical), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-destructive-hover:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-destructive-idle:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-destructive-pressed:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-disabled:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-disc-operations:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disc-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-dns-requests:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--dns-requests), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-focus:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--focus), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-1:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-10:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-10), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-11:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-11), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-2:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-3:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-3), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-4:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-4), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-5:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-6:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-6), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-7:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-7), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-8:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-8), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-9:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-9), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-disabled:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-ground-floor:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--ground-floor), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-high:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--high), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-informational:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--informational), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-lines-dark:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-dark), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-lines-light:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-light), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-low:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--low), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-medium:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--medium), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-mezzanine:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--mezzanine), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-nav-text-and-icons:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-nav-text-secondary:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-secondary), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-network-operations:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--network-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-normal-hover:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-normal-idle:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-normal-pressed:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-overlay-0\\\\.5:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-0\\\\.5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-overlay-1:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-overlay-2:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-positive:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--positive), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-primary-hover:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-primary-idle:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-primary-pressed:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-process-operations:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--process-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-purple:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--purple), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-registry-operations:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--registry-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-selected:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--selected), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-2xl:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-2xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-base:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-base), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-inner:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-inner), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-lg:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-lg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-md:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-md), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-xl:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-text-and-icons:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-titles-and-attributes:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--titles-and-attributes), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-current:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), currentColor, var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-transparent:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), transparent, var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.focus\\\\:via-falcon:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--falcon), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-basement:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--basement), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-blue:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--blue), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-body-and-labels:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--body-and-labels), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-brand:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--brand), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-code-base-64:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-base-64), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-code-bg:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-bg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-code-outline:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-outline), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-code-text:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-text), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-critical:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--critical), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-destructive-hover:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-destructive-idle:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-destructive-pressed:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-disabled:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-disc-operations:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disc-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-dns-requests:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--dns-requests), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-focus:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--focus), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-1:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-10:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-10), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-11:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-11), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-2:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-3:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-3), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-4:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-4), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-5:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-6:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-6), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-7:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-7), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-8:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-8), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-9:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-9), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-disabled:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-ground-floor:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--ground-floor), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-high:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--high), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-informational:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--informational), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-lines-dark:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-dark), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-lines-light:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-light), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-low:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--low), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-medium:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--medium), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-mezzanine:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--mezzanine), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-nav-text-and-icons:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-nav-text-secondary:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-secondary), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-network-operations:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--network-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-normal-hover:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-normal-idle:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-normal-pressed:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-overlay-0\\\\.5:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-0\\\\.5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-overlay-1:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-overlay-2:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-positive:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--positive), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-primary-hover:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-primary-idle:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-primary-pressed:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-process-operations:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--process-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-purple:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--purple), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-registry-operations:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--registry-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-selected:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--selected), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-2xl:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-2xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-base:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-base), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-inner:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-inner), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-lg:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-lg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-md:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-md), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-xl:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-text-and-icons:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-titles-and-attributes:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--titles-and-attributes), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.to-current {
+  --tw-gradient-to: currentColor;
+}
+
+.to-transparent {
+  --tw-gradient-to: transparent;
+}
+
+.to-falcon {
+  --tw-gradient-to: var(--falcon);
+}
+
+.to-basement {
+  --tw-gradient-to: var(--basement);
+}
+
+.to-blue {
+  --tw-gradient-to: var(--blue);
+}
+
+.to-body-and-labels {
+  --tw-gradient-to: var(--body-and-labels);
+}
+
+.to-brand {
+  --tw-gradient-to: var(--brand);
+}
+
+.to-code-base-64 {
+  --tw-gradient-to: var(--code-base-64);
+}
+
+.to-code-bg {
+  --tw-gradient-to: var(--code-bg);
+}
+
+.to-code-outline {
+  --tw-gradient-to: var(--code-outline);
+}
+
+.to-code-text {
+  --tw-gradient-to: var(--code-text);
+}
+
+.to-critical {
+  --tw-gradient-to: var(--critical);
+}
+
+.to-destructive-hover {
+  --tw-gradient-to: var(--destructive-hover);
+}
+
+.to-destructive-idle {
+  --tw-gradient-to: var(--destructive-idle);
+}
+
+.to-destructive-pressed {
+  --tw-gradient-to: var(--destructive-pressed);
+}
+
+.to-disabled {
+  --tw-gradient-to: var(--disabled);
+}
+
+.to-disc-operations {
+  --tw-gradient-to: var(--disc-operations);
+}
+
+.to-dns-requests {
+  --tw-gradient-to: var(--dns-requests);
+}
+
+.to-focus {
+  --tw-gradient-to: var(--focus);
+}
+
+.to-graph-1 {
+  --tw-gradient-to: var(--graph-1);
+}
+
+.to-graph-10 {
+  --tw-gradient-to: var(--graph-10);
+}
+
+.to-graph-11 {
+  --tw-gradient-to: var(--graph-11);
+}
+
+.to-graph-2 {
+  --tw-gradient-to: var(--graph-2);
+}
+
+.to-graph-3 {
+  --tw-gradient-to: var(--graph-3);
+}
+
+.to-graph-4 {
+  --tw-gradient-to: var(--graph-4);
+}
+
+.to-graph-5 {
+  --tw-gradient-to: var(--graph-5);
+}
+
+.to-graph-6 {
+  --tw-gradient-to: var(--graph-6);
+}
+
+.to-graph-7 {
+  --tw-gradient-to: var(--graph-7);
+}
+
+.to-graph-8 {
+  --tw-gradient-to: var(--graph-8);
+}
+
+.to-graph-9 {
+  --tw-gradient-to: var(--graph-9);
+}
+
+.to-graph-disabled {
+  --tw-gradient-to: var(--graph-disabled);
+}
+
+.to-ground-floor {
+  --tw-gradient-to: var(--ground-floor);
+}
+
+.to-high {
+  --tw-gradient-to: var(--high);
+}
+
+.to-informational {
+  --tw-gradient-to: var(--informational);
+}
+
+.to-lines-dark {
+  --tw-gradient-to: var(--lines-dark);
+}
+
+.to-lines-light {
+  --tw-gradient-to: var(--lines-light);
+}
+
+.to-low {
+  --tw-gradient-to: var(--low);
+}
+
+.to-medium {
+  --tw-gradient-to: var(--medium);
+}
+
+.to-mezzanine {
+  --tw-gradient-to: var(--mezzanine);
+}
+
+.to-nav-text-and-icons {
+  --tw-gradient-to: var(--nav-text-and-icons);
+}
+
+.to-nav-text-secondary {
+  --tw-gradient-to: var(--nav-text-secondary);
+}
+
+.to-network-operations {
+  --tw-gradient-to: var(--network-operations);
+}
+
+.to-normal-hover {
+  --tw-gradient-to: var(--normal-hover);
+}
+
+.to-normal-idle {
+  --tw-gradient-to: var(--normal-idle);
+}
+
+.to-normal-pressed {
+  --tw-gradient-to: var(--normal-pressed);
+}
+
+.to-overlay-0\\\\.5 {
+  --tw-gradient-to: var(--overlay-0\\\\.5);
+}
+
+.to-overlay-1 {
+  --tw-gradient-to: var(--overlay-1);
+}
+
+.to-overlay-2 {
+  --tw-gradient-to: var(--overlay-2);
+}
+
+.to-positive {
+  --tw-gradient-to: var(--positive);
+}
+
+.to-primary-hover {
+  --tw-gradient-to: var(--primary-hover);
+}
+
+.to-primary-idle {
+  --tw-gradient-to: var(--primary-idle);
+}
+
+.to-primary-pressed {
+  --tw-gradient-to: var(--primary-pressed);
+}
+
+.to-process-operations {
+  --tw-gradient-to: var(--process-operations);
+}
+
+.to-purple {
+  --tw-gradient-to: var(--purple);
+}
+
+.to-registry-operations {
+  --tw-gradient-to: var(--registry-operations);
+}
+
+.to-selected {
+  --tw-gradient-to: var(--selected);
+}
+
+.to-surface-2xl {
+  --tw-gradient-to: var(--surface-2xl);
+}
+
+.to-surface-base {
+  --tw-gradient-to: var(--surface-base);
+}
+
+.to-surface-inner {
+  --tw-gradient-to: var(--surface-inner);
+}
+
+.to-surface-lg {
+  --tw-gradient-to: var(--surface-lg);
+}
+
+.to-surface-md {
+  --tw-gradient-to: var(--surface-md);
+}
+
+.to-surface-xl {
+  --tw-gradient-to: var(--surface-xl);
+}
+
+.to-text-and-icons {
+  --tw-gradient-to: var(--text-and-icons);
+}
+
+.to-titles-and-attributes {
+  --tw-gradient-to: var(--titles-and-attributes);
+}
+
+.hover\\\\:to-current:hover {
+  --tw-gradient-to: currentColor;
+}
+
+.hover\\\\:to-transparent:hover {
+  --tw-gradient-to: transparent;
+}
+
+.hover\\\\:to-falcon:hover {
+  --tw-gradient-to: var(--falcon);
+}
+
+.hover\\\\:to-basement:hover {
+  --tw-gradient-to: var(--basement);
+}
+
+.hover\\\\:to-blue:hover {
+  --tw-gradient-to: var(--blue);
+}
+
+.hover\\\\:to-body-and-labels:hover {
+  --tw-gradient-to: var(--body-and-labels);
+}
+
+.hover\\\\:to-brand:hover {
+  --tw-gradient-to: var(--brand);
+}
+
+.hover\\\\:to-code-base-64:hover {
+  --tw-gradient-to: var(--code-base-64);
+}
+
+.hover\\\\:to-code-bg:hover {
+  --tw-gradient-to: var(--code-bg);
+}
+
+.hover\\\\:to-code-outline:hover {
+  --tw-gradient-to: var(--code-outline);
+}
+
+.hover\\\\:to-code-text:hover {
+  --tw-gradient-to: var(--code-text);
+}
+
+.hover\\\\:to-critical:hover {
+  --tw-gradient-to: var(--critical);
+}
+
+.hover\\\\:to-destructive-hover:hover {
+  --tw-gradient-to: var(--destructive-hover);
+}
+
+.hover\\\\:to-destructive-idle:hover {
+  --tw-gradient-to: var(--destructive-idle);
+}
+
+.hover\\\\:to-destructive-pressed:hover {
+  --tw-gradient-to: var(--destructive-pressed);
+}
+
+.hover\\\\:to-disabled:hover {
+  --tw-gradient-to: var(--disabled);
+}
+
+.hover\\\\:to-disc-operations:hover {
+  --tw-gradient-to: var(--disc-operations);
+}
+
+.hover\\\\:to-dns-requests:hover {
+  --tw-gradient-to: var(--dns-requests);
+}
+
+.hover\\\\:to-focus:hover {
+  --tw-gradient-to: var(--focus);
+}
+
+.hover\\\\:to-graph-1:hover {
+  --tw-gradient-to: var(--graph-1);
+}
+
+.hover\\\\:to-graph-10:hover {
+  --tw-gradient-to: var(--graph-10);
+}
+
+.hover\\\\:to-graph-11:hover {
+  --tw-gradient-to: var(--graph-11);
+}
+
+.hover\\\\:to-graph-2:hover {
+  --tw-gradient-to: var(--graph-2);
+}
+
+.hover\\\\:to-graph-3:hover {
+  --tw-gradient-to: var(--graph-3);
+}
+
+.hover\\\\:to-graph-4:hover {
+  --tw-gradient-to: var(--graph-4);
+}
+
+.hover\\\\:to-graph-5:hover {
+  --tw-gradient-to: var(--graph-5);
+}
+
+.hover\\\\:to-graph-6:hover {
+  --tw-gradient-to: var(--graph-6);
+}
+
+.hover\\\\:to-graph-7:hover {
+  --tw-gradient-to: var(--graph-7);
+}
+
+.hover\\\\:to-graph-8:hover {
+  --tw-gradient-to: var(--graph-8);
+}
+
+.hover\\\\:to-graph-9:hover {
+  --tw-gradient-to: var(--graph-9);
+}
+
+.hover\\\\:to-graph-disabled:hover {
+  --tw-gradient-to: var(--graph-disabled);
+}
+
+.hover\\\\:to-ground-floor:hover {
+  --tw-gradient-to: var(--ground-floor);
+}
+
+.hover\\\\:to-high:hover {
+  --tw-gradient-to: var(--high);
+}
+
+.hover\\\\:to-informational:hover {
+  --tw-gradient-to: var(--informational);
+}
+
+.hover\\\\:to-lines-dark:hover {
+  --tw-gradient-to: var(--lines-dark);
+}
+
+.hover\\\\:to-lines-light:hover {
+  --tw-gradient-to: var(--lines-light);
+}
+
+.hover\\\\:to-low:hover {
+  --tw-gradient-to: var(--low);
+}
+
+.hover\\\\:to-medium:hover {
+  --tw-gradient-to: var(--medium);
+}
+
+.hover\\\\:to-mezzanine:hover {
+  --tw-gradient-to: var(--mezzanine);
+}
+
+.hover\\\\:to-nav-text-and-icons:hover {
+  --tw-gradient-to: var(--nav-text-and-icons);
+}
+
+.hover\\\\:to-nav-text-secondary:hover {
+  --tw-gradient-to: var(--nav-text-secondary);
+}
+
+.hover\\\\:to-network-operations:hover {
+  --tw-gradient-to: var(--network-operations);
+}
+
+.hover\\\\:to-normal-hover:hover {
+  --tw-gradient-to: var(--normal-hover);
+}
+
+.hover\\\\:to-normal-idle:hover {
+  --tw-gradient-to: var(--normal-idle);
+}
+
+.hover\\\\:to-normal-pressed:hover {
+  --tw-gradient-to: var(--normal-pressed);
+}
+
+.hover\\\\:to-overlay-0\\\\.5:hover {
+  --tw-gradient-to: var(--overlay-0\\\\.5);
+}
+
+.hover\\\\:to-overlay-1:hover {
+  --tw-gradient-to: var(--overlay-1);
+}
+
+.hover\\\\:to-overlay-2:hover {
+  --tw-gradient-to: var(--overlay-2);
+}
+
+.hover\\\\:to-positive:hover {
+  --tw-gradient-to: var(--positive);
+}
+
+.hover\\\\:to-primary-hover:hover {
+  --tw-gradient-to: var(--primary-hover);
+}
+
+.hover\\\\:to-primary-idle:hover {
+  --tw-gradient-to: var(--primary-idle);
+}
+
+.hover\\\\:to-primary-pressed:hover {
+  --tw-gradient-to: var(--primary-pressed);
+}
+
+.hover\\\\:to-process-operations:hover {
+  --tw-gradient-to: var(--process-operations);
+}
+
+.hover\\\\:to-purple:hover {
+  --tw-gradient-to: var(--purple);
+}
+
+.hover\\\\:to-registry-operations:hover {
+  --tw-gradient-to: var(--registry-operations);
+}
+
+.hover\\\\:to-selected:hover {
+  --tw-gradient-to: var(--selected);
+}
+
+.hover\\\\:to-surface-2xl:hover {
+  --tw-gradient-to: var(--surface-2xl);
+}
+
+.hover\\\\:to-surface-base:hover {
+  --tw-gradient-to: var(--surface-base);
+}
+
+.hover\\\\:to-surface-inner:hover {
+  --tw-gradient-to: var(--surface-inner);
+}
+
+.hover\\\\:to-surface-lg:hover {
+  --tw-gradient-to: var(--surface-lg);
+}
+
+.hover\\\\:to-surface-md:hover {
+  --tw-gradient-to: var(--surface-md);
+}
+
+.hover\\\\:to-surface-xl:hover {
+  --tw-gradient-to: var(--surface-xl);
+}
+
+.hover\\\\:to-text-and-icons:hover {
+  --tw-gradient-to: var(--text-and-icons);
+}
+
+.hover\\\\:to-titles-and-attributes:hover {
+  --tw-gradient-to: var(--titles-and-attributes);
+}
+
+.focus\\\\:to-current:focus {
+  --tw-gradient-to: currentColor;
+}
+
+.focus\\\\:to-transparent:focus {
+  --tw-gradient-to: transparent;
+}
+
+.focus\\\\:to-falcon:focus {
+  --tw-gradient-to: var(--falcon);
+}
+
+.focus\\\\:to-basement:focus {
+  --tw-gradient-to: var(--basement);
+}
+
+.focus\\\\:to-blue:focus {
+  --tw-gradient-to: var(--blue);
+}
+
+.focus\\\\:to-body-and-labels:focus {
+  --tw-gradient-to: var(--body-and-labels);
+}
+
+.focus\\\\:to-brand:focus {
+  --tw-gradient-to: var(--brand);
+}
+
+.focus\\\\:to-code-base-64:focus {
+  --tw-gradient-to: var(--code-base-64);
+}
+
+.focus\\\\:to-code-bg:focus {
+  --tw-gradient-to: var(--code-bg);
+}
+
+.focus\\\\:to-code-outline:focus {
+  --tw-gradient-to: var(--code-outline);
+}
+
+.focus\\\\:to-code-text:focus {
+  --tw-gradient-to: var(--code-text);
+}
+
+.focus\\\\:to-critical:focus {
+  --tw-gradient-to: var(--critical);
+}
+
+.focus\\\\:to-destructive-hover:focus {
+  --tw-gradient-to: var(--destructive-hover);
+}
+
+.focus\\\\:to-destructive-idle:focus {
+  --tw-gradient-to: var(--destructive-idle);
+}
+
+.focus\\\\:to-destructive-pressed:focus {
+  --tw-gradient-to: var(--destructive-pressed);
+}
+
+.focus\\\\:to-disabled:focus {
+  --tw-gradient-to: var(--disabled);
+}
+
+.focus\\\\:to-disc-operations:focus {
+  --tw-gradient-to: var(--disc-operations);
+}
+
+.focus\\\\:to-dns-requests:focus {
+  --tw-gradient-to: var(--dns-requests);
+}
+
+.focus\\\\:to-focus:focus {
+  --tw-gradient-to: var(--focus);
+}
+
+.focus\\\\:to-graph-1:focus {
+  --tw-gradient-to: var(--graph-1);
+}
+
+.focus\\\\:to-graph-10:focus {
+  --tw-gradient-to: var(--graph-10);
+}
+
+.focus\\\\:to-graph-11:focus {
+  --tw-gradient-to: var(--graph-11);
+}
+
+.focus\\\\:to-graph-2:focus {
+  --tw-gradient-to: var(--graph-2);
+}
+
+.focus\\\\:to-graph-3:focus {
+  --tw-gradient-to: var(--graph-3);
+}
+
+.focus\\\\:to-graph-4:focus {
+  --tw-gradient-to: var(--graph-4);
+}
+
+.focus\\\\:to-graph-5:focus {
+  --tw-gradient-to: var(--graph-5);
+}
+
+.focus\\\\:to-graph-6:focus {
+  --tw-gradient-to: var(--graph-6);
+}
+
+.focus\\\\:to-graph-7:focus {
+  --tw-gradient-to: var(--graph-7);
+}
+
+.focus\\\\:to-graph-8:focus {
+  --tw-gradient-to: var(--graph-8);
+}
+
+.focus\\\\:to-graph-9:focus {
+  --tw-gradient-to: var(--graph-9);
+}
+
+.focus\\\\:to-graph-disabled:focus {
+  --tw-gradient-to: var(--graph-disabled);
+}
+
+.focus\\\\:to-ground-floor:focus {
+  --tw-gradient-to: var(--ground-floor);
+}
+
+.focus\\\\:to-high:focus {
+  --tw-gradient-to: var(--high);
+}
+
+.focus\\\\:to-informational:focus {
+  --tw-gradient-to: var(--informational);
+}
+
+.focus\\\\:to-lines-dark:focus {
+  --tw-gradient-to: var(--lines-dark);
+}
+
+.focus\\\\:to-lines-light:focus {
+  --tw-gradient-to: var(--lines-light);
+}
+
+.focus\\\\:to-low:focus {
+  --tw-gradient-to: var(--low);
+}
+
+.focus\\\\:to-medium:focus {
+  --tw-gradient-to: var(--medium);
+}
+
+.focus\\\\:to-mezzanine:focus {
+  --tw-gradient-to: var(--mezzanine);
+}
+
+.focus\\\\:to-nav-text-and-icons:focus {
+  --tw-gradient-to: var(--nav-text-and-icons);
+}
+
+.focus\\\\:to-nav-text-secondary:focus {
+  --tw-gradient-to: var(--nav-text-secondary);
+}
+
+.focus\\\\:to-network-operations:focus {
+  --tw-gradient-to: var(--network-operations);
+}
+
+.focus\\\\:to-normal-hover:focus {
+  --tw-gradient-to: var(--normal-hover);
+}
+
+.focus\\\\:to-normal-idle:focus {
+  --tw-gradient-to: var(--normal-idle);
+}
+
+.focus\\\\:to-normal-pressed:focus {
+  --tw-gradient-to: var(--normal-pressed);
+}
+
+.focus\\\\:to-overlay-0\\\\.5:focus {
+  --tw-gradient-to: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:to-overlay-1:focus {
+  --tw-gradient-to: var(--overlay-1);
+}
+
+.focus\\\\:to-overlay-2:focus {
+  --tw-gradient-to: var(--overlay-2);
+}
+
+.focus\\\\:to-positive:focus {
+  --tw-gradient-to: var(--positive);
+}
+
+.focus\\\\:to-primary-hover:focus {
+  --tw-gradient-to: var(--primary-hover);
+}
+
+.focus\\\\:to-primary-idle:focus {
+  --tw-gradient-to: var(--primary-idle);
+}
+
+.focus\\\\:to-primary-pressed:focus {
+  --tw-gradient-to: var(--primary-pressed);
+}
+
+.focus\\\\:to-process-operations:focus {
+  --tw-gradient-to: var(--process-operations);
+}
+
+.focus\\\\:to-purple:focus {
+  --tw-gradient-to: var(--purple);
+}
+
+.focus\\\\:to-registry-operations:focus {
+  --tw-gradient-to: var(--registry-operations);
+}
+
+.focus\\\\:to-selected:focus {
+  --tw-gradient-to: var(--selected);
+}
+
+.focus\\\\:to-surface-2xl:focus {
+  --tw-gradient-to: var(--surface-2xl);
+}
+
+.focus\\\\:to-surface-base:focus {
+  --tw-gradient-to: var(--surface-base);
+}
+
+.focus\\\\:to-surface-inner:focus {
+  --tw-gradient-to: var(--surface-inner);
+}
+
+.focus\\\\:to-surface-lg:focus {
+  --tw-gradient-to: var(--surface-lg);
+}
+
+.focus\\\\:to-surface-md:focus {
+  --tw-gradient-to: var(--surface-md);
+}
+
+.focus\\\\:to-surface-xl:focus {
+  --tw-gradient-to: var(--surface-xl);
+}
+
+.focus\\\\:to-text-and-icons:focus {
+  --tw-gradient-to: var(--text-and-icons);
+}
+
+.focus\\\\:to-titles-and-attributes:focus {
+  --tw-gradient-to: var(--titles-and-attributes);
+}
+
+.decoration-slice {
+  -webkit-box-decoration-break: slice;
+          box-decoration-break: slice;
+}
+
+.decoration-clone {
+  -webkit-box-decoration-break: clone;
+          box-decoration-break: clone;
+}
+
+.bg-auto {
+  background-size: auto;
+}
+
+.bg-cover {
+  background-size: cover;
+}
+
+.bg-contain {
+  background-size: contain;
+}
+
+.bg-fixed {
+  background-attachment: fixed;
+}
+
+.bg-local {
+  background-attachment: local;
+}
+
+.bg-scroll {
+  background-attachment: scroll;
+}
+
+.bg-clip-border {
+  background-clip: border-box;
+}
+
+.bg-clip-padding {
+  background-clip: padding-box;
+}
+
+.bg-clip-content {
+  background-clip: content-box;
+}
+
+.bg-clip-text {
+  -webkit-background-clip: text;
+          background-clip: text;
+}
+
+.bg-bottom {
+  background-position: bottom;
+}
+
+.bg-center {
+  background-position: center;
+}
+
+.bg-left {
+  background-position: left;
+}
+
+.bg-left-bottom {
+  background-position: left bottom;
+}
+
+.bg-left-top {
+  background-position: left top;
+}
+
+.bg-right {
+  background-position: right;
+}
+
+.bg-right-bottom {
+  background-position: right bottom;
+}
+
+.bg-right-top {
+  background-position: right top;
+}
+
+.bg-top {
+  background-position: top;
+}
+
+.bg-repeat {
+  background-repeat: repeat;
+}
+
+.bg-no-repeat {
+  background-repeat: no-repeat;
+}
+
+.bg-repeat-x {
+  background-repeat: repeat-x;
+}
+
+.bg-repeat-y {
+  background-repeat: repeat-y;
+}
+
+.bg-repeat-round {
+  background-repeat: round;
+}
+
+.bg-repeat-space {
+  background-repeat: space;
+}
+
+.bg-origin-border {
+  background-origin: border-box;
+}
+
+.bg-origin-padding {
+  background-origin: padding-box;
+}
+
+.bg-origin-content {
+  background-origin: content-box;
+}
+
+.fill-current {
+  fill: currentColor;
+}
+
+.stroke-current {
+  stroke: currentColor;
+}
+
+.stroke-0 {
+  stroke-width: 0;
+}
+
+.stroke-1 {
+  stroke-width: 1;
+}
+
+.stroke-2 {
+  stroke-width: 2;
+}
+
+.object-contain {
+  -o-object-fit: contain;
+     object-fit: contain;
+}
+
+.object-cover {
+  -o-object-fit: cover;
+     object-fit: cover;
+}
+
+.object-fill {
+  -o-object-fit: fill;
+     object-fit: fill;
+}
+
+.object-none {
+  -o-object-fit: none;
+     object-fit: none;
+}
+
+.object-scale-down {
+  -o-object-fit: scale-down;
+     object-fit: scale-down;
+}
+
+.object-bottom {
+  -o-object-position: bottom;
+     object-position: bottom;
+}
+
+.object-center {
+  -o-object-position: center;
+     object-position: center;
+}
+
+.object-left {
+  -o-object-position: left;
+     object-position: left;
+}
+
+.object-left-bottom {
+  -o-object-position: left bottom;
+     object-position: left bottom;
+}
+
+.object-left-top {
+  -o-object-position: left top;
+     object-position: left top;
+}
+
+.object-right {
+  -o-object-position: right;
+     object-position: right;
+}
+
+.object-right-bottom {
+  -o-object-position: right bottom;
+     object-position: right bottom;
+}
+
+.object-right-top {
+  -o-object-position: right top;
+     object-position: right top;
+}
+
+.object-top {
+  -o-object-position: top;
+     object-position: top;
+}
+
+.p-0 {
+  padding: 0px;
+}
+
+.p-1 {
+  padding: 0.25rem;
+}
+
+.p-2 {
+  padding: 0.5rem;
+}
+
+.p-3 {
+  padding: 0.75rem;
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.p-5 {
+  padding: 1.25rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
+}
+
+.p-7 {
+  padding: 1.75rem;
+}
+
+.p-8 {
+  padding: 2rem;
+}
+
+.p-9 {
+  padding: 2.25rem;
+}
+
+.p-10 {
+  padding: 2.5rem;
+}
+
+.p-11 {
+  padding: 2.75rem;
+}
+
+.p-12 {
+  padding: 3rem;
+}
+
+.p-14 {
+  padding: 3.5rem;
+}
+
+.p-16 {
+  padding: 4rem;
+}
+
+.p-20 {
+  padding: 5rem;
+}
+
+.p-24 {
+  padding: 6rem;
+}
+
+.p-28 {
+  padding: 7rem;
+}
+
+.p-32 {
+  padding: 8rem;
+}
+
+.p-36 {
+  padding: 9rem;
+}
+
+.p-40 {
+  padding: 10rem;
+}
+
+.p-44 {
+  padding: 11rem;
+}
+
+.p-48 {
+  padding: 12rem;
+}
+
+.p-52 {
+  padding: 13rem;
+}
+
+.p-56 {
+  padding: 14rem;
+}
+
+.p-60 {
+  padding: 15rem;
+}
+
+.p-64 {
+  padding: 16rem;
+}
+
+.p-72 {
+  padding: 18rem;
+}
+
+.p-80 {
+  padding: 20rem;
+}
+
+.p-96 {
+  padding: 24rem;
+}
+
+.p-px {
+  padding: 1px;
+}
+
+.p-0\\\\.5 {
+  padding: 0.125rem;
+}
+
+.p-1\\\\.5 {
+  padding: 0.375rem;
+}
+
+.p-2\\\\.5 {
+  padding: 0.625rem;
+}
+
+.p-3\\\\.5 {
+  padding: 0.875rem;
+}
+
+.p-0\\\\.25 {
+  padding: 0.063rem;
+}
+
+.p-property-tabs-top {
+  padding: var(--property-tabs-top);
+}
+
+.p-unset {
+  padding: unset;
+}
+
+.px-0 {
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.px-5 {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.px-7 {
+  padding-left: 1.75rem;
+  padding-right: 1.75rem;
+}
+
+.px-8 {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.px-9 {
+  padding-left: 2.25rem;
+  padding-right: 2.25rem;
+}
+
+.px-10 {
+  padding-left: 2.5rem;
+  padding-right: 2.5rem;
+}
+
+.px-11 {
+  padding-left: 2.75rem;
+  padding-right: 2.75rem;
+}
+
+.px-12 {
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.px-14 {
+  padding-left: 3.5rem;
+  padding-right: 3.5rem;
+}
+
+.px-16 {
+  padding-left: 4rem;
+  padding-right: 4rem;
+}
+
+.px-20 {
+  padding-left: 5rem;
+  padding-right: 5rem;
+}
+
+.px-24 {
+  padding-left: 6rem;
+  padding-right: 6rem;
+}
+
+.px-28 {
+  padding-left: 7rem;
+  padding-right: 7rem;
+}
+
+.px-32 {
+  padding-left: 8rem;
+  padding-right: 8rem;
+}
+
+.px-36 {
+  padding-left: 9rem;
+  padding-right: 9rem;
+}
+
+.px-40 {
+  padding-left: 10rem;
+  padding-right: 10rem;
+}
+
+.px-44 {
+  padding-left: 11rem;
+  padding-right: 11rem;
+}
+
+.px-48 {
+  padding-left: 12rem;
+  padding-right: 12rem;
+}
+
+.px-52 {
+  padding-left: 13rem;
+  padding-right: 13rem;
+}
+
+.px-56 {
+  padding-left: 14rem;
+  padding-right: 14rem;
+}
+
+.px-60 {
+  padding-left: 15rem;
+  padding-right: 15rem;
+}
+
+.px-64 {
+  padding-left: 16rem;
+  padding-right: 16rem;
+}
+
+.px-72 {
+  padding-left: 18rem;
+  padding-right: 18rem;
+}
+
+.px-80 {
+  padding-left: 20rem;
+  padding-right: 20rem;
+}
+
+.px-96 {
+  padding-left: 24rem;
+  padding-right: 24rem;
+}
+
+.px-px {
+  padding-left: 1px;
+  padding-right: 1px;
+}
+
+.px-0\\\\.5 {
+  padding-left: 0.125rem;
+  padding-right: 0.125rem;
+}
+
+.px-1\\\\.5 {
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+}
+
+.px-2\\\\.5 {
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+}
+
+.px-3\\\\.5 {
+  padding-left: 0.875rem;
+  padding-right: 0.875rem;
+}
+
+.px-0\\\\.25 {
+  padding-left: 0.063rem;
+  padding-right: 0.063rem;
+}
+
+.px-property-tabs-top {
+  padding-left: var(--property-tabs-top);
+  padding-right: var(--property-tabs-top);
+}
+
+.px-unset {
+  padding-left: unset;
+  padding-right: unset;
+}
+
+.py-0 {
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+}
+
+.py-6 {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.py-7 {
+  padding-top: 1.75rem;
+  padding-bottom: 1.75rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.py-9 {
+  padding-top: 2.25rem;
+  padding-bottom: 2.25rem;
+}
+
+.py-10 {
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
+}
+
+.py-11 {
+  padding-top: 2.75rem;
+  padding-bottom: 2.75rem;
+}
+
+.py-12 {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.py-14 {
+  padding-top: 3.5rem;
+  padding-bottom: 3.5rem;
+}
+
+.py-16 {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}
+
+.py-20 {
+  padding-top: 5rem;
+  padding-bottom: 5rem;
+}
+
+.py-24 {
+  padding-top: 6rem;
+  padding-bottom: 6rem;
+}
+
+.py-28 {
+  padding-top: 7rem;
+  padding-bottom: 7rem;
+}
+
+.py-32 {
+  padding-top: 8rem;
+  padding-bottom: 8rem;
+}
+
+.py-36 {
+  padding-top: 9rem;
+  padding-bottom: 9rem;
+}
+
+.py-40 {
+  padding-top: 10rem;
+  padding-bottom: 10rem;
+}
+
+.py-44 {
+  padding-top: 11rem;
+  padding-bottom: 11rem;
+}
+
+.py-48 {
+  padding-top: 12rem;
+  padding-bottom: 12rem;
+}
+
+.py-52 {
+  padding-top: 13rem;
+  padding-bottom: 13rem;
+}
+
+.py-56 {
+  padding-top: 14rem;
+  padding-bottom: 14rem;
+}
+
+.py-60 {
+  padding-top: 15rem;
+  padding-bottom: 15rem;
+}
+
+.py-64 {
+  padding-top: 16rem;
+  padding-bottom: 16rem;
+}
+
+.py-72 {
+  padding-top: 18rem;
+  padding-bottom: 18rem;
+}
+
+.py-80 {
+  padding-top: 20rem;
+  padding-bottom: 20rem;
+}
+
+.py-96 {
+  padding-top: 24rem;
+  padding-bottom: 24rem;
+}
+
+.py-px {
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+
+.py-0\\\\.5 {
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+}
+
+.py-1\\\\.5 {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+}
+
+.py-2\\\\.5 {
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+}
+
+.py-3\\\\.5 {
+  padding-top: 0.875rem;
+  padding-bottom: 0.875rem;
+}
+
+.py-0\\\\.25 {
+  padding-top: 0.063rem;
+  padding-bottom: 0.063rem;
+}
+
+.py-property-tabs-top {
+  padding-top: var(--property-tabs-top);
+  padding-bottom: var(--property-tabs-top);
+}
+
+.py-unset {
+  padding-top: unset;
+  padding-bottom: unset;
+}
+
+.pt-0 {
+  padding-top: 0px;
+}
+
+.pt-1 {
+  padding-top: 0.25rem;
+}
+
+.pt-2 {
+  padding-top: 0.5rem;
+}
+
+.pt-3 {
+  padding-top: 0.75rem;
+}
+
+.pt-4 {
+  padding-top: 1rem;
+}
+
+.pt-5 {
+  padding-top: 1.25rem;
+}
+
+.pt-6 {
+  padding-top: 1.5rem;
+}
+
+.pt-7 {
+  padding-top: 1.75rem;
+}
+
+.pt-8 {
+  padding-top: 2rem;
+}
+
+.pt-9 {
+  padding-top: 2.25rem;
+}
+
+.pt-10 {
+  padding-top: 2.5rem;
+}
+
+.pt-11 {
+  padding-top: 2.75rem;
+}
+
+.pt-12 {
+  padding-top: 3rem;
+}
+
+.pt-14 {
+  padding-top: 3.5rem;
+}
+
+.pt-16 {
+  padding-top: 4rem;
+}
+
+.pt-20 {
+  padding-top: 5rem;
+}
+
+.pt-24 {
+  padding-top: 6rem;
+}
+
+.pt-28 {
+  padding-top: 7rem;
+}
+
+.pt-32 {
+  padding-top: 8rem;
+}
+
+.pt-36 {
+  padding-top: 9rem;
+}
+
+.pt-40 {
+  padding-top: 10rem;
+}
+
+.pt-44 {
+  padding-top: 11rem;
+}
+
+.pt-48 {
+  padding-top: 12rem;
+}
+
+.pt-52 {
+  padding-top: 13rem;
+}
+
+.pt-56 {
+  padding-top: 14rem;
+}
+
+.pt-60 {
+  padding-top: 15rem;
+}
+
+.pt-64 {
+  padding-top: 16rem;
+}
+
+.pt-72 {
+  padding-top: 18rem;
+}
+
+.pt-80 {
+  padding-top: 20rem;
+}
+
+.pt-96 {
+  padding-top: 24rem;
+}
+
+.pt-px {
+  padding-top: 1px;
+}
+
+.pt-0\\\\.5 {
+  padding-top: 0.125rem;
+}
+
+.pt-1\\\\.5 {
+  padding-top: 0.375rem;
+}
+
+.pt-2\\\\.5 {
+  padding-top: 0.625rem;
+}
+
+.pt-3\\\\.5 {
+  padding-top: 0.875rem;
+}
+
+.pt-0\\\\.25 {
+  padding-top: 0.063rem;
+}
+
+.pt-property-tabs-top {
+  padding-top: var(--property-tabs-top);
+}
+
+.pt-unset {
+  padding-top: unset;
+}
+
+.pr-0 {
+  padding-right: 0px;
+}
+
+.pr-1 {
+  padding-right: 0.25rem;
+}
+
+.pr-2 {
+  padding-right: 0.5rem;
+}
+
+.pr-3 {
+  padding-right: 0.75rem;
+}
+
+.pr-4 {
+  padding-right: 1rem;
+}
+
+.pr-5 {
+  padding-right: 1.25rem;
+}
+
+.pr-6 {
+  padding-right: 1.5rem;
+}
+
+.pr-7 {
+  padding-right: 1.75rem;
+}
+
+.pr-8 {
+  padding-right: 2rem;
+}
+
+.pr-9 {
+  padding-right: 2.25rem;
+}
+
+.pr-10 {
+  padding-right: 2.5rem;
+}
+
+.pr-11 {
+  padding-right: 2.75rem;
+}
+
+.pr-12 {
+  padding-right: 3rem;
+}
+
+.pr-14 {
+  padding-right: 3.5rem;
+}
+
+.pr-16 {
+  padding-right: 4rem;
+}
+
+.pr-20 {
+  padding-right: 5rem;
+}
+
+.pr-24 {
+  padding-right: 6rem;
+}
+
+.pr-28 {
+  padding-right: 7rem;
+}
+
+.pr-32 {
+  padding-right: 8rem;
+}
+
+.pr-36 {
+  padding-right: 9rem;
+}
+
+.pr-40 {
+  padding-right: 10rem;
+}
+
+.pr-44 {
+  padding-right: 11rem;
+}
+
+.pr-48 {
+  padding-right: 12rem;
+}
+
+.pr-52 {
+  padding-right: 13rem;
+}
+
+.pr-56 {
+  padding-right: 14rem;
+}
+
+.pr-60 {
+  padding-right: 15rem;
+}
+
+.pr-64 {
+  padding-right: 16rem;
+}
+
+.pr-72 {
+  padding-right: 18rem;
+}
+
+.pr-80 {
+  padding-right: 20rem;
+}
+
+.pr-96 {
+  padding-right: 24rem;
+}
+
+.pr-px {
+  padding-right: 1px;
+}
+
+.pr-0\\\\.5 {
+  padding-right: 0.125rem;
+}
+
+.pr-1\\\\.5 {
+  padding-right: 0.375rem;
+}
+
+.pr-2\\\\.5 {
+  padding-right: 0.625rem;
+}
+
+.pr-3\\\\.5 {
+  padding-right: 0.875rem;
+}
+
+.pr-0\\\\.25 {
+  padding-right: 0.063rem;
+}
+
+.pr-property-tabs-top {
+  padding-right: var(--property-tabs-top);
+}
+
+.pr-unset {
+  padding-right: unset;
+}
+
+.pb-0 {
+  padding-bottom: 0px;
+}
+
+.pb-1 {
+  padding-bottom: 0.25rem;
+}
+
+.pb-2 {
+  padding-bottom: 0.5rem;
+}
+
+.pb-3 {
+  padding-bottom: 0.75rem;
+}
+
+.pb-4 {
+  padding-bottom: 1rem;
+}
+
+.pb-5 {
+  padding-bottom: 1.25rem;
+}
+
+.pb-6 {
+  padding-bottom: 1.5rem;
+}
+
+.pb-7 {
+  padding-bottom: 1.75rem;
+}
+
+.pb-8 {
+  padding-bottom: 2rem;
+}
+
+.pb-9 {
+  padding-bottom: 2.25rem;
+}
+
+.pb-10 {
+  padding-bottom: 2.5rem;
+}
+
+.pb-11 {
+  padding-bottom: 2.75rem;
+}
+
+.pb-12 {
+  padding-bottom: 3rem;
+}
+
+.pb-14 {
+  padding-bottom: 3.5rem;
+}
+
+.pb-16 {
+  padding-bottom: 4rem;
+}
+
+.pb-20 {
+  padding-bottom: 5rem;
+}
+
+.pb-24 {
+  padding-bottom: 6rem;
+}
+
+.pb-28 {
+  padding-bottom: 7rem;
+}
+
+.pb-32 {
+  padding-bottom: 8rem;
+}
+
+.pb-36 {
+  padding-bottom: 9rem;
+}
+
+.pb-40 {
+  padding-bottom: 10rem;
+}
+
+.pb-44 {
+  padding-bottom: 11rem;
+}
+
+.pb-48 {
+  padding-bottom: 12rem;
+}
+
+.pb-52 {
+  padding-bottom: 13rem;
+}
+
+.pb-56 {
+  padding-bottom: 14rem;
+}
+
+.pb-60 {
+  padding-bottom: 15rem;
+}
+
+.pb-64 {
+  padding-bottom: 16rem;
+}
+
+.pb-72 {
+  padding-bottom: 18rem;
+}
+
+.pb-80 {
+  padding-bottom: 20rem;
+}
+
+.pb-96 {
+  padding-bottom: 24rem;
+}
+
+.pb-px {
+  padding-bottom: 1px;
+}
+
+.pb-0\\\\.5 {
+  padding-bottom: 0.125rem;
+}
+
+.pb-1\\\\.5 {
+  padding-bottom: 0.375rem;
+}
+
+.pb-2\\\\.5 {
+  padding-bottom: 0.625rem;
+}
+
+.pb-3\\\\.5 {
+  padding-bottom: 0.875rem;
+}
+
+.pb-0\\\\.25 {
+  padding-bottom: 0.063rem;
+}
+
+.pb-property-tabs-top {
+  padding-bottom: var(--property-tabs-top);
+}
+
+.pb-unset {
+  padding-bottom: unset;
+}
+
+.pl-0 {
+  padding-left: 0px;
+}
+
+.pl-1 {
+  padding-left: 0.25rem;
+}
+
+.pl-2 {
+  padding-left: 0.5rem;
+}
+
+.pl-3 {
+  padding-left: 0.75rem;
+}
+
+.pl-4 {
+  padding-left: 1rem;
+}
+
+.pl-5 {
+  padding-left: 1.25rem;
+}
+
+.pl-6 {
+  padding-left: 1.5rem;
+}
+
+.pl-7 {
+  padding-left: 1.75rem;
+}
+
+.pl-8 {
+  padding-left: 2rem;
+}
+
+.pl-9 {
+  padding-left: 2.25rem;
+}
+
+.pl-10 {
+  padding-left: 2.5rem;
+}
+
+.pl-11 {
+  padding-left: 2.75rem;
+}
+
+.pl-12 {
+  padding-left: 3rem;
+}
+
+.pl-14 {
+  padding-left: 3.5rem;
+}
+
+.pl-16 {
+  padding-left: 4rem;
+}
+
+.pl-20 {
+  padding-left: 5rem;
+}
+
+.pl-24 {
+  padding-left: 6rem;
+}
+
+.pl-28 {
+  padding-left: 7rem;
+}
+
+.pl-32 {
+  padding-left: 8rem;
+}
+
+.pl-36 {
+  padding-left: 9rem;
+}
+
+.pl-40 {
+  padding-left: 10rem;
+}
+
+.pl-44 {
+  padding-left: 11rem;
+}
+
+.pl-48 {
+  padding-left: 12rem;
+}
+
+.pl-52 {
+  padding-left: 13rem;
+}
+
+.pl-56 {
+  padding-left: 14rem;
+}
+
+.pl-60 {
+  padding-left: 15rem;
+}
+
+.pl-64 {
+  padding-left: 16rem;
+}
+
+.pl-72 {
+  padding-left: 18rem;
+}
+
+.pl-80 {
+  padding-left: 20rem;
+}
+
+.pl-96 {
+  padding-left: 24rem;
+}
+
+.pl-px {
+  padding-left: 1px;
+}
+
+.pl-0\\\\.5 {
+  padding-left: 0.125rem;
+}
+
+.pl-1\\\\.5 {
+  padding-left: 0.375rem;
+}
+
+.pl-2\\\\.5 {
+  padding-left: 0.625rem;
+}
+
+.pl-3\\\\.5 {
+  padding-left: 0.875rem;
+}
+
+.pl-0\\\\.25 {
+  padding-left: 0.063rem;
+}
+
+.pl-property-tabs-top {
+  padding-left: var(--property-tabs-top);
+}
+
+.pl-unset {
+  padding-left: unset;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.text-justify {
+  text-align: justify;
+}
+
+.align-baseline {
+  vertical-align: baseline;
+}
+
+.align-top {
+  vertical-align: top;
+}
+
+.align-middle {
+  vertical-align: middle;
+}
+
+.align-bottom {
+  vertical-align: bottom;
+}
+
+.align-text-top {
+  vertical-align: text-top;
+}
+
+.align-text-bottom {
+  vertical-align: text-bottom;
+}
+
+.font-sans {
+  font-family: Calibre, sans-serif;
+}
+
+.font-mono {
+  font-family: Monaco, monospace;
+}
+
+.text-xxs {
+  font-size: .5625rem;
+  line-height: 1rem;
+}
+
+.text-xs {
+  font-size: .75rem;
+  line-height: 1.25rem;
+}
+
+.text-sm {
+  font-size: .875rem;
+  line-height: 1.5rem;
+}
+
+.text-md {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.text-lg {
+  font-size: 1.25rem;
+  line-height: 2rem;
+}
+
+.text-xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+.text-2xl {
+  font-size: 2rem;
+  line-height: 2.5rem;
+}
+
+.text-3xl {
+  font-size: 2.5rem;
+  line-height: 3rem;
+}
+
+.text-4xl {
+  font-size: 3rem;
+  line-height: 3.25rem;
+}
+
+.font-thin {
+  font-weight: 100;
+}
+
+.font-extralight {
+  font-weight: 200;
+}
+
+.font-light {
+  font-weight: 300;
+}
+
+.font-normal {
+  font-weight: 400;
+}
+
+.font-medium {
+  font-weight: 500;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-extrabold {
+  font-weight: 800;
+}
+
+.font-black {
+  font-weight: 900;
+}
+
+.hover\\\\:font-thin:hover {
+  font-weight: 100;
+}
+
+.hover\\\\:font-extralight:hover {
+  font-weight: 200;
+}
+
+.hover\\\\:font-light:hover {
+  font-weight: 300;
+}
+
+.hover\\\\:font-normal:hover {
+  font-weight: 400;
+}
+
+.hover\\\\:font-medium:hover {
+  font-weight: 500;
+}
+
+.hover\\\\:font-semibold:hover {
+  font-weight: 600;
+}
+
+.hover\\\\:font-bold:hover {
+  font-weight: 700;
+}
+
+.hover\\\\:font-extrabold:hover {
+  font-weight: 800;
+}
+
+.hover\\\\:font-black:hover {
+  font-weight: 900;
+}
+
+.focus\\\\:font-thin:focus {
+  font-weight: 100;
+}
+
+.focus\\\\:font-extralight:focus {
+  font-weight: 200;
+}
+
+.focus\\\\:font-light:focus {
+  font-weight: 300;
+}
+
+.focus\\\\:font-normal:focus {
+  font-weight: 400;
+}
+
+.focus\\\\:font-medium:focus {
+  font-weight: 500;
+}
+
+.focus\\\\:font-semibold:focus {
+  font-weight: 600;
+}
+
+.focus\\\\:font-bold:focus {
+  font-weight: 700;
+}
+
+.focus\\\\:font-extrabold:focus {
+  font-weight: 800;
+}
+
+.focus\\\\:font-black:focus {
+  font-weight: 900;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.lowercase {
+  text-transform: lowercase;
+}
+
+.capitalize {
+  text-transform: capitalize;
+}
+
+.normal-case {
+  text-transform: none;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.not-italic {
+  font-style: normal;
+}
+
+.ordinal, .slashed-zero, .lining-nums, .oldstyle-nums, .proportional-nums, .tabular-nums, .diagonal-fractions, .stacked-fractions {
+  --tw-ordinal: var(--tw-empty,/*!*/ /*!*/);
+  --tw-slashed-zero: var(--tw-empty,/*!*/ /*!*/);
+  --tw-numeric-figure: var(--tw-empty,/*!*/ /*!*/);
+  --tw-numeric-spacing: var(--tw-empty,/*!*/ /*!*/);
+  --tw-numeric-fraction: var(--tw-empty,/*!*/ /*!*/);
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
+}
+
+.normal-nums {
+  font-variant-numeric: normal;
+}
+
+.ordinal {
+  --tw-ordinal: ordinal;
+}
+
+.slashed-zero {
+  --tw-slashed-zero: slashed-zero;
+}
+
+.lining-nums {
+  --tw-numeric-figure: lining-nums;
+}
+
+.oldstyle-nums {
+  --tw-numeric-figure: oldstyle-nums;
+}
+
+.proportional-nums {
+  --tw-numeric-spacing: proportional-nums;
+}
+
+.tabular-nums {
+  --tw-numeric-spacing: tabular-nums;
+}
+
+.diagonal-fractions {
+  --tw-numeric-fraction: diagonal-fractions;
+}
+
+.stacked-fractions {
+  --tw-numeric-fraction: stacked-fractions;
+}
+
+.leading-3 {
+  line-height: .75rem;
+}
+
+.leading-4 {
+  line-height: 1rem;
+}
+
+.leading-5 {
+  line-height: 1.25rem;
+}
+
+.leading-6 {
+  line-height: 1.5rem;
+}
+
+.leading-7 {
+  line-height: 1.75rem;
+}
+
+.leading-8 {
+  line-height: 2rem;
+}
+
+.leading-9 {
+  line-height: 2.25rem;
+}
+
+.leading-10 {
+  line-height: 2.5rem;
+}
+
+.leading-12 {
+  line-height: 3rem;
+}
+
+.leading-13 {
+  line-height: 3.25rem;
+}
+
+.leading-none {
+  line-height: 1;
+}
+
+.leading-tight {
+  line-height: 1.25;
+}
+
+.leading-snug {
+  line-height: 1.375;
+}
+
+.leading-normal {
+  line-height: 1.5;
+}
+
+.leading-relaxed {
+  line-height: 1.625;
+}
+
+.leading-loose {
+  line-height: 2;
+}
+
+.tracking-tighter {
+  letter-spacing: -0.05em;
+}
+
+.tracking-tight {
+  letter-spacing: -0.025em;
+}
+
+.tracking-normal {
+  letter-spacing: 0em;
+}
+
+.tracking-wide {
+  letter-spacing: 0.025em;
+}
+
+.tracking-wider {
+  letter-spacing: 0.05em;
+}
+
+.tracking-widest {
+  letter-spacing: 0.1em;
+}
+
+.text-current {
+  color: currentColor;
+}
+
+.text-transparent {
+  color: transparent;
+}
+
+.text-falcon {
+  color: var(--falcon);
+}
+
+.text-basement {
+  color: var(--basement);
+}
+
+.text-blue {
+  color: var(--blue);
+}
+
+.text-body-and-labels {
+  color: var(--body-and-labels);
+}
+
+.text-brand {
+  color: var(--brand);
+}
+
+.text-code-base-64 {
+  color: var(--code-base-64);
+}
+
+.text-code-bg {
+  color: var(--code-bg);
+}
+
+.text-code-outline {
+  color: var(--code-outline);
+}
+
+.text-code-text {
+  color: var(--code-text);
+}
+
+.text-critical {
+  color: var(--critical);
+}
+
+.text-destructive-hover {
+  color: var(--destructive-hover);
+}
+
+.text-destructive-idle {
+  color: var(--destructive-idle);
+}
+
+.text-destructive-pressed {
+  color: var(--destructive-pressed);
+}
+
+.text-disabled {
+  color: var(--disabled);
+}
+
+.text-disc-operations {
+  color: var(--disc-operations);
+}
+
+.text-dns-requests {
+  color: var(--dns-requests);
+}
+
+.text-focus {
+  color: var(--focus);
+}
+
+.text-graph-1 {
+  color: var(--graph-1);
+}
+
+.text-graph-10 {
+  color: var(--graph-10);
+}
+
+.text-graph-11 {
+  color: var(--graph-11);
+}
+
+.text-graph-2 {
+  color: var(--graph-2);
+}
+
+.text-graph-3 {
+  color: var(--graph-3);
+}
+
+.text-graph-4 {
+  color: var(--graph-4);
+}
+
+.text-graph-5 {
+  color: var(--graph-5);
+}
+
+.text-graph-6 {
+  color: var(--graph-6);
+}
+
+.text-graph-7 {
+  color: var(--graph-7);
+}
+
+.text-graph-8 {
+  color: var(--graph-8);
+}
+
+.text-graph-9 {
+  color: var(--graph-9);
+}
+
+.text-graph-disabled {
+  color: var(--graph-disabled);
+}
+
+.text-ground-floor {
+  color: var(--ground-floor);
+}
+
+.text-high {
+  color: var(--high);
+}
+
+.text-informational {
+  color: var(--informational);
+}
+
+.text-lines-dark {
+  color: var(--lines-dark);
+}
+
+.text-lines-light {
+  color: var(--lines-light);
+}
+
+.text-low {
+  color: var(--low);
+}
+
+.text-medium {
+  color: var(--medium);
+}
+
+.text-mezzanine {
+  color: var(--mezzanine);
+}
+
+.text-nav-text-and-icons {
+  color: var(--nav-text-and-icons);
+}
+
+.text-nav-text-secondary {
+  color: var(--nav-text-secondary);
+}
+
+.text-network-operations {
+  color: var(--network-operations);
+}
+
+.text-normal-hover {
+  color: var(--normal-hover);
+}
+
+.text-normal-idle {
+  color: var(--normal-idle);
+}
+
+.text-normal-pressed {
+  color: var(--normal-pressed);
+}
+
+.text-overlay-0\\\\.5 {
+  color: var(--overlay-0\\\\.5);
+}
+
+.text-overlay-1 {
+  color: var(--overlay-1);
+}
+
+.text-overlay-2 {
+  color: var(--overlay-2);
+}
+
+.text-positive {
+  color: var(--positive);
+}
+
+.text-primary-hover {
+  color: var(--primary-hover);
+}
+
+.text-primary-idle {
+  color: var(--primary-idle);
+}
+
+.text-primary-pressed {
+  color: var(--primary-pressed);
+}
+
+.text-process-operations {
+  color: var(--process-operations);
+}
+
+.text-purple {
+  color: var(--purple);
+}
+
+.text-registry-operations {
+  color: var(--registry-operations);
+}
+
+.text-selected {
+  color: var(--selected);
+}
+
+.text-surface-2xl {
+  color: var(--surface-2xl);
+}
+
+.text-surface-base {
+  color: var(--surface-base);
+}
+
+.text-surface-inner {
+  color: var(--surface-inner);
+}
+
+.text-surface-lg {
+  color: var(--surface-lg);
+}
+
+.text-surface-md {
+  color: var(--surface-md);
+}
+
+.text-surface-xl {
+  color: var(--surface-xl);
+}
+
+.text-text-and-icons {
+  color: var(--text-and-icons);
+}
+
+.text-titles-and-attributes {
+  color: var(--titles-and-attributes);
+}
+
+.hover\\\\:text-current:hover {
+  color: currentColor;
+}
+
+.hover\\\\:text-transparent:hover {
+  color: transparent;
+}
+
+.hover\\\\:text-falcon:hover {
+  color: var(--falcon);
+}
+
+.hover\\\\:text-basement:hover {
+  color: var(--basement);
+}
+
+.hover\\\\:text-blue:hover {
+  color: var(--blue);
+}
+
+.hover\\\\:text-body-and-labels:hover {
+  color: var(--body-and-labels);
+}
+
+.hover\\\\:text-brand:hover {
+  color: var(--brand);
+}
+
+.hover\\\\:text-code-base-64:hover {
+  color: var(--code-base-64);
+}
+
+.hover\\\\:text-code-bg:hover {
+  color: var(--code-bg);
+}
+
+.hover\\\\:text-code-outline:hover {
+  color: var(--code-outline);
+}
+
+.hover\\\\:text-code-text:hover {
+  color: var(--code-text);
+}
+
+.hover\\\\:text-critical:hover {
+  color: var(--critical);
+}
+
+.hover\\\\:text-destructive-hover:hover {
+  color: var(--destructive-hover);
+}
+
+.hover\\\\:text-destructive-idle:hover {
+  color: var(--destructive-idle);
+}
+
+.hover\\\\:text-destructive-pressed:hover {
+  color: var(--destructive-pressed);
+}
+
+.hover\\\\:text-disabled:hover {
+  color: var(--disabled);
+}
+
+.hover\\\\:text-disc-operations:hover {
+  color: var(--disc-operations);
+}
+
+.hover\\\\:text-dns-requests:hover {
+  color: var(--dns-requests);
+}
+
+.hover\\\\:text-focus:hover {
+  color: var(--focus);
+}
+
+.hover\\\\:text-graph-1:hover {
+  color: var(--graph-1);
+}
+
+.hover\\\\:text-graph-10:hover {
+  color: var(--graph-10);
+}
+
+.hover\\\\:text-graph-11:hover {
+  color: var(--graph-11);
+}
+
+.hover\\\\:text-graph-2:hover {
+  color: var(--graph-2);
+}
+
+.hover\\\\:text-graph-3:hover {
+  color: var(--graph-3);
+}
+
+.hover\\\\:text-graph-4:hover {
+  color: var(--graph-4);
+}
+
+.hover\\\\:text-graph-5:hover {
+  color: var(--graph-5);
+}
+
+.hover\\\\:text-graph-6:hover {
+  color: var(--graph-6);
+}
+
+.hover\\\\:text-graph-7:hover {
+  color: var(--graph-7);
+}
+
+.hover\\\\:text-graph-8:hover {
+  color: var(--graph-8);
+}
+
+.hover\\\\:text-graph-9:hover {
+  color: var(--graph-9);
+}
+
+.hover\\\\:text-graph-disabled:hover {
+  color: var(--graph-disabled);
+}
+
+.hover\\\\:text-ground-floor:hover {
+  color: var(--ground-floor);
+}
+
+.hover\\\\:text-high:hover {
+  color: var(--high);
+}
+
+.hover\\\\:text-informational:hover {
+  color: var(--informational);
+}
+
+.hover\\\\:text-lines-dark:hover {
+  color: var(--lines-dark);
+}
+
+.hover\\\\:text-lines-light:hover {
+  color: var(--lines-light);
+}
+
+.hover\\\\:text-low:hover {
+  color: var(--low);
+}
+
+.hover\\\\:text-medium:hover {
+  color: var(--medium);
+}
+
+.hover\\\\:text-mezzanine:hover {
+  color: var(--mezzanine);
+}
+
+.hover\\\\:text-nav-text-and-icons:hover {
+  color: var(--nav-text-and-icons);
+}
+
+.hover\\\\:text-nav-text-secondary:hover {
+  color: var(--nav-text-secondary);
+}
+
+.hover\\\\:text-network-operations:hover {
+  color: var(--network-operations);
+}
+
+.hover\\\\:text-normal-hover:hover {
+  color: var(--normal-hover);
+}
+
+.hover\\\\:text-normal-idle:hover {
+  color: var(--normal-idle);
+}
+
+.hover\\\\:text-normal-pressed:hover {
+  color: var(--normal-pressed);
+}
+
+.hover\\\\:text-overlay-0\\\\.5:hover {
+  color: var(--overlay-0\\\\.5);
+}
+
+.hover\\\\:text-overlay-1:hover {
+  color: var(--overlay-1);
+}
+
+.hover\\\\:text-overlay-2:hover {
+  color: var(--overlay-2);
+}
+
+.hover\\\\:text-positive:hover {
+  color: var(--positive);
+}
+
+.hover\\\\:text-primary-hover:hover {
+  color: var(--primary-hover);
+}
+
+.hover\\\\:text-primary-idle:hover {
+  color: var(--primary-idle);
+}
+
+.hover\\\\:text-primary-pressed:hover {
+  color: var(--primary-pressed);
+}
+
+.hover\\\\:text-process-operations:hover {
+  color: var(--process-operations);
+}
+
+.hover\\\\:text-purple:hover {
+  color: var(--purple);
+}
+
+.hover\\\\:text-registry-operations:hover {
+  color: var(--registry-operations);
+}
+
+.hover\\\\:text-selected:hover {
+  color: var(--selected);
+}
+
+.hover\\\\:text-surface-2xl:hover {
+  color: var(--surface-2xl);
+}
+
+.hover\\\\:text-surface-base:hover {
+  color: var(--surface-base);
+}
+
+.hover\\\\:text-surface-inner:hover {
+  color: var(--surface-inner);
+}
+
+.hover\\\\:text-surface-lg:hover {
+  color: var(--surface-lg);
+}
+
+.hover\\\\:text-surface-md:hover {
+  color: var(--surface-md);
+}
+
+.hover\\\\:text-surface-xl:hover {
+  color: var(--surface-xl);
+}
+
+.hover\\\\:text-text-and-icons:hover {
+  color: var(--text-and-icons);
+}
+
+.hover\\\\:text-titles-and-attributes:hover {
+  color: var(--titles-and-attributes);
+}
+
+.focus\\\\:text-current:focus {
+  color: currentColor;
+}
+
+.focus\\\\:text-transparent:focus {
+  color: transparent;
+}
+
+.focus\\\\:text-falcon:focus {
+  color: var(--falcon);
+}
+
+.focus\\\\:text-basement:focus {
+  color: var(--basement);
+}
+
+.focus\\\\:text-blue:focus {
+  color: var(--blue);
+}
+
+.focus\\\\:text-body-and-labels:focus {
+  color: var(--body-and-labels);
+}
+
+.focus\\\\:text-brand:focus {
+  color: var(--brand);
+}
+
+.focus\\\\:text-code-base-64:focus {
+  color: var(--code-base-64);
+}
+
+.focus\\\\:text-code-bg:focus {
+  color: var(--code-bg);
+}
+
+.focus\\\\:text-code-outline:focus {
+  color: var(--code-outline);
+}
+
+.focus\\\\:text-code-text:focus {
+  color: var(--code-text);
+}
+
+.focus\\\\:text-critical:focus {
+  color: var(--critical);
+}
+
+.focus\\\\:text-destructive-hover:focus {
+  color: var(--destructive-hover);
+}
+
+.focus\\\\:text-destructive-idle:focus {
+  color: var(--destructive-idle);
+}
+
+.focus\\\\:text-destructive-pressed:focus {
+  color: var(--destructive-pressed);
+}
+
+.focus\\\\:text-disabled:focus {
+  color: var(--disabled);
+}
+
+.focus\\\\:text-disc-operations:focus {
+  color: var(--disc-operations);
+}
+
+.focus\\\\:text-dns-requests:focus {
+  color: var(--dns-requests);
+}
+
+.focus\\\\:text-focus:focus {
+  color: var(--focus);
+}
+
+.focus\\\\:text-graph-1:focus {
+  color: var(--graph-1);
+}
+
+.focus\\\\:text-graph-10:focus {
+  color: var(--graph-10);
+}
+
+.focus\\\\:text-graph-11:focus {
+  color: var(--graph-11);
+}
+
+.focus\\\\:text-graph-2:focus {
+  color: var(--graph-2);
+}
+
+.focus\\\\:text-graph-3:focus {
+  color: var(--graph-3);
+}
+
+.focus\\\\:text-graph-4:focus {
+  color: var(--graph-4);
+}
+
+.focus\\\\:text-graph-5:focus {
+  color: var(--graph-5);
+}
+
+.focus\\\\:text-graph-6:focus {
+  color: var(--graph-6);
+}
+
+.focus\\\\:text-graph-7:focus {
+  color: var(--graph-7);
+}
+
+.focus\\\\:text-graph-8:focus {
+  color: var(--graph-8);
+}
+
+.focus\\\\:text-graph-9:focus {
+  color: var(--graph-9);
+}
+
+.focus\\\\:text-graph-disabled:focus {
+  color: var(--graph-disabled);
+}
+
+.focus\\\\:text-ground-floor:focus {
+  color: var(--ground-floor);
+}
+
+.focus\\\\:text-high:focus {
+  color: var(--high);
+}
+
+.focus\\\\:text-informational:focus {
+  color: var(--informational);
+}
+
+.focus\\\\:text-lines-dark:focus {
+  color: var(--lines-dark);
+}
+
+.focus\\\\:text-lines-light:focus {
+  color: var(--lines-light);
+}
+
+.focus\\\\:text-low:focus {
+  color: var(--low);
+}
+
+.focus\\\\:text-medium:focus {
+  color: var(--medium);
+}
+
+.focus\\\\:text-mezzanine:focus {
+  color: var(--mezzanine);
+}
+
+.focus\\\\:text-nav-text-and-icons:focus {
+  color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:text-nav-text-secondary:focus {
+  color: var(--nav-text-secondary);
+}
+
+.focus\\\\:text-network-operations:focus {
+  color: var(--network-operations);
+}
+
+.focus\\\\:text-normal-hover:focus {
+  color: var(--normal-hover);
+}
+
+.focus\\\\:text-normal-idle:focus {
+  color: var(--normal-idle);
+}
+
+.focus\\\\:text-normal-pressed:focus {
+  color: var(--normal-pressed);
+}
+
+.focus\\\\:text-overlay-0\\\\.5:focus {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:text-overlay-1:focus {
+  color: var(--overlay-1);
+}
+
+.focus\\\\:text-overlay-2:focus {
+  color: var(--overlay-2);
+}
+
+.focus\\\\:text-positive:focus {
+  color: var(--positive);
+}
+
+.focus\\\\:text-primary-hover:focus {
+  color: var(--primary-hover);
+}
+
+.focus\\\\:text-primary-idle:focus {
+  color: var(--primary-idle);
+}
+
+.focus\\\\:text-primary-pressed:focus {
+  color: var(--primary-pressed);
+}
+
+.focus\\\\:text-process-operations:focus {
+  color: var(--process-operations);
+}
+
+.focus\\\\:text-purple:focus {
+  color: var(--purple);
+}
+
+.focus\\\\:text-registry-operations:focus {
+  color: var(--registry-operations);
+}
+
+.focus\\\\:text-selected:focus {
+  color: var(--selected);
+}
+
+.focus\\\\:text-surface-2xl:focus {
+  color: var(--surface-2xl);
+}
+
+.focus\\\\:text-surface-base:focus {
+  color: var(--surface-base);
+}
+
+.focus\\\\:text-surface-inner:focus {
+  color: var(--surface-inner);
+}
+
+.focus\\\\:text-surface-lg:focus {
+  color: var(--surface-lg);
+}
+
+.focus\\\\:text-surface-md:focus {
+  color: var(--surface-md);
+}
+
+.focus\\\\:text-surface-xl:focus {
+  color: var(--surface-xl);
+}
+
+.focus\\\\:text-text-and-icons:focus {
+  color: var(--text-and-icons);
+}
+
+.focus\\\\:text-titles-and-attributes:focus {
+  color: var(--titles-and-attributes);
+}
+
+.focus-visible\\\\:text-current:focus-visible {
+  color: currentColor;
+}
+
+.focus-visible\\\\:text-transparent:focus-visible {
+  color: transparent;
+}
+
+.focus-visible\\\\:text-falcon:focus-visible {
+  color: var(--falcon);
+}
+
+.focus-visible\\\\:text-basement:focus-visible {
+  color: var(--basement);
+}
+
+.focus-visible\\\\:text-blue:focus-visible {
+  color: var(--blue);
+}
+
+.focus-visible\\\\:text-body-and-labels:focus-visible {
+  color: var(--body-and-labels);
+}
+
+.focus-visible\\\\:text-brand:focus-visible {
+  color: var(--brand);
+}
+
+.focus-visible\\\\:text-code-base-64:focus-visible {
+  color: var(--code-base-64);
+}
+
+.focus-visible\\\\:text-code-bg:focus-visible {
+  color: var(--code-bg);
+}
+
+.focus-visible\\\\:text-code-outline:focus-visible {
+  color: var(--code-outline);
+}
+
+.focus-visible\\\\:text-code-text:focus-visible {
+  color: var(--code-text);
+}
+
+.focus-visible\\\\:text-critical:focus-visible {
+  color: var(--critical);
+}
+
+.focus-visible\\\\:text-destructive-hover:focus-visible {
+  color: var(--destructive-hover);
+}
+
+.focus-visible\\\\:text-destructive-idle:focus-visible {
+  color: var(--destructive-idle);
+}
+
+.focus-visible\\\\:text-destructive-pressed:focus-visible {
+  color: var(--destructive-pressed);
+}
+
+.focus-visible\\\\:text-disabled:focus-visible {
+  color: var(--disabled);
+}
+
+.focus-visible\\\\:text-disc-operations:focus-visible {
+  color: var(--disc-operations);
+}
+
+.focus-visible\\\\:text-dns-requests:focus-visible {
+  color: var(--dns-requests);
+}
+
+.focus-visible\\\\:text-focus:focus-visible {
+  color: var(--focus);
+}
+
+.focus-visible\\\\:text-graph-1:focus-visible {
+  color: var(--graph-1);
+}
+
+.focus-visible\\\\:text-graph-10:focus-visible {
+  color: var(--graph-10);
+}
+
+.focus-visible\\\\:text-graph-11:focus-visible {
+  color: var(--graph-11);
+}
+
+.focus-visible\\\\:text-graph-2:focus-visible {
+  color: var(--graph-2);
+}
+
+.focus-visible\\\\:text-graph-3:focus-visible {
+  color: var(--graph-3);
+}
+
+.focus-visible\\\\:text-graph-4:focus-visible {
+  color: var(--graph-4);
+}
+
+.focus-visible\\\\:text-graph-5:focus-visible {
+  color: var(--graph-5);
+}
+
+.focus-visible\\\\:text-graph-6:focus-visible {
+  color: var(--graph-6);
+}
+
+.focus-visible\\\\:text-graph-7:focus-visible {
+  color: var(--graph-7);
+}
+
+.focus-visible\\\\:text-graph-8:focus-visible {
+  color: var(--graph-8);
+}
+
+.focus-visible\\\\:text-graph-9:focus-visible {
+  color: var(--graph-9);
+}
+
+.focus-visible\\\\:text-graph-disabled:focus-visible {
+  color: var(--graph-disabled);
+}
+
+.focus-visible\\\\:text-ground-floor:focus-visible {
+  color: var(--ground-floor);
+}
+
+.focus-visible\\\\:text-high:focus-visible {
+  color: var(--high);
+}
+
+.focus-visible\\\\:text-informational:focus-visible {
+  color: var(--informational);
+}
+
+.focus-visible\\\\:text-lines-dark:focus-visible {
+  color: var(--lines-dark);
+}
+
+.focus-visible\\\\:text-lines-light:focus-visible {
+  color: var(--lines-light);
+}
+
+.focus-visible\\\\:text-low:focus-visible {
+  color: var(--low);
+}
+
+.focus-visible\\\\:text-medium:focus-visible {
+  color: var(--medium);
+}
+
+.focus-visible\\\\:text-mezzanine:focus-visible {
+  color: var(--mezzanine);
+}
+
+.focus-visible\\\\:text-nav-text-and-icons:focus-visible {
+  color: var(--nav-text-and-icons);
+}
+
+.focus-visible\\\\:text-nav-text-secondary:focus-visible {
+  color: var(--nav-text-secondary);
+}
+
+.focus-visible\\\\:text-network-operations:focus-visible {
+  color: var(--network-operations);
+}
+
+.focus-visible\\\\:text-normal-hover:focus-visible {
+  color: var(--normal-hover);
+}
+
+.focus-visible\\\\:text-normal-idle:focus-visible {
+  color: var(--normal-idle);
+}
+
+.focus-visible\\\\:text-normal-pressed:focus-visible {
+  color: var(--normal-pressed);
+}
+
+.focus-visible\\\\:text-overlay-0\\\\.5:focus-visible {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus-visible\\\\:text-overlay-1:focus-visible {
+  color: var(--overlay-1);
+}
+
+.focus-visible\\\\:text-overlay-2:focus-visible {
+  color: var(--overlay-2);
+}
+
+.focus-visible\\\\:text-positive:focus-visible {
+  color: var(--positive);
+}
+
+.focus-visible\\\\:text-primary-hover:focus-visible {
+  color: var(--primary-hover);
+}
+
+.focus-visible\\\\:text-primary-idle:focus-visible {
+  color: var(--primary-idle);
+}
+
+.focus-visible\\\\:text-primary-pressed:focus-visible {
+  color: var(--primary-pressed);
+}
+
+.focus-visible\\\\:text-process-operations:focus-visible {
+  color: var(--process-operations);
+}
+
+.focus-visible\\\\:text-purple:focus-visible {
+  color: var(--purple);
+}
+
+.focus-visible\\\\:text-registry-operations:focus-visible {
+  color: var(--registry-operations);
+}
+
+.focus-visible\\\\:text-selected:focus-visible {
+  color: var(--selected);
+}
+
+.focus-visible\\\\:text-surface-2xl:focus-visible {
+  color: var(--surface-2xl);
+}
+
+.focus-visible\\\\:text-surface-base:focus-visible {
+  color: var(--surface-base);
+}
+
+.focus-visible\\\\:text-surface-inner:focus-visible {
+  color: var(--surface-inner);
+}
+
+.focus-visible\\\\:text-surface-lg:focus-visible {
+  color: var(--surface-lg);
+}
+
+.focus-visible\\\\:text-surface-md:focus-visible {
+  color: var(--surface-md);
+}
+
+.focus-visible\\\\:text-surface-xl:focus-visible {
+  color: var(--surface-xl);
+}
+
+.focus-visible\\\\:text-text-and-icons:focus-visible {
+  color: var(--text-and-icons);
+}
+
+.focus-visible\\\\:text-titles-and-attributes:focus-visible {
+  color: var(--titles-and-attributes);
+}
+
+.group:hover .group-hover\\\\:text-current {
+  color: currentColor;
+}
+
+.group:hover .group-hover\\\\:text-transparent {
+  color: transparent;
+}
+
+.group:hover .group-hover\\\\:text-falcon {
+  color: var(--falcon);
+}
+
+.group:hover .group-hover\\\\:text-basement {
+  color: var(--basement);
+}
+
+.group:hover .group-hover\\\\:text-blue {
+  color: var(--blue);
+}
+
+.group:hover .group-hover\\\\:text-body-and-labels {
+  color: var(--body-and-labels);
+}
+
+.group:hover .group-hover\\\\:text-brand {
+  color: var(--brand);
+}
+
+.group:hover .group-hover\\\\:text-code-base-64 {
+  color: var(--code-base-64);
+}
+
+.group:hover .group-hover\\\\:text-code-bg {
+  color: var(--code-bg);
+}
+
+.group:hover .group-hover\\\\:text-code-outline {
+  color: var(--code-outline);
+}
+
+.group:hover .group-hover\\\\:text-code-text {
+  color: var(--code-text);
+}
+
+.group:hover .group-hover\\\\:text-critical {
+  color: var(--critical);
+}
+
+.group:hover .group-hover\\\\:text-destructive-hover {
+  color: var(--destructive-hover);
+}
+
+.group:hover .group-hover\\\\:text-destructive-idle {
+  color: var(--destructive-idle);
+}
+
+.group:hover .group-hover\\\\:text-destructive-pressed {
+  color: var(--destructive-pressed);
+}
+
+.group:hover .group-hover\\\\:text-disabled {
+  color: var(--disabled);
+}
+
+.group:hover .group-hover\\\\:text-disc-operations {
+  color: var(--disc-operations);
+}
+
+.group:hover .group-hover\\\\:text-dns-requests {
+  color: var(--dns-requests);
+}
+
+.group:hover .group-hover\\\\:text-focus {
+  color: var(--focus);
+}
+
+.group:hover .group-hover\\\\:text-graph-1 {
+  color: var(--graph-1);
+}
+
+.group:hover .group-hover\\\\:text-graph-10 {
+  color: var(--graph-10);
+}
+
+.group:hover .group-hover\\\\:text-graph-11 {
+  color: var(--graph-11);
+}
+
+.group:hover .group-hover\\\\:text-graph-2 {
+  color: var(--graph-2);
+}
+
+.group:hover .group-hover\\\\:text-graph-3 {
+  color: var(--graph-3);
+}
+
+.group:hover .group-hover\\\\:text-graph-4 {
+  color: var(--graph-4);
+}
+
+.group:hover .group-hover\\\\:text-graph-5 {
+  color: var(--graph-5);
+}
+
+.group:hover .group-hover\\\\:text-graph-6 {
+  color: var(--graph-6);
+}
+
+.group:hover .group-hover\\\\:text-graph-7 {
+  color: var(--graph-7);
+}
+
+.group:hover .group-hover\\\\:text-graph-8 {
+  color: var(--graph-8);
+}
+
+.group:hover .group-hover\\\\:text-graph-9 {
+  color: var(--graph-9);
+}
+
+.group:hover .group-hover\\\\:text-graph-disabled {
+  color: var(--graph-disabled);
+}
+
+.group:hover .group-hover\\\\:text-ground-floor {
+  color: var(--ground-floor);
+}
+
+.group:hover .group-hover\\\\:text-high {
+  color: var(--high);
+}
+
+.group:hover .group-hover\\\\:text-informational {
+  color: var(--informational);
+}
+
+.group:hover .group-hover\\\\:text-lines-dark {
+  color: var(--lines-dark);
+}
+
+.group:hover .group-hover\\\\:text-lines-light {
+  color: var(--lines-light);
+}
+
+.group:hover .group-hover\\\\:text-low {
+  color: var(--low);
+}
+
+.group:hover .group-hover\\\\:text-medium {
+  color: var(--medium);
+}
+
+.group:hover .group-hover\\\\:text-mezzanine {
+  color: var(--mezzanine);
+}
+
+.group:hover .group-hover\\\\:text-nav-text-and-icons {
+  color: var(--nav-text-and-icons);
+}
+
+.group:hover .group-hover\\\\:text-nav-text-secondary {
+  color: var(--nav-text-secondary);
+}
+
+.group:hover .group-hover\\\\:text-network-operations {
+  color: var(--network-operations);
+}
+
+.group:hover .group-hover\\\\:text-normal-hover {
+  color: var(--normal-hover);
+}
+
+.group:hover .group-hover\\\\:text-normal-idle {
+  color: var(--normal-idle);
+}
+
+.group:hover .group-hover\\\\:text-normal-pressed {
+  color: var(--normal-pressed);
+}
+
+.group:hover .group-hover\\\\:text-overlay-0\\\\.5 {
+  color: var(--overlay-0\\\\.5);
+}
+
+.group:hover .group-hover\\\\:text-overlay-1 {
+  color: var(--overlay-1);
+}
+
+.group:hover .group-hover\\\\:text-overlay-2 {
+  color: var(--overlay-2);
+}
+
+.group:hover .group-hover\\\\:text-positive {
+  color: var(--positive);
+}
+
+.group:hover .group-hover\\\\:text-primary-hover {
+  color: var(--primary-hover);
+}
+
+.group:hover .group-hover\\\\:text-primary-idle {
+  color: var(--primary-idle);
+}
+
+.group:hover .group-hover\\\\:text-primary-pressed {
+  color: var(--primary-pressed);
+}
+
+.group:hover .group-hover\\\\:text-process-operations {
+  color: var(--process-operations);
+}
+
+.group:hover .group-hover\\\\:text-purple {
+  color: var(--purple);
+}
+
+.group:hover .group-hover\\\\:text-registry-operations {
+  color: var(--registry-operations);
+}
+
+.group:hover .group-hover\\\\:text-selected {
+  color: var(--selected);
+}
+
+.group:hover .group-hover\\\\:text-surface-2xl {
+  color: var(--surface-2xl);
+}
+
+.group:hover .group-hover\\\\:text-surface-base {
+  color: var(--surface-base);
+}
+
+.group:hover .group-hover\\\\:text-surface-inner {
+  color: var(--surface-inner);
+}
+
+.group:hover .group-hover\\\\:text-surface-lg {
+  color: var(--surface-lg);
+}
+
+.group:hover .group-hover\\\\:text-surface-md {
+  color: var(--surface-md);
+}
+
+.group:hover .group-hover\\\\:text-surface-xl {
+  color: var(--surface-xl);
+}
+
+.group:hover .group-hover\\\\:text-text-and-icons {
+  color: var(--text-and-icons);
+}
+
+.group:hover .group-hover\\\\:text-titles-and-attributes {
+  color: var(--titles-and-attributes);
+}
+
+.active\\\\:text-current:active {
+  color: currentColor;
+}
+
+.active\\\\:text-transparent:active {
+  color: transparent;
+}
+
+.active\\\\:text-falcon:active {
+  color: var(--falcon);
+}
+
+.active\\\\:text-basement:active {
+  color: var(--basement);
+}
+
+.active\\\\:text-blue:active {
+  color: var(--blue);
+}
+
+.active\\\\:text-body-and-labels:active {
+  color: var(--body-and-labels);
+}
+
+.active\\\\:text-brand:active {
+  color: var(--brand);
+}
+
+.active\\\\:text-code-base-64:active {
+  color: var(--code-base-64);
+}
+
+.active\\\\:text-code-bg:active {
+  color: var(--code-bg);
+}
+
+.active\\\\:text-code-outline:active {
+  color: var(--code-outline);
+}
+
+.active\\\\:text-code-text:active {
+  color: var(--code-text);
+}
+
+.active\\\\:text-critical:active {
+  color: var(--critical);
+}
+
+.active\\\\:text-destructive-hover:active {
+  color: var(--destructive-hover);
+}
+
+.active\\\\:text-destructive-idle:active {
+  color: var(--destructive-idle);
+}
+
+.active\\\\:text-destructive-pressed:active {
+  color: var(--destructive-pressed);
+}
+
+.active\\\\:text-disabled:active {
+  color: var(--disabled);
+}
+
+.active\\\\:text-disc-operations:active {
+  color: var(--disc-operations);
+}
+
+.active\\\\:text-dns-requests:active {
+  color: var(--dns-requests);
+}
+
+.active\\\\:text-focus:active {
+  color: var(--focus);
+}
+
+.active\\\\:text-graph-1:active {
+  color: var(--graph-1);
+}
+
+.active\\\\:text-graph-10:active {
+  color: var(--graph-10);
+}
+
+.active\\\\:text-graph-11:active {
+  color: var(--graph-11);
+}
+
+.active\\\\:text-graph-2:active {
+  color: var(--graph-2);
+}
+
+.active\\\\:text-graph-3:active {
+  color: var(--graph-3);
+}
+
+.active\\\\:text-graph-4:active {
+  color: var(--graph-4);
+}
+
+.active\\\\:text-graph-5:active {
+  color: var(--graph-5);
+}
+
+.active\\\\:text-graph-6:active {
+  color: var(--graph-6);
+}
+
+.active\\\\:text-graph-7:active {
+  color: var(--graph-7);
+}
+
+.active\\\\:text-graph-8:active {
+  color: var(--graph-8);
+}
+
+.active\\\\:text-graph-9:active {
+  color: var(--graph-9);
+}
+
+.active\\\\:text-graph-disabled:active {
+  color: var(--graph-disabled);
+}
+
+.active\\\\:text-ground-floor:active {
+  color: var(--ground-floor);
+}
+
+.active\\\\:text-high:active {
+  color: var(--high);
+}
+
+.active\\\\:text-informational:active {
+  color: var(--informational);
+}
+
+.active\\\\:text-lines-dark:active {
+  color: var(--lines-dark);
+}
+
+.active\\\\:text-lines-light:active {
+  color: var(--lines-light);
+}
+
+.active\\\\:text-low:active {
+  color: var(--low);
+}
+
+.active\\\\:text-medium:active {
+  color: var(--medium);
+}
+
+.active\\\\:text-mezzanine:active {
+  color: var(--mezzanine);
+}
+
+.active\\\\:text-nav-text-and-icons:active {
+  color: var(--nav-text-and-icons);
+}
+
+.active\\\\:text-nav-text-secondary:active {
+  color: var(--nav-text-secondary);
+}
+
+.active\\\\:text-network-operations:active {
+  color: var(--network-operations);
+}
+
+.active\\\\:text-normal-hover:active {
+  color: var(--normal-hover);
+}
+
+.active\\\\:text-normal-idle:active {
+  color: var(--normal-idle);
+}
+
+.active\\\\:text-normal-pressed:active {
+  color: var(--normal-pressed);
+}
+
+.active\\\\:text-overlay-0\\\\.5:active {
+  color: var(--overlay-0\\\\.5);
+}
+
+.active\\\\:text-overlay-1:active {
+  color: var(--overlay-1);
+}
+
+.active\\\\:text-overlay-2:active {
+  color: var(--overlay-2);
+}
+
+.active\\\\:text-positive:active {
+  color: var(--positive);
+}
+
+.active\\\\:text-primary-hover:active {
+  color: var(--primary-hover);
+}
+
+.active\\\\:text-primary-idle:active {
+  color: var(--primary-idle);
+}
+
+.active\\\\:text-primary-pressed:active {
+  color: var(--primary-pressed);
+}
+
+.active\\\\:text-process-operations:active {
+  color: var(--process-operations);
+}
+
+.active\\\\:text-purple:active {
+  color: var(--purple);
+}
+
+.active\\\\:text-registry-operations:active {
+  color: var(--registry-operations);
+}
+
+.active\\\\:text-selected:active {
+  color: var(--selected);
+}
+
+.active\\\\:text-surface-2xl:active {
+  color: var(--surface-2xl);
+}
+
+.active\\\\:text-surface-base:active {
+  color: var(--surface-base);
+}
+
+.active\\\\:text-surface-inner:active {
+  color: var(--surface-inner);
+}
+
+.active\\\\:text-surface-lg:active {
+  color: var(--surface-lg);
+}
+
+.active\\\\:text-surface-md:active {
+  color: var(--surface-md);
+}
+
+.active\\\\:text-surface-xl:active {
+  color: var(--surface-xl);
+}
+
+.active\\\\:text-text-and-icons:active {
+  color: var(--text-and-icons);
+}
+
+.active\\\\:text-titles-and-attributes:active {
+  color: var(--titles-and-attributes);
+}
+
+.disabled\\\\:text-current:disabled {
+  color: currentColor;
+}
+
+.disabled\\\\:text-transparent:disabled {
+  color: transparent;
+}
+
+.disabled\\\\:text-falcon:disabled {
+  color: var(--falcon);
+}
+
+.disabled\\\\:text-basement:disabled {
+  color: var(--basement);
+}
+
+.disabled\\\\:text-blue:disabled {
+  color: var(--blue);
+}
+
+.disabled\\\\:text-body-and-labels:disabled {
+  color: var(--body-and-labels);
+}
+
+.disabled\\\\:text-brand:disabled {
+  color: var(--brand);
+}
+
+.disabled\\\\:text-code-base-64:disabled {
+  color: var(--code-base-64);
+}
+
+.disabled\\\\:text-code-bg:disabled {
+  color: var(--code-bg);
+}
+
+.disabled\\\\:text-code-outline:disabled {
+  color: var(--code-outline);
+}
+
+.disabled\\\\:text-code-text:disabled {
+  color: var(--code-text);
+}
+
+.disabled\\\\:text-critical:disabled {
+  color: var(--critical);
+}
+
+.disabled\\\\:text-destructive-hover:disabled {
+  color: var(--destructive-hover);
+}
+
+.disabled\\\\:text-destructive-idle:disabled {
+  color: var(--destructive-idle);
+}
+
+.disabled\\\\:text-destructive-pressed:disabled {
+  color: var(--destructive-pressed);
+}
+
+.disabled\\\\:text-disabled:disabled {
+  color: var(--disabled);
+}
+
+.disabled\\\\:text-disc-operations:disabled {
+  color: var(--disc-operations);
+}
+
+.disabled\\\\:text-dns-requests:disabled {
+  color: var(--dns-requests);
+}
+
+.disabled\\\\:text-focus:disabled {
+  color: var(--focus);
+}
+
+.disabled\\\\:text-graph-1:disabled {
+  color: var(--graph-1);
+}
+
+.disabled\\\\:text-graph-10:disabled {
+  color: var(--graph-10);
+}
+
+.disabled\\\\:text-graph-11:disabled {
+  color: var(--graph-11);
+}
+
+.disabled\\\\:text-graph-2:disabled {
+  color: var(--graph-2);
+}
+
+.disabled\\\\:text-graph-3:disabled {
+  color: var(--graph-3);
+}
+
+.disabled\\\\:text-graph-4:disabled {
+  color: var(--graph-4);
+}
+
+.disabled\\\\:text-graph-5:disabled {
+  color: var(--graph-5);
+}
+
+.disabled\\\\:text-graph-6:disabled {
+  color: var(--graph-6);
+}
+
+.disabled\\\\:text-graph-7:disabled {
+  color: var(--graph-7);
+}
+
+.disabled\\\\:text-graph-8:disabled {
+  color: var(--graph-8);
+}
+
+.disabled\\\\:text-graph-9:disabled {
+  color: var(--graph-9);
+}
+
+.disabled\\\\:text-graph-disabled:disabled {
+  color: var(--graph-disabled);
+}
+
+.disabled\\\\:text-ground-floor:disabled {
+  color: var(--ground-floor);
+}
+
+.disabled\\\\:text-high:disabled {
+  color: var(--high);
+}
+
+.disabled\\\\:text-informational:disabled {
+  color: var(--informational);
+}
+
+.disabled\\\\:text-lines-dark:disabled {
+  color: var(--lines-dark);
+}
+
+.disabled\\\\:text-lines-light:disabled {
+  color: var(--lines-light);
+}
+
+.disabled\\\\:text-low:disabled {
+  color: var(--low);
+}
+
+.disabled\\\\:text-medium:disabled {
+  color: var(--medium);
+}
+
+.disabled\\\\:text-mezzanine:disabled {
+  color: var(--mezzanine);
+}
+
+.disabled\\\\:text-nav-text-and-icons:disabled {
+  color: var(--nav-text-and-icons);
+}
+
+.disabled\\\\:text-nav-text-secondary:disabled {
+  color: var(--nav-text-secondary);
+}
+
+.disabled\\\\:text-network-operations:disabled {
+  color: var(--network-operations);
+}
+
+.disabled\\\\:text-normal-hover:disabled {
+  color: var(--normal-hover);
+}
+
+.disabled\\\\:text-normal-idle:disabled {
+  color: var(--normal-idle);
+}
+
+.disabled\\\\:text-normal-pressed:disabled {
+  color: var(--normal-pressed);
+}
+
+.disabled\\\\:text-overlay-0\\\\.5:disabled {
+  color: var(--overlay-0\\\\.5);
+}
+
+.disabled\\\\:text-overlay-1:disabled {
+  color: var(--overlay-1);
+}
+
+.disabled\\\\:text-overlay-2:disabled {
+  color: var(--overlay-2);
+}
+
+.disabled\\\\:text-positive:disabled {
+  color: var(--positive);
+}
+
+.disabled\\\\:text-primary-hover:disabled {
+  color: var(--primary-hover);
+}
+
+.disabled\\\\:text-primary-idle:disabled {
+  color: var(--primary-idle);
+}
+
+.disabled\\\\:text-primary-pressed:disabled {
+  color: var(--primary-pressed);
+}
+
+.disabled\\\\:text-process-operations:disabled {
+  color: var(--process-operations);
+}
+
+.disabled\\\\:text-purple:disabled {
+  color: var(--purple);
+}
+
+.disabled\\\\:text-registry-operations:disabled {
+  color: var(--registry-operations);
+}
+
+.disabled\\\\:text-selected:disabled {
+  color: var(--selected);
+}
+
+.disabled\\\\:text-surface-2xl:disabled {
+  color: var(--surface-2xl);
+}
+
+.disabled\\\\:text-surface-base:disabled {
+  color: var(--surface-base);
+}
+
+.disabled\\\\:text-surface-inner:disabled {
+  color: var(--surface-inner);
+}
+
+.disabled\\\\:text-surface-lg:disabled {
+  color: var(--surface-lg);
+}
+
+.disabled\\\\:text-surface-md:disabled {
+  color: var(--surface-md);
+}
+
+.disabled\\\\:text-surface-xl:disabled {
+  color: var(--surface-xl);
+}
+
+.disabled\\\\:text-text-and-icons:disabled {
+  color: var(--text-and-icons);
+}
+
+.disabled\\\\:text-titles-and-attributes:disabled {
+  color: var(--titles-and-attributes);
+}
+
+.text-opacity-0 {
+  --tw-text-opacity: 0;
+}
+
+.text-opacity-5 {
+  --tw-text-opacity: 0.05;
+}
+
+.text-opacity-10 {
+  --tw-text-opacity: 0.1;
+}
+
+.text-opacity-20 {
+  --tw-text-opacity: 0.2;
+}
+
+.text-opacity-25 {
+  --tw-text-opacity: 0.25;
+}
+
+.text-opacity-30 {
+  --tw-text-opacity: 0.3;
+}
+
+.text-opacity-40 {
+  --tw-text-opacity: 0.4;
+}
+
+.text-opacity-50 {
+  --tw-text-opacity: 0.5;
+}
+
+.text-opacity-60 {
+  --tw-text-opacity: 0.6;
+}
+
+.text-opacity-70 {
+  --tw-text-opacity: 0.7;
+}
+
+.text-opacity-75 {
+  --tw-text-opacity: 0.75;
+}
+
+.text-opacity-80 {
+  --tw-text-opacity: 0.8;
+}
+
+.text-opacity-90 {
+  --tw-text-opacity: 0.9;
+}
+
+.text-opacity-95 {
+  --tw-text-opacity: 0.95;
+}
+
+.text-opacity-100 {
+  --tw-text-opacity: 1;
+}
+
+.hover\\\\:text-opacity-0:hover {
+  --tw-text-opacity: 0;
+}
+
+.hover\\\\:text-opacity-5:hover {
+  --tw-text-opacity: 0.05;
+}
+
+.hover\\\\:text-opacity-10:hover {
+  --tw-text-opacity: 0.1;
+}
+
+.hover\\\\:text-opacity-20:hover {
+  --tw-text-opacity: 0.2;
+}
+
+.hover\\\\:text-opacity-25:hover {
+  --tw-text-opacity: 0.25;
+}
+
+.hover\\\\:text-opacity-30:hover {
+  --tw-text-opacity: 0.3;
+}
+
+.hover\\\\:text-opacity-40:hover {
+  --tw-text-opacity: 0.4;
+}
+
+.hover\\\\:text-opacity-50:hover {
+  --tw-text-opacity: 0.5;
+}
+
+.hover\\\\:text-opacity-60:hover {
+  --tw-text-opacity: 0.6;
+}
+
+.hover\\\\:text-opacity-70:hover {
+  --tw-text-opacity: 0.7;
+}
+
+.hover\\\\:text-opacity-75:hover {
+  --tw-text-opacity: 0.75;
+}
+
+.hover\\\\:text-opacity-80:hover {
+  --tw-text-opacity: 0.8;
+}
+
+.hover\\\\:text-opacity-90:hover {
+  --tw-text-opacity: 0.9;
+}
+
+.hover\\\\:text-opacity-95:hover {
+  --tw-text-opacity: 0.95;
+}
+
+.hover\\\\:text-opacity-100:hover {
+  --tw-text-opacity: 1;
+}
+
+.focus\\\\:text-opacity-0:focus {
+  --tw-text-opacity: 0;
+}
+
+.focus\\\\:text-opacity-5:focus {
+  --tw-text-opacity: 0.05;
+}
+
+.focus\\\\:text-opacity-10:focus {
+  --tw-text-opacity: 0.1;
+}
+
+.focus\\\\:text-opacity-20:focus {
+  --tw-text-opacity: 0.2;
+}
+
+.focus\\\\:text-opacity-25:focus {
+  --tw-text-opacity: 0.25;
+}
+
+.focus\\\\:text-opacity-30:focus {
+  --tw-text-opacity: 0.3;
+}
+
+.focus\\\\:text-opacity-40:focus {
+  --tw-text-opacity: 0.4;
+}
+
+.focus\\\\:text-opacity-50:focus {
+  --tw-text-opacity: 0.5;
+}
+
+.focus\\\\:text-opacity-60:focus {
+  --tw-text-opacity: 0.6;
+}
+
+.focus\\\\:text-opacity-70:focus {
+  --tw-text-opacity: 0.7;
+}
+
+.focus\\\\:text-opacity-75:focus {
+  --tw-text-opacity: 0.75;
+}
+
+.focus\\\\:text-opacity-80:focus {
+  --tw-text-opacity: 0.8;
+}
+
+.focus\\\\:text-opacity-90:focus {
+  --tw-text-opacity: 0.9;
+}
+
+.focus\\\\:text-opacity-95:focus {
+  --tw-text-opacity: 0.95;
+}
+
+.focus\\\\:text-opacity-100:focus {
+  --tw-text-opacity: 1;
+}
+
+.underline {
+  text-decoration: underline;
+}
+
+.line-through {
+  text-decoration: line-through;
+}
+
+.no-underline {
+  text-decoration: none;
+}
+
+.hover\\\\:underline:hover {
+  text-decoration: underline;
+}
+
+.hover\\\\:line-through:hover {
+  text-decoration: line-through;
+}
+
+.hover\\\\:no-underline:hover {
+  text-decoration: none;
+}
+
+.focus\\\\:underline:focus {
+  text-decoration: underline;
+}
+
+.focus\\\\:line-through:focus {
+  text-decoration: line-through;
+}
+
+.focus\\\\:no-underline:focus {
+  text-decoration: none;
+}
+
+.antialiased {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.subpixel-antialiased {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+}
+
+.placeholder-current::-moz-placeholder {
+  color: currentColor;
+}
+
+.placeholder-current:-ms-input-placeholder {
+  color: currentColor;
+}
+
+.placeholder-current::placeholder {
+  color: currentColor;
+}
+
+.placeholder-transparent::-moz-placeholder {
+  color: transparent;
+}
+
+.placeholder-transparent:-ms-input-placeholder {
+  color: transparent;
+}
+
+.placeholder-transparent::placeholder {
+  color: transparent;
+}
+
+.placeholder-falcon::-moz-placeholder {
+  color: var(--falcon);
+}
+
+.placeholder-falcon:-ms-input-placeholder {
+  color: var(--falcon);
+}
+
+.placeholder-falcon::placeholder {
+  color: var(--falcon);
+}
+
+.placeholder-basement::-moz-placeholder {
+  color: var(--basement);
+}
+
+.placeholder-basement:-ms-input-placeholder {
+  color: var(--basement);
+}
+
+.placeholder-basement::placeholder {
+  color: var(--basement);
+}
+
+.placeholder-blue::-moz-placeholder {
+  color: var(--blue);
+}
+
+.placeholder-blue:-ms-input-placeholder {
+  color: var(--blue);
+}
+
+.placeholder-blue::placeholder {
+  color: var(--blue);
+}
+
+.placeholder-body-and-labels::-moz-placeholder {
+  color: var(--body-and-labels);
+}
+
+.placeholder-body-and-labels:-ms-input-placeholder {
+  color: var(--body-and-labels);
+}
+
+.placeholder-body-and-labels::placeholder {
+  color: var(--body-and-labels);
+}
+
+.placeholder-brand::-moz-placeholder {
+  color: var(--brand);
+}
+
+.placeholder-brand:-ms-input-placeholder {
+  color: var(--brand);
+}
+
+.placeholder-brand::placeholder {
+  color: var(--brand);
+}
+
+.placeholder-code-base-64::-moz-placeholder {
+  color: var(--code-base-64);
+}
+
+.placeholder-code-base-64:-ms-input-placeholder {
+  color: var(--code-base-64);
+}
+
+.placeholder-code-base-64::placeholder {
+  color: var(--code-base-64);
+}
+
+.placeholder-code-bg::-moz-placeholder {
+  color: var(--code-bg);
+}
+
+.placeholder-code-bg:-ms-input-placeholder {
+  color: var(--code-bg);
+}
+
+.placeholder-code-bg::placeholder {
+  color: var(--code-bg);
+}
+
+.placeholder-code-outline::-moz-placeholder {
+  color: var(--code-outline);
+}
+
+.placeholder-code-outline:-ms-input-placeholder {
+  color: var(--code-outline);
+}
+
+.placeholder-code-outline::placeholder {
+  color: var(--code-outline);
+}
+
+.placeholder-code-text::-moz-placeholder {
+  color: var(--code-text);
+}
+
+.placeholder-code-text:-ms-input-placeholder {
+  color: var(--code-text);
+}
+
+.placeholder-code-text::placeholder {
+  color: var(--code-text);
+}
+
+.placeholder-critical::-moz-placeholder {
+  color: var(--critical);
+}
+
+.placeholder-critical:-ms-input-placeholder {
+  color: var(--critical);
+}
+
+.placeholder-critical::placeholder {
+  color: var(--critical);
+}
+
+.placeholder-destructive-hover::-moz-placeholder {
+  color: var(--destructive-hover);
+}
+
+.placeholder-destructive-hover:-ms-input-placeholder {
+  color: var(--destructive-hover);
+}
+
+.placeholder-destructive-hover::placeholder {
+  color: var(--destructive-hover);
+}
+
+.placeholder-destructive-idle::-moz-placeholder {
+  color: var(--destructive-idle);
+}
+
+.placeholder-destructive-idle:-ms-input-placeholder {
+  color: var(--destructive-idle);
+}
+
+.placeholder-destructive-idle::placeholder {
+  color: var(--destructive-idle);
+}
+
+.placeholder-destructive-pressed::-moz-placeholder {
+  color: var(--destructive-pressed);
+}
+
+.placeholder-destructive-pressed:-ms-input-placeholder {
+  color: var(--destructive-pressed);
+}
+
+.placeholder-destructive-pressed::placeholder {
+  color: var(--destructive-pressed);
+}
+
+.placeholder-disabled::-moz-placeholder {
+  color: var(--disabled);
+}
+
+.placeholder-disabled:-ms-input-placeholder {
+  color: var(--disabled);
+}
+
+.placeholder-disabled::placeholder {
+  color: var(--disabled);
+}
+
+.placeholder-disc-operations::-moz-placeholder {
+  color: var(--disc-operations);
+}
+
+.placeholder-disc-operations:-ms-input-placeholder {
+  color: var(--disc-operations);
+}
+
+.placeholder-disc-operations::placeholder {
+  color: var(--disc-operations);
+}
+
+.placeholder-dns-requests::-moz-placeholder {
+  color: var(--dns-requests);
+}
+
+.placeholder-dns-requests:-ms-input-placeholder {
+  color: var(--dns-requests);
+}
+
+.placeholder-dns-requests::placeholder {
+  color: var(--dns-requests);
+}
+
+.placeholder-focus::-moz-placeholder {
+  color: var(--focus);
+}
+
+.placeholder-focus:-ms-input-placeholder {
+  color: var(--focus);
+}
+
+.placeholder-focus::placeholder {
+  color: var(--focus);
+}
+
+.placeholder-graph-1::-moz-placeholder {
+  color: var(--graph-1);
+}
+
+.placeholder-graph-1:-ms-input-placeholder {
+  color: var(--graph-1);
+}
+
+.placeholder-graph-1::placeholder {
+  color: var(--graph-1);
+}
+
+.placeholder-graph-10::-moz-placeholder {
+  color: var(--graph-10);
+}
+
+.placeholder-graph-10:-ms-input-placeholder {
+  color: var(--graph-10);
+}
+
+.placeholder-graph-10::placeholder {
+  color: var(--graph-10);
+}
+
+.placeholder-graph-11::-moz-placeholder {
+  color: var(--graph-11);
+}
+
+.placeholder-graph-11:-ms-input-placeholder {
+  color: var(--graph-11);
+}
+
+.placeholder-graph-11::placeholder {
+  color: var(--graph-11);
+}
+
+.placeholder-graph-2::-moz-placeholder {
+  color: var(--graph-2);
+}
+
+.placeholder-graph-2:-ms-input-placeholder {
+  color: var(--graph-2);
+}
+
+.placeholder-graph-2::placeholder {
+  color: var(--graph-2);
+}
+
+.placeholder-graph-3::-moz-placeholder {
+  color: var(--graph-3);
+}
+
+.placeholder-graph-3:-ms-input-placeholder {
+  color: var(--graph-3);
+}
+
+.placeholder-graph-3::placeholder {
+  color: var(--graph-3);
+}
+
+.placeholder-graph-4::-moz-placeholder {
+  color: var(--graph-4);
+}
+
+.placeholder-graph-4:-ms-input-placeholder {
+  color: var(--graph-4);
+}
+
+.placeholder-graph-4::placeholder {
+  color: var(--graph-4);
+}
+
+.placeholder-graph-5::-moz-placeholder {
+  color: var(--graph-5);
+}
+
+.placeholder-graph-5:-ms-input-placeholder {
+  color: var(--graph-5);
+}
+
+.placeholder-graph-5::placeholder {
+  color: var(--graph-5);
+}
+
+.placeholder-graph-6::-moz-placeholder {
+  color: var(--graph-6);
+}
+
+.placeholder-graph-6:-ms-input-placeholder {
+  color: var(--graph-6);
+}
+
+.placeholder-graph-6::placeholder {
+  color: var(--graph-6);
+}
+
+.placeholder-graph-7::-moz-placeholder {
+  color: var(--graph-7);
+}
+
+.placeholder-graph-7:-ms-input-placeholder {
+  color: var(--graph-7);
+}
+
+.placeholder-graph-7::placeholder {
+  color: var(--graph-7);
+}
+
+.placeholder-graph-8::-moz-placeholder {
+  color: var(--graph-8);
+}
+
+.placeholder-graph-8:-ms-input-placeholder {
+  color: var(--graph-8);
+}
+
+.placeholder-graph-8::placeholder {
+  color: var(--graph-8);
+}
+
+.placeholder-graph-9::-moz-placeholder {
+  color: var(--graph-9);
+}
+
+.placeholder-graph-9:-ms-input-placeholder {
+  color: var(--graph-9);
+}
+
+.placeholder-graph-9::placeholder {
+  color: var(--graph-9);
+}
+
+.placeholder-graph-disabled::-moz-placeholder {
+  color: var(--graph-disabled);
+}
+
+.placeholder-graph-disabled:-ms-input-placeholder {
+  color: var(--graph-disabled);
+}
+
+.placeholder-graph-disabled::placeholder {
+  color: var(--graph-disabled);
+}
+
+.placeholder-ground-floor::-moz-placeholder {
+  color: var(--ground-floor);
+}
+
+.placeholder-ground-floor:-ms-input-placeholder {
+  color: var(--ground-floor);
+}
+
+.placeholder-ground-floor::placeholder {
+  color: var(--ground-floor);
+}
+
+.placeholder-high::-moz-placeholder {
+  color: var(--high);
+}
+
+.placeholder-high:-ms-input-placeholder {
+  color: var(--high);
+}
+
+.placeholder-high::placeholder {
+  color: var(--high);
+}
+
+.placeholder-informational::-moz-placeholder {
+  color: var(--informational);
+}
+
+.placeholder-informational:-ms-input-placeholder {
+  color: var(--informational);
+}
+
+.placeholder-informational::placeholder {
+  color: var(--informational);
+}
+
+.placeholder-lines-dark::-moz-placeholder {
+  color: var(--lines-dark);
+}
+
+.placeholder-lines-dark:-ms-input-placeholder {
+  color: var(--lines-dark);
+}
+
+.placeholder-lines-dark::placeholder {
+  color: var(--lines-dark);
+}
+
+.placeholder-lines-light::-moz-placeholder {
+  color: var(--lines-light);
+}
+
+.placeholder-lines-light:-ms-input-placeholder {
+  color: var(--lines-light);
+}
+
+.placeholder-lines-light::placeholder {
+  color: var(--lines-light);
+}
+
+.placeholder-low::-moz-placeholder {
+  color: var(--low);
+}
+
+.placeholder-low:-ms-input-placeholder {
+  color: var(--low);
+}
+
+.placeholder-low::placeholder {
+  color: var(--low);
+}
+
+.placeholder-medium::-moz-placeholder {
+  color: var(--medium);
+}
+
+.placeholder-medium:-ms-input-placeholder {
+  color: var(--medium);
+}
+
+.placeholder-medium::placeholder {
+  color: var(--medium);
+}
+
+.placeholder-mezzanine::-moz-placeholder {
+  color: var(--mezzanine);
+}
+
+.placeholder-mezzanine:-ms-input-placeholder {
+  color: var(--mezzanine);
+}
+
+.placeholder-mezzanine::placeholder {
+  color: var(--mezzanine);
+}
+
+.placeholder-nav-text-and-icons::-moz-placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.placeholder-nav-text-and-icons:-ms-input-placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.placeholder-nav-text-and-icons::placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.placeholder-nav-text-secondary::-moz-placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.placeholder-nav-text-secondary:-ms-input-placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.placeholder-nav-text-secondary::placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.placeholder-network-operations::-moz-placeholder {
+  color: var(--network-operations);
+}
+
+.placeholder-network-operations:-ms-input-placeholder {
+  color: var(--network-operations);
+}
+
+.placeholder-network-operations::placeholder {
+  color: var(--network-operations);
+}
+
+.placeholder-normal-hover::-moz-placeholder {
+  color: var(--normal-hover);
+}
+
+.placeholder-normal-hover:-ms-input-placeholder {
+  color: var(--normal-hover);
+}
+
+.placeholder-normal-hover::placeholder {
+  color: var(--normal-hover);
+}
+
+.placeholder-normal-idle::-moz-placeholder {
+  color: var(--normal-idle);
+}
+
+.placeholder-normal-idle:-ms-input-placeholder {
+  color: var(--normal-idle);
+}
+
+.placeholder-normal-idle::placeholder {
+  color: var(--normal-idle);
+}
+
+.placeholder-normal-pressed::-moz-placeholder {
+  color: var(--normal-pressed);
+}
+
+.placeholder-normal-pressed:-ms-input-placeholder {
+  color: var(--normal-pressed);
+}
+
+.placeholder-normal-pressed::placeholder {
+  color: var(--normal-pressed);
+}
+
+.placeholder-overlay-0\\\\.5::-moz-placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.placeholder-overlay-0\\\\.5:-ms-input-placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.placeholder-overlay-0\\\\.5::placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.placeholder-overlay-1::-moz-placeholder {
+  color: var(--overlay-1);
+}
+
+.placeholder-overlay-1:-ms-input-placeholder {
+  color: var(--overlay-1);
+}
+
+.placeholder-overlay-1::placeholder {
+  color: var(--overlay-1);
+}
+
+.placeholder-overlay-2::-moz-placeholder {
+  color: var(--overlay-2);
+}
+
+.placeholder-overlay-2:-ms-input-placeholder {
+  color: var(--overlay-2);
+}
+
+.placeholder-overlay-2::placeholder {
+  color: var(--overlay-2);
+}
+
+.placeholder-positive::-moz-placeholder {
+  color: var(--positive);
+}
+
+.placeholder-positive:-ms-input-placeholder {
+  color: var(--positive);
+}
+
+.placeholder-positive::placeholder {
+  color: var(--positive);
+}
+
+.placeholder-primary-hover::-moz-placeholder {
+  color: var(--primary-hover);
+}
+
+.placeholder-primary-hover:-ms-input-placeholder {
+  color: var(--primary-hover);
+}
+
+.placeholder-primary-hover::placeholder {
+  color: var(--primary-hover);
+}
+
+.placeholder-primary-idle::-moz-placeholder {
+  color: var(--primary-idle);
+}
+
+.placeholder-primary-idle:-ms-input-placeholder {
+  color: var(--primary-idle);
+}
+
+.placeholder-primary-idle::placeholder {
+  color: var(--primary-idle);
+}
+
+.placeholder-primary-pressed::-moz-placeholder {
+  color: var(--primary-pressed);
+}
+
+.placeholder-primary-pressed:-ms-input-placeholder {
+  color: var(--primary-pressed);
+}
+
+.placeholder-primary-pressed::placeholder {
+  color: var(--primary-pressed);
+}
+
+.placeholder-process-operations::-moz-placeholder {
+  color: var(--process-operations);
+}
+
+.placeholder-process-operations:-ms-input-placeholder {
+  color: var(--process-operations);
+}
+
+.placeholder-process-operations::placeholder {
+  color: var(--process-operations);
+}
+
+.placeholder-purple::-moz-placeholder {
+  color: var(--purple);
+}
+
+.placeholder-purple:-ms-input-placeholder {
+  color: var(--purple);
+}
+
+.placeholder-purple::placeholder {
+  color: var(--purple);
+}
+
+.placeholder-registry-operations::-moz-placeholder {
+  color: var(--registry-operations);
+}
+
+.placeholder-registry-operations:-ms-input-placeholder {
+  color: var(--registry-operations);
+}
+
+.placeholder-registry-operations::placeholder {
+  color: var(--registry-operations);
+}
+
+.placeholder-selected::-moz-placeholder {
+  color: var(--selected);
+}
+
+.placeholder-selected:-ms-input-placeholder {
+  color: var(--selected);
+}
+
+.placeholder-selected::placeholder {
+  color: var(--selected);
+}
+
+.placeholder-surface-2xl::-moz-placeholder {
+  color: var(--surface-2xl);
+}
+
+.placeholder-surface-2xl:-ms-input-placeholder {
+  color: var(--surface-2xl);
+}
+
+.placeholder-surface-2xl::placeholder {
+  color: var(--surface-2xl);
+}
+
+.placeholder-surface-base::-moz-placeholder {
+  color: var(--surface-base);
+}
+
+.placeholder-surface-base:-ms-input-placeholder {
+  color: var(--surface-base);
+}
+
+.placeholder-surface-base::placeholder {
+  color: var(--surface-base);
+}
+
+.placeholder-surface-inner::-moz-placeholder {
+  color: var(--surface-inner);
+}
+
+.placeholder-surface-inner:-ms-input-placeholder {
+  color: var(--surface-inner);
+}
+
+.placeholder-surface-inner::placeholder {
+  color: var(--surface-inner);
+}
+
+.placeholder-surface-lg::-moz-placeholder {
+  color: var(--surface-lg);
+}
+
+.placeholder-surface-lg:-ms-input-placeholder {
+  color: var(--surface-lg);
+}
+
+.placeholder-surface-lg::placeholder {
+  color: var(--surface-lg);
+}
+
+.placeholder-surface-md::-moz-placeholder {
+  color: var(--surface-md);
+}
+
+.placeholder-surface-md:-ms-input-placeholder {
+  color: var(--surface-md);
+}
+
+.placeholder-surface-md::placeholder {
+  color: var(--surface-md);
+}
+
+.placeholder-surface-xl::-moz-placeholder {
+  color: var(--surface-xl);
+}
+
+.placeholder-surface-xl:-ms-input-placeholder {
+  color: var(--surface-xl);
+}
+
+.placeholder-surface-xl::placeholder {
+  color: var(--surface-xl);
+}
+
+.placeholder-text-and-icons::-moz-placeholder {
+  color: var(--text-and-icons);
+}
+
+.placeholder-text-and-icons:-ms-input-placeholder {
+  color: var(--text-and-icons);
+}
+
+.placeholder-text-and-icons::placeholder {
+  color: var(--text-and-icons);
+}
+
+.placeholder-titles-and-attributes::-moz-placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.placeholder-titles-and-attributes:-ms-input-placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.placeholder-titles-and-attributes::placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.focus\\\\:placeholder-current:focus::-moz-placeholder {
+  color: currentColor;
+}
+
+.focus\\\\:placeholder-current:focus:-ms-input-placeholder {
+  color: currentColor;
+}
+
+.focus\\\\:placeholder-current:focus::placeholder {
+  color: currentColor;
+}
+
+.focus\\\\:placeholder-transparent:focus::-moz-placeholder {
+  color: transparent;
+}
+
+.focus\\\\:placeholder-transparent:focus:-ms-input-placeholder {
+  color: transparent;
+}
+
+.focus\\\\:placeholder-transparent:focus::placeholder {
+  color: transparent;
+}
+
+.focus\\\\:placeholder-falcon:focus::-moz-placeholder {
+  color: var(--falcon);
+}
+
+.focus\\\\:placeholder-falcon:focus:-ms-input-placeholder {
+  color: var(--falcon);
+}
+
+.focus\\\\:placeholder-falcon:focus::placeholder {
+  color: var(--falcon);
+}
+
+.focus\\\\:placeholder-basement:focus::-moz-placeholder {
+  color: var(--basement);
+}
+
+.focus\\\\:placeholder-basement:focus:-ms-input-placeholder {
+  color: var(--basement);
+}
+
+.focus\\\\:placeholder-basement:focus::placeholder {
+  color: var(--basement);
+}
+
+.focus\\\\:placeholder-blue:focus::-moz-placeholder {
+  color: var(--blue);
+}
+
+.focus\\\\:placeholder-blue:focus:-ms-input-placeholder {
+  color: var(--blue);
+}
+
+.focus\\\\:placeholder-blue:focus::placeholder {
+  color: var(--blue);
+}
+
+.focus\\\\:placeholder-body-and-labels:focus::-moz-placeholder {
+  color: var(--body-and-labels);
+}
+
+.focus\\\\:placeholder-body-and-labels:focus:-ms-input-placeholder {
+  color: var(--body-and-labels);
+}
+
+.focus\\\\:placeholder-body-and-labels:focus::placeholder {
+  color: var(--body-and-labels);
+}
+
+.focus\\\\:placeholder-brand:focus::-moz-placeholder {
+  color: var(--brand);
+}
+
+.focus\\\\:placeholder-brand:focus:-ms-input-placeholder {
+  color: var(--brand);
+}
+
+.focus\\\\:placeholder-brand:focus::placeholder {
+  color: var(--brand);
+}
+
+.focus\\\\:placeholder-code-base-64:focus::-moz-placeholder {
+  color: var(--code-base-64);
+}
+
+.focus\\\\:placeholder-code-base-64:focus:-ms-input-placeholder {
+  color: var(--code-base-64);
+}
+
+.focus\\\\:placeholder-code-base-64:focus::placeholder {
+  color: var(--code-base-64);
+}
+
+.focus\\\\:placeholder-code-bg:focus::-moz-placeholder {
+  color: var(--code-bg);
+}
+
+.focus\\\\:placeholder-code-bg:focus:-ms-input-placeholder {
+  color: var(--code-bg);
+}
+
+.focus\\\\:placeholder-code-bg:focus::placeholder {
+  color: var(--code-bg);
+}
+
+.focus\\\\:placeholder-code-outline:focus::-moz-placeholder {
+  color: var(--code-outline);
+}
+
+.focus\\\\:placeholder-code-outline:focus:-ms-input-placeholder {
+  color: var(--code-outline);
+}
+
+.focus\\\\:placeholder-code-outline:focus::placeholder {
+  color: var(--code-outline);
+}
+
+.focus\\\\:placeholder-code-text:focus::-moz-placeholder {
+  color: var(--code-text);
+}
+
+.focus\\\\:placeholder-code-text:focus:-ms-input-placeholder {
+  color: var(--code-text);
+}
+
+.focus\\\\:placeholder-code-text:focus::placeholder {
+  color: var(--code-text);
+}
+
+.focus\\\\:placeholder-critical:focus::-moz-placeholder {
+  color: var(--critical);
+}
+
+.focus\\\\:placeholder-critical:focus:-ms-input-placeholder {
+  color: var(--critical);
+}
+
+.focus\\\\:placeholder-critical:focus::placeholder {
+  color: var(--critical);
+}
+
+.focus\\\\:placeholder-destructive-hover:focus::-moz-placeholder {
+  color: var(--destructive-hover);
+}
+
+.focus\\\\:placeholder-destructive-hover:focus:-ms-input-placeholder {
+  color: var(--destructive-hover);
+}
+
+.focus\\\\:placeholder-destructive-hover:focus::placeholder {
+  color: var(--destructive-hover);
+}
+
+.focus\\\\:placeholder-destructive-idle:focus::-moz-placeholder {
+  color: var(--destructive-idle);
+}
+
+.focus\\\\:placeholder-destructive-idle:focus:-ms-input-placeholder {
+  color: var(--destructive-idle);
+}
+
+.focus\\\\:placeholder-destructive-idle:focus::placeholder {
+  color: var(--destructive-idle);
+}
+
+.focus\\\\:placeholder-destructive-pressed:focus::-moz-placeholder {
+  color: var(--destructive-pressed);
+}
+
+.focus\\\\:placeholder-destructive-pressed:focus:-ms-input-placeholder {
+  color: var(--destructive-pressed);
+}
+
+.focus\\\\:placeholder-destructive-pressed:focus::placeholder {
+  color: var(--destructive-pressed);
+}
+
+.focus\\\\:placeholder-disabled:focus::-moz-placeholder {
+  color: var(--disabled);
+}
+
+.focus\\\\:placeholder-disabled:focus:-ms-input-placeholder {
+  color: var(--disabled);
+}
+
+.focus\\\\:placeholder-disabled:focus::placeholder {
+  color: var(--disabled);
+}
+
+.focus\\\\:placeholder-disc-operations:focus::-moz-placeholder {
+  color: var(--disc-operations);
+}
+
+.focus\\\\:placeholder-disc-operations:focus:-ms-input-placeholder {
+  color: var(--disc-operations);
+}
+
+.focus\\\\:placeholder-disc-operations:focus::placeholder {
+  color: var(--disc-operations);
+}
+
+.focus\\\\:placeholder-dns-requests:focus::-moz-placeholder {
+  color: var(--dns-requests);
+}
+
+.focus\\\\:placeholder-dns-requests:focus:-ms-input-placeholder {
+  color: var(--dns-requests);
+}
+
+.focus\\\\:placeholder-dns-requests:focus::placeholder {
+  color: var(--dns-requests);
+}
+
+.focus\\\\:placeholder-focus:focus::-moz-placeholder {
+  color: var(--focus);
+}
+
+.focus\\\\:placeholder-focus:focus:-ms-input-placeholder {
+  color: var(--focus);
+}
+
+.focus\\\\:placeholder-focus:focus::placeholder {
+  color: var(--focus);
+}
+
+.focus\\\\:placeholder-graph-1:focus::-moz-placeholder {
+  color: var(--graph-1);
+}
+
+.focus\\\\:placeholder-graph-1:focus:-ms-input-placeholder {
+  color: var(--graph-1);
+}
+
+.focus\\\\:placeholder-graph-1:focus::placeholder {
+  color: var(--graph-1);
+}
+
+.focus\\\\:placeholder-graph-10:focus::-moz-placeholder {
+  color: var(--graph-10);
+}
+
+.focus\\\\:placeholder-graph-10:focus:-ms-input-placeholder {
+  color: var(--graph-10);
+}
+
+.focus\\\\:placeholder-graph-10:focus::placeholder {
+  color: var(--graph-10);
+}
+
+.focus\\\\:placeholder-graph-11:focus::-moz-placeholder {
+  color: var(--graph-11);
+}
+
+.focus\\\\:placeholder-graph-11:focus:-ms-input-placeholder {
+  color: var(--graph-11);
+}
+
+.focus\\\\:placeholder-graph-11:focus::placeholder {
+  color: var(--graph-11);
+}
+
+.focus\\\\:placeholder-graph-2:focus::-moz-placeholder {
+  color: var(--graph-2);
+}
+
+.focus\\\\:placeholder-graph-2:focus:-ms-input-placeholder {
+  color: var(--graph-2);
+}
+
+.focus\\\\:placeholder-graph-2:focus::placeholder {
+  color: var(--graph-2);
+}
+
+.focus\\\\:placeholder-graph-3:focus::-moz-placeholder {
+  color: var(--graph-3);
+}
+
+.focus\\\\:placeholder-graph-3:focus:-ms-input-placeholder {
+  color: var(--graph-3);
+}
+
+.focus\\\\:placeholder-graph-3:focus::placeholder {
+  color: var(--graph-3);
+}
+
+.focus\\\\:placeholder-graph-4:focus::-moz-placeholder {
+  color: var(--graph-4);
+}
+
+.focus\\\\:placeholder-graph-4:focus:-ms-input-placeholder {
+  color: var(--graph-4);
+}
+
+.focus\\\\:placeholder-graph-4:focus::placeholder {
+  color: var(--graph-4);
+}
+
+.focus\\\\:placeholder-graph-5:focus::-moz-placeholder {
+  color: var(--graph-5);
+}
+
+.focus\\\\:placeholder-graph-5:focus:-ms-input-placeholder {
+  color: var(--graph-5);
+}
+
+.focus\\\\:placeholder-graph-5:focus::placeholder {
+  color: var(--graph-5);
+}
+
+.focus\\\\:placeholder-graph-6:focus::-moz-placeholder {
+  color: var(--graph-6);
+}
+
+.focus\\\\:placeholder-graph-6:focus:-ms-input-placeholder {
+  color: var(--graph-6);
+}
+
+.focus\\\\:placeholder-graph-6:focus::placeholder {
+  color: var(--graph-6);
+}
+
+.focus\\\\:placeholder-graph-7:focus::-moz-placeholder {
+  color: var(--graph-7);
+}
+
+.focus\\\\:placeholder-graph-7:focus:-ms-input-placeholder {
+  color: var(--graph-7);
+}
+
+.focus\\\\:placeholder-graph-7:focus::placeholder {
+  color: var(--graph-7);
+}
+
+.focus\\\\:placeholder-graph-8:focus::-moz-placeholder {
+  color: var(--graph-8);
+}
+
+.focus\\\\:placeholder-graph-8:focus:-ms-input-placeholder {
+  color: var(--graph-8);
+}
+
+.focus\\\\:placeholder-graph-8:focus::placeholder {
+  color: var(--graph-8);
+}
+
+.focus\\\\:placeholder-graph-9:focus::-moz-placeholder {
+  color: var(--graph-9);
+}
+
+.focus\\\\:placeholder-graph-9:focus:-ms-input-placeholder {
+  color: var(--graph-9);
+}
+
+.focus\\\\:placeholder-graph-9:focus::placeholder {
+  color: var(--graph-9);
+}
+
+.focus\\\\:placeholder-graph-disabled:focus::-moz-placeholder {
+  color: var(--graph-disabled);
+}
+
+.focus\\\\:placeholder-graph-disabled:focus:-ms-input-placeholder {
+  color: var(--graph-disabled);
+}
+
+.focus\\\\:placeholder-graph-disabled:focus::placeholder {
+  color: var(--graph-disabled);
+}
+
+.focus\\\\:placeholder-ground-floor:focus::-moz-placeholder {
+  color: var(--ground-floor);
+}
+
+.focus\\\\:placeholder-ground-floor:focus:-ms-input-placeholder {
+  color: var(--ground-floor);
+}
+
+.focus\\\\:placeholder-ground-floor:focus::placeholder {
+  color: var(--ground-floor);
+}
+
+.focus\\\\:placeholder-high:focus::-moz-placeholder {
+  color: var(--high);
+}
+
+.focus\\\\:placeholder-high:focus:-ms-input-placeholder {
+  color: var(--high);
+}
+
+.focus\\\\:placeholder-high:focus::placeholder {
+  color: var(--high);
+}
+
+.focus\\\\:placeholder-informational:focus::-moz-placeholder {
+  color: var(--informational);
+}
+
+.focus\\\\:placeholder-informational:focus:-ms-input-placeholder {
+  color: var(--informational);
+}
+
+.focus\\\\:placeholder-informational:focus::placeholder {
+  color: var(--informational);
+}
+
+.focus\\\\:placeholder-lines-dark:focus::-moz-placeholder {
+  color: var(--lines-dark);
+}
+
+.focus\\\\:placeholder-lines-dark:focus:-ms-input-placeholder {
+  color: var(--lines-dark);
+}
+
+.focus\\\\:placeholder-lines-dark:focus::placeholder {
+  color: var(--lines-dark);
+}
+
+.focus\\\\:placeholder-lines-light:focus::-moz-placeholder {
+  color: var(--lines-light);
+}
+
+.focus\\\\:placeholder-lines-light:focus:-ms-input-placeholder {
+  color: var(--lines-light);
+}
+
+.focus\\\\:placeholder-lines-light:focus::placeholder {
+  color: var(--lines-light);
+}
+
+.focus\\\\:placeholder-low:focus::-moz-placeholder {
+  color: var(--low);
+}
+
+.focus\\\\:placeholder-low:focus:-ms-input-placeholder {
+  color: var(--low);
+}
+
+.focus\\\\:placeholder-low:focus::placeholder {
+  color: var(--low);
+}
+
+.focus\\\\:placeholder-medium:focus::-moz-placeholder {
+  color: var(--medium);
+}
+
+.focus\\\\:placeholder-medium:focus:-ms-input-placeholder {
+  color: var(--medium);
+}
+
+.focus\\\\:placeholder-medium:focus::placeholder {
+  color: var(--medium);
+}
+
+.focus\\\\:placeholder-mezzanine:focus::-moz-placeholder {
+  color: var(--mezzanine);
+}
+
+.focus\\\\:placeholder-mezzanine:focus:-ms-input-placeholder {
+  color: var(--mezzanine);
+}
+
+.focus\\\\:placeholder-mezzanine:focus::placeholder {
+  color: var(--mezzanine);
+}
+
+.focus\\\\:placeholder-nav-text-and-icons:focus::-moz-placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:placeholder-nav-text-and-icons:focus:-ms-input-placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:placeholder-nav-text-and-icons:focus::placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:placeholder-nav-text-secondary:focus::-moz-placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.focus\\\\:placeholder-nav-text-secondary:focus:-ms-input-placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.focus\\\\:placeholder-nav-text-secondary:focus::placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.focus\\\\:placeholder-network-operations:focus::-moz-placeholder {
+  color: var(--network-operations);
+}
+
+.focus\\\\:placeholder-network-operations:focus:-ms-input-placeholder {
+  color: var(--network-operations);
+}
+
+.focus\\\\:placeholder-network-operations:focus::placeholder {
+  color: var(--network-operations);
+}
+
+.focus\\\\:placeholder-normal-hover:focus::-moz-placeholder {
+  color: var(--normal-hover);
+}
+
+.focus\\\\:placeholder-normal-hover:focus:-ms-input-placeholder {
+  color: var(--normal-hover);
+}
+
+.focus\\\\:placeholder-normal-hover:focus::placeholder {
+  color: var(--normal-hover);
+}
+
+.focus\\\\:placeholder-normal-idle:focus::-moz-placeholder {
+  color: var(--normal-idle);
+}
+
+.focus\\\\:placeholder-normal-idle:focus:-ms-input-placeholder {
+  color: var(--normal-idle);
+}
+
+.focus\\\\:placeholder-normal-idle:focus::placeholder {
+  color: var(--normal-idle);
+}
+
+.focus\\\\:placeholder-normal-pressed:focus::-moz-placeholder {
+  color: var(--normal-pressed);
+}
+
+.focus\\\\:placeholder-normal-pressed:focus:-ms-input-placeholder {
+  color: var(--normal-pressed);
+}
+
+.focus\\\\:placeholder-normal-pressed:focus::placeholder {
+  color: var(--normal-pressed);
+}
+
+.focus\\\\:placeholder-overlay-0\\\\.5:focus::-moz-placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:placeholder-overlay-0\\\\.5:focus:-ms-input-placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:placeholder-overlay-0\\\\.5:focus::placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:placeholder-overlay-1:focus::-moz-placeholder {
+  color: var(--overlay-1);
+}
+
+.focus\\\\:placeholder-overlay-1:focus:-ms-input-placeholder {
+  color: var(--overlay-1);
+}
+
+.focus\\\\:placeholder-overlay-1:focus::placeholder {
+  color: var(--overlay-1);
+}
+
+.focus\\\\:placeholder-overlay-2:focus::-moz-placeholder {
+  color: var(--overlay-2);
+}
+
+.focus\\\\:placeholder-overlay-2:focus:-ms-input-placeholder {
+  color: var(--overlay-2);
+}
+
+.focus\\\\:placeholder-overlay-2:focus::placeholder {
+  color: var(--overlay-2);
+}
+
+.focus\\\\:placeholder-positive:focus::-moz-placeholder {
+  color: var(--positive);
+}
+
+.focus\\\\:placeholder-positive:focus:-ms-input-placeholder {
+  color: var(--positive);
+}
+
+.focus\\\\:placeholder-positive:focus::placeholder {
+  color: var(--positive);
+}
+
+.focus\\\\:placeholder-primary-hover:focus::-moz-placeholder {
+  color: var(--primary-hover);
+}
+
+.focus\\\\:placeholder-primary-hover:focus:-ms-input-placeholder {
+  color: var(--primary-hover);
+}
+
+.focus\\\\:placeholder-primary-hover:focus::placeholder {
+  color: var(--primary-hover);
+}
+
+.focus\\\\:placeholder-primary-idle:focus::-moz-placeholder {
+  color: var(--primary-idle);
+}
+
+.focus\\\\:placeholder-primary-idle:focus:-ms-input-placeholder {
+  color: var(--primary-idle);
+}
+
+.focus\\\\:placeholder-primary-idle:focus::placeholder {
+  color: var(--primary-idle);
+}
+
+.focus\\\\:placeholder-primary-pressed:focus::-moz-placeholder {
+  color: var(--primary-pressed);
+}
+
+.focus\\\\:placeholder-primary-pressed:focus:-ms-input-placeholder {
+  color: var(--primary-pressed);
+}
+
+.focus\\\\:placeholder-primary-pressed:focus::placeholder {
+  color: var(--primary-pressed);
+}
+
+.focus\\\\:placeholder-process-operations:focus::-moz-placeholder {
+  color: var(--process-operations);
+}
+
+.focus\\\\:placeholder-process-operations:focus:-ms-input-placeholder {
+  color: var(--process-operations);
+}
+
+.focus\\\\:placeholder-process-operations:focus::placeholder {
+  color: var(--process-operations);
+}
+
+.focus\\\\:placeholder-purple:focus::-moz-placeholder {
+  color: var(--purple);
+}
+
+.focus\\\\:placeholder-purple:focus:-ms-input-placeholder {
+  color: var(--purple);
+}
+
+.focus\\\\:placeholder-purple:focus::placeholder {
+  color: var(--purple);
+}
+
+.focus\\\\:placeholder-registry-operations:focus::-moz-placeholder {
+  color: var(--registry-operations);
+}
+
+.focus\\\\:placeholder-registry-operations:focus:-ms-input-placeholder {
+  color: var(--registry-operations);
+}
+
+.focus\\\\:placeholder-registry-operations:focus::placeholder {
+  color: var(--registry-operations);
+}
+
+.focus\\\\:placeholder-selected:focus::-moz-placeholder {
+  color: var(--selected);
+}
+
+.focus\\\\:placeholder-selected:focus:-ms-input-placeholder {
+  color: var(--selected);
+}
+
+.focus\\\\:placeholder-selected:focus::placeholder {
+  color: var(--selected);
+}
+
+.focus\\\\:placeholder-surface-2xl:focus::-moz-placeholder {
+  color: var(--surface-2xl);
+}
+
+.focus\\\\:placeholder-surface-2xl:focus:-ms-input-placeholder {
+  color: var(--surface-2xl);
+}
+
+.focus\\\\:placeholder-surface-2xl:focus::placeholder {
+  color: var(--surface-2xl);
+}
+
+.focus\\\\:placeholder-surface-base:focus::-moz-placeholder {
+  color: var(--surface-base);
+}
+
+.focus\\\\:placeholder-surface-base:focus:-ms-input-placeholder {
+  color: var(--surface-base);
+}
+
+.focus\\\\:placeholder-surface-base:focus::placeholder {
+  color: var(--surface-base);
+}
+
+.focus\\\\:placeholder-surface-inner:focus::-moz-placeholder {
+  color: var(--surface-inner);
+}
+
+.focus\\\\:placeholder-surface-inner:focus:-ms-input-placeholder {
+  color: var(--surface-inner);
+}
+
+.focus\\\\:placeholder-surface-inner:focus::placeholder {
+  color: var(--surface-inner);
+}
+
+.focus\\\\:placeholder-surface-lg:focus::-moz-placeholder {
+  color: var(--surface-lg);
+}
+
+.focus\\\\:placeholder-surface-lg:focus:-ms-input-placeholder {
+  color: var(--surface-lg);
+}
+
+.focus\\\\:placeholder-surface-lg:focus::placeholder {
+  color: var(--surface-lg);
+}
+
+.focus\\\\:placeholder-surface-md:focus::-moz-placeholder {
+  color: var(--surface-md);
+}
+
+.focus\\\\:placeholder-surface-md:focus:-ms-input-placeholder {
+  color: var(--surface-md);
+}
+
+.focus\\\\:placeholder-surface-md:focus::placeholder {
+  color: var(--surface-md);
+}
+
+.focus\\\\:placeholder-surface-xl:focus::-moz-placeholder {
+  color: var(--surface-xl);
+}
+
+.focus\\\\:placeholder-surface-xl:focus:-ms-input-placeholder {
+  color: var(--surface-xl);
+}
+
+.focus\\\\:placeholder-surface-xl:focus::placeholder {
+  color: var(--surface-xl);
+}
+
+.focus\\\\:placeholder-text-and-icons:focus::-moz-placeholder {
+  color: var(--text-and-icons);
+}
+
+.focus\\\\:placeholder-text-and-icons:focus:-ms-input-placeholder {
+  color: var(--text-and-icons);
+}
+
+.focus\\\\:placeholder-text-and-icons:focus::placeholder {
+  color: var(--text-and-icons);
+}
+
+.focus\\\\:placeholder-titles-and-attributes:focus::-moz-placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.focus\\\\:placeholder-titles-and-attributes:focus:-ms-input-placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.focus\\\\:placeholder-titles-and-attributes:focus::placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.placeholder-opacity-0::-moz-placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.placeholder-opacity-0:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.placeholder-opacity-0::placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.placeholder-opacity-5::-moz-placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.placeholder-opacity-5:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.placeholder-opacity-5::placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.placeholder-opacity-10::-moz-placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.placeholder-opacity-10:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.placeholder-opacity-10::placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.placeholder-opacity-20::-moz-placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.placeholder-opacity-20:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.placeholder-opacity-20::placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.placeholder-opacity-25::-moz-placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.placeholder-opacity-25:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.placeholder-opacity-25::placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.placeholder-opacity-30::-moz-placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.placeholder-opacity-30:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.placeholder-opacity-30::placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.placeholder-opacity-40::-moz-placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.placeholder-opacity-40:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.placeholder-opacity-40::placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.placeholder-opacity-50::-moz-placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.placeholder-opacity-50:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.placeholder-opacity-50::placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.placeholder-opacity-60::-moz-placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.placeholder-opacity-60:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.placeholder-opacity-60::placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.placeholder-opacity-70::-moz-placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.placeholder-opacity-70:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.placeholder-opacity-70::placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.placeholder-opacity-75::-moz-placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.placeholder-opacity-75:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.placeholder-opacity-75::placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.placeholder-opacity-80::-moz-placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.placeholder-opacity-80:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.placeholder-opacity-80::placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.placeholder-opacity-90::-moz-placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.placeholder-opacity-90:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.placeholder-opacity-90::placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.placeholder-opacity-95::-moz-placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.placeholder-opacity-95:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.placeholder-opacity-95::placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.placeholder-opacity-100::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.placeholder-opacity-100:-ms-input-placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.placeholder-opacity-100::placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.focus\\\\:placeholder-opacity-0:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.focus\\\\:placeholder-opacity-0:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.focus\\\\:placeholder-opacity-0:focus::placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.focus\\\\:placeholder-opacity-5:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.focus\\\\:placeholder-opacity-5:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.focus\\\\:placeholder-opacity-5:focus::placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.focus\\\\:placeholder-opacity-10:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.focus\\\\:placeholder-opacity-10:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.focus\\\\:placeholder-opacity-10:focus::placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.focus\\\\:placeholder-opacity-20:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.focus\\\\:placeholder-opacity-20:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.focus\\\\:placeholder-opacity-20:focus::placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.focus\\\\:placeholder-opacity-25:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.focus\\\\:placeholder-opacity-25:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.focus\\\\:placeholder-opacity-25:focus::placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.focus\\\\:placeholder-opacity-30:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.focus\\\\:placeholder-opacity-30:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.focus\\\\:placeholder-opacity-30:focus::placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.focus\\\\:placeholder-opacity-40:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.focus\\\\:placeholder-opacity-40:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.focus\\\\:placeholder-opacity-40:focus::placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.focus\\\\:placeholder-opacity-50:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.focus\\\\:placeholder-opacity-50:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.focus\\\\:placeholder-opacity-50:focus::placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.focus\\\\:placeholder-opacity-60:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.focus\\\\:placeholder-opacity-60:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.focus\\\\:placeholder-opacity-60:focus::placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.focus\\\\:placeholder-opacity-70:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.focus\\\\:placeholder-opacity-70:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.focus\\\\:placeholder-opacity-70:focus::placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.focus\\\\:placeholder-opacity-75:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.focus\\\\:placeholder-opacity-75:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.focus\\\\:placeholder-opacity-75:focus::placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.focus\\\\:placeholder-opacity-80:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.focus\\\\:placeholder-opacity-80:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.focus\\\\:placeholder-opacity-80:focus::placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.focus\\\\:placeholder-opacity-90:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.focus\\\\:placeholder-opacity-90:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.focus\\\\:placeholder-opacity-90:focus::placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.focus\\\\:placeholder-opacity-95:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.focus\\\\:placeholder-opacity-95:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.focus\\\\:placeholder-opacity-95:focus::placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.focus\\\\:placeholder-opacity-100:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.focus\\\\:placeholder-opacity-100:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.focus\\\\:placeholder-opacity-100:focus::placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.caret-current {
+  caret-color: currentColor;
+}
+
+.caret-transparent {
+  caret-color: transparent;
+}
+
+.caret-falcon {
+  caret-color: var(--falcon);
+}
+
+.caret-basement {
+  caret-color: var(--basement);
+}
+
+.caret-blue {
+  caret-color: var(--blue);
+}
+
+.caret-body-and-labels {
+  caret-color: var(--body-and-labels);
+}
+
+.caret-brand {
+  caret-color: var(--brand);
+}
+
+.caret-code-base-64 {
+  caret-color: var(--code-base-64);
+}
+
+.caret-code-bg {
+  caret-color: var(--code-bg);
+}
+
+.caret-code-outline {
+  caret-color: var(--code-outline);
+}
+
+.caret-code-text {
+  caret-color: var(--code-text);
+}
+
+.caret-critical {
+  caret-color: var(--critical);
+}
+
+.caret-destructive-hover {
+  caret-color: var(--destructive-hover);
+}
+
+.caret-destructive-idle {
+  caret-color: var(--destructive-idle);
+}
+
+.caret-destructive-pressed {
+  caret-color: var(--destructive-pressed);
+}
+
+.caret-disabled {
+  caret-color: var(--disabled);
+}
+
+.caret-disc-operations {
+  caret-color: var(--disc-operations);
+}
+
+.caret-dns-requests {
+  caret-color: var(--dns-requests);
+}
+
+.caret-focus {
+  caret-color: var(--focus);
+}
+
+.caret-graph-1 {
+  caret-color: var(--graph-1);
+}
+
+.caret-graph-10 {
+  caret-color: var(--graph-10);
+}
+
+.caret-graph-11 {
+  caret-color: var(--graph-11);
+}
+
+.caret-graph-2 {
+  caret-color: var(--graph-2);
+}
+
+.caret-graph-3 {
+  caret-color: var(--graph-3);
+}
+
+.caret-graph-4 {
+  caret-color: var(--graph-4);
+}
+
+.caret-graph-5 {
+  caret-color: var(--graph-5);
+}
+
+.caret-graph-6 {
+  caret-color: var(--graph-6);
+}
+
+.caret-graph-7 {
+  caret-color: var(--graph-7);
+}
+
+.caret-graph-8 {
+  caret-color: var(--graph-8);
+}
+
+.caret-graph-9 {
+  caret-color: var(--graph-9);
+}
+
+.caret-graph-disabled {
+  caret-color: var(--graph-disabled);
+}
+
+.caret-ground-floor {
+  caret-color: var(--ground-floor);
+}
+
+.caret-high {
+  caret-color: var(--high);
+}
+
+.caret-informational {
+  caret-color: var(--informational);
+}
+
+.caret-lines-dark {
+  caret-color: var(--lines-dark);
+}
+
+.caret-lines-light {
+  caret-color: var(--lines-light);
+}
+
+.caret-low {
+  caret-color: var(--low);
+}
+
+.caret-medium {
+  caret-color: var(--medium);
+}
+
+.caret-mezzanine {
+  caret-color: var(--mezzanine);
+}
+
+.caret-nav-text-and-icons {
+  caret-color: var(--nav-text-and-icons);
+}
+
+.caret-nav-text-secondary {
+  caret-color: var(--nav-text-secondary);
+}
+
+.caret-network-operations {
+  caret-color: var(--network-operations);
+}
+
+.caret-normal-hover {
+  caret-color: var(--normal-hover);
+}
+
+.caret-normal-idle {
+  caret-color: var(--normal-idle);
+}
+
+.caret-normal-pressed {
+  caret-color: var(--normal-pressed);
+}
+
+.caret-overlay-0\\\\.5 {
+  caret-color: var(--overlay-0\\\\.5);
+}
+
+.caret-overlay-1 {
+  caret-color: var(--overlay-1);
+}
+
+.caret-overlay-2 {
+  caret-color: var(--overlay-2);
+}
+
+.caret-positive {
+  caret-color: var(--positive);
+}
+
+.caret-primary-hover {
+  caret-color: var(--primary-hover);
+}
+
+.caret-primary-idle {
+  caret-color: var(--primary-idle);
+}
+
+.caret-primary-pressed {
+  caret-color: var(--primary-pressed);
+}
+
+.caret-process-operations {
+  caret-color: var(--process-operations);
+}
+
+.caret-purple {
+  caret-color: var(--purple);
+}
+
+.caret-registry-operations {
+  caret-color: var(--registry-operations);
+}
+
+.caret-selected {
+  caret-color: var(--selected);
+}
+
+.caret-surface-2xl {
+  caret-color: var(--surface-2xl);
+}
+
+.caret-surface-base {
+  caret-color: var(--surface-base);
+}
+
+.caret-surface-inner {
+  caret-color: var(--surface-inner);
+}
+
+.caret-surface-lg {
+  caret-color: var(--surface-lg);
+}
+
+.caret-surface-md {
+  caret-color: var(--surface-md);
+}
+
+.caret-surface-xl {
+  caret-color: var(--surface-xl);
+}
+
+.caret-text-and-icons {
+  caret-color: var(--text-and-icons);
+}
+
+.caret-titles-and-attributes {
+  caret-color: var(--titles-and-attributes);
+}
+
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-5 {
+  opacity: 0.05;
+}
+
+.opacity-10 {
+  opacity: 0.1;
+}
+
+.opacity-20 {
+  opacity: 0.2;
+}
+
+.opacity-25 {
+  opacity: 0.25;
+}
+
+.opacity-30 {
+  opacity: 0.3;
+}
+
+.opacity-40 {
+  opacity: 0.4;
+}
+
+.opacity-50 {
+  opacity: 0.5;
+}
+
+.opacity-60 {
+  opacity: 0.6;
+}
+
+.opacity-70 {
+  opacity: 0.7;
+}
+
+.opacity-75 {
+  opacity: 0.75;
+}
+
+.opacity-80 {
+  opacity: 0.8;
+}
+
+.opacity-90 {
+  opacity: 0.9;
+}
+
+.opacity-95 {
+  opacity: 0.95;
+}
+
+.opacity-100 {
+  opacity: 1;
+}
+
+.hover\\\\:opacity-0:hover {
+  opacity: 0;
+}
+
+.hover\\\\:opacity-5:hover {
+  opacity: 0.05;
+}
+
+.hover\\\\:opacity-10:hover {
+  opacity: 0.1;
+}
+
+.hover\\\\:opacity-20:hover {
+  opacity: 0.2;
+}
+
+.hover\\\\:opacity-25:hover {
+  opacity: 0.25;
+}
+
+.hover\\\\:opacity-30:hover {
+  opacity: 0.3;
+}
+
+.hover\\\\:opacity-40:hover {
+  opacity: 0.4;
+}
+
+.hover\\\\:opacity-50:hover {
+  opacity: 0.5;
+}
+
+.hover\\\\:opacity-60:hover {
+  opacity: 0.6;
+}
+
+.hover\\\\:opacity-70:hover {
+  opacity: 0.7;
+}
+
+.hover\\\\:opacity-75:hover {
+  opacity: 0.75;
+}
+
+.hover\\\\:opacity-80:hover {
+  opacity: 0.8;
+}
+
+.hover\\\\:opacity-90:hover {
+  opacity: 0.9;
+}
+
+.hover\\\\:opacity-95:hover {
+  opacity: 0.95;
+}
+
+.hover\\\\:opacity-100:hover {
+  opacity: 1;
+}
+
+.focus\\\\:opacity-0:focus {
+  opacity: 0;
+}
+
+.focus\\\\:opacity-5:focus {
+  opacity: 0.05;
+}
+
+.focus\\\\:opacity-10:focus {
+  opacity: 0.1;
+}
+
+.focus\\\\:opacity-20:focus {
+  opacity: 0.2;
+}
+
+.focus\\\\:opacity-25:focus {
+  opacity: 0.25;
+}
+
+.focus\\\\:opacity-30:focus {
+  opacity: 0.3;
+}
+
+.focus\\\\:opacity-40:focus {
+  opacity: 0.4;
+}
+
+.focus\\\\:opacity-50:focus {
+  opacity: 0.5;
+}
+
+.focus\\\\:opacity-60:focus {
+  opacity: 0.6;
+}
+
+.focus\\\\:opacity-70:focus {
+  opacity: 0.7;
+}
+
+.focus\\\\:opacity-75:focus {
+  opacity: 0.75;
+}
+
+.focus\\\\:opacity-80:focus {
+  opacity: 0.8;
+}
+
+.focus\\\\:opacity-90:focus {
+  opacity: 0.9;
+}
+
+.focus\\\\:opacity-95:focus {
+  opacity: 0.95;
+}
+
+.focus\\\\:opacity-100:focus {
+  opacity: 1;
+}
+
+.group:hover .group-hover\\\\:opacity-0 {
+  opacity: 0;
+}
+
+.group:hover .group-hover\\\\:opacity-5 {
+  opacity: 0.05;
+}
+
+.group:hover .group-hover\\\\:opacity-10 {
+  opacity: 0.1;
+}
+
+.group:hover .group-hover\\\\:opacity-20 {
+  opacity: 0.2;
+}
+
+.group:hover .group-hover\\\\:opacity-25 {
+  opacity: 0.25;
+}
+
+.group:hover .group-hover\\\\:opacity-30 {
+  opacity: 0.3;
+}
+
+.group:hover .group-hover\\\\:opacity-40 {
+  opacity: 0.4;
+}
+
+.group:hover .group-hover\\\\:opacity-50 {
+  opacity: 0.5;
+}
+
+.group:hover .group-hover\\\\:opacity-60 {
+  opacity: 0.6;
+}
+
+.group:hover .group-hover\\\\:opacity-70 {
+  opacity: 0.7;
+}
+
+.group:hover .group-hover\\\\:opacity-75 {
+  opacity: 0.75;
+}
+
+.group:hover .group-hover\\\\:opacity-80 {
+  opacity: 0.8;
+}
+
+.group:hover .group-hover\\\\:opacity-90 {
+  opacity: 0.9;
+}
+
+.group:hover .group-hover\\\\:opacity-95 {
+  opacity: 0.95;
+}
+
+.group:hover .group-hover\\\\:opacity-100 {
+  opacity: 1;
+}
+
+.group:focus .group-focus\\\\:opacity-0 {
+  opacity: 0;
+}
+
+.group:focus .group-focus\\\\:opacity-5 {
+  opacity: 0.05;
+}
+
+.group:focus .group-focus\\\\:opacity-10 {
+  opacity: 0.1;
+}
+
+.group:focus .group-focus\\\\:opacity-20 {
+  opacity: 0.2;
+}
+
+.group:focus .group-focus\\\\:opacity-25 {
+  opacity: 0.25;
+}
+
+.group:focus .group-focus\\\\:opacity-30 {
+  opacity: 0.3;
+}
+
+.group:focus .group-focus\\\\:opacity-40 {
+  opacity: 0.4;
+}
+
+.group:focus .group-focus\\\\:opacity-50 {
+  opacity: 0.5;
+}
+
+.group:focus .group-focus\\\\:opacity-60 {
+  opacity: 0.6;
+}
+
+.group:focus .group-focus\\\\:opacity-70 {
+  opacity: 0.7;
+}
+
+.group:focus .group-focus\\\\:opacity-75 {
+  opacity: 0.75;
+}
+
+.group:focus .group-focus\\\\:opacity-80 {
+  opacity: 0.8;
+}
+
+.group:focus .group-focus\\\\:opacity-90 {
+  opacity: 0.9;
+}
+
+.group:focus .group-focus\\\\:opacity-95 {
+  opacity: 0.95;
+}
+
+.group:focus .group-focus\\\\:opacity-100 {
+  opacity: 1;
+}
+
+.bg-blend-normal {
+  background-blend-mode: normal;
+}
+
+.bg-blend-multiply {
+  background-blend-mode: multiply;
+}
+
+.bg-blend-screen {
+  background-blend-mode: screen;
+}
+
+.bg-blend-overlay {
+  background-blend-mode: overlay;
+}
+
+.bg-blend-darken {
+  background-blend-mode: darken;
+}
+
+.bg-blend-lighten {
+  background-blend-mode: lighten;
+}
+
+.bg-blend-color-dodge {
+  background-blend-mode: color-dodge;
+}
+
+.bg-blend-color-burn {
+  background-blend-mode: color-burn;
+}
+
+.bg-blend-hard-light {
+  background-blend-mode: hard-light;
+}
+
+.bg-blend-soft-light {
+  background-blend-mode: soft-light;
+}
+
+.bg-blend-difference {
+  background-blend-mode: difference;
+}
+
+.bg-blend-exclusion {
+  background-blend-mode: exclusion;
+}
+
+.bg-blend-hue {
+  background-blend-mode: hue;
+}
+
+.bg-blend-saturation {
+  background-blend-mode: saturation;
+}
+
+.bg-blend-color {
+  background-blend-mode: color;
+}
+
+.bg-blend-luminosity {
+  background-blend-mode: luminosity;
+}
+
+.mix-blend-normal {
+  mix-blend-mode: normal;
+}
+
+.mix-blend-multiply {
+  mix-blend-mode: multiply;
+}
+
+.mix-blend-screen {
+  mix-blend-mode: screen;
+}
+
+.mix-blend-overlay {
+  mix-blend-mode: overlay;
+}
+
+.mix-blend-darken {
+  mix-blend-mode: darken;
+}
+
+.mix-blend-lighten {
+  mix-blend-mode: lighten;
+}
+
+.mix-blend-color-dodge {
+  mix-blend-mode: color-dodge;
+}
+
+.mix-blend-color-burn {
+  mix-blend-mode: color-burn;
+}
+
+.mix-blend-hard-light {
+  mix-blend-mode: hard-light;
+}
+
+.mix-blend-soft-light {
+  mix-blend-mode: soft-light;
+}
+
+.mix-blend-difference {
+  mix-blend-mode: difference;
+}
+
+.mix-blend-exclusion {
+  mix-blend-mode: exclusion;
+}
+
+.mix-blend-hue {
+  mix-blend-mode: hue;
+}
+
+.mix-blend-saturation {
+  mix-blend-mode: saturation;
+}
+
+.mix-blend-color {
+  mix-blend-mode: color;
+}
+
+.mix-blend-luminosity {
+  mix-blend-mode: luminosity;
+}
+
+*, ::before, ::after {
+  --tw-shadow: 0 0 #0000;
+}
+
+.shadow-none {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-focusable-outline {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-focus-outline {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-error-outline {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-search-input {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-2xl {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-base {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-inner-lg {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-inner-md {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-lg {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-md {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-xl {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-none:hover {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-focusable-outline:hover {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-focus-outline:hover {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-error-outline:hover {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-search-input:hover {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-2xl:hover {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-base:hover {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-inner-lg:hover {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-inner-md:hover {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-lg:hover {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-md:hover {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-xl:hover {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-none {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-focusable-outline {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-focus-outline {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-error-outline {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-search-input {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-2xl {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-base {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-inner-lg {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-inner-md {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-lg {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-md {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-xl {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-none:focus {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-focusable-outline:focus {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-focus-outline:focus {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-error-outline:focus {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-search-input:focus {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-2xl:focus {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-base:focus {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-inner-lg:focus {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-inner-md:focus {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-lg:focus {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-md:focus {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-xl:focus {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-none:focus-within {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-focusable-outline:focus-within {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-focus-outline:focus-within {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-error-outline:focus-within {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-search-input:focus-within {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-2xl:focus-within {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-base:focus-within {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-inner-lg:focus-within {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-inner-md:focus-within {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-lg:focus-within {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-md:focus-within {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-xl:focus-within {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-none:focus-visible {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-focusable-outline:focus-visible {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-focus-outline:focus-visible {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-error-outline:focus-visible {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-search-input:focus-visible {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-2xl:focus-visible {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-base:focus-visible {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-inner-lg:focus-visible {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-inner-md:focus-visible {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-lg:focus-visible {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-md:focus-visible {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-xl:focus-visible {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-none:active {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-focusable-outline:active {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-focus-outline:active {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-error-outline:active {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-search-input:active {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-2xl:active {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-base:active {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-inner-lg:active {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-inner-md:active {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-lg:active {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-md:active {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-xl:active {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-none:disabled {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-focusable-outline:disabled {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-focus-outline:disabled {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-error-outline:disabled {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-search-input:disabled {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-2xl:disabled {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-base:disabled {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-inner-lg:disabled {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-inner-md:disabled {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-lg:disabled {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-md:disabled {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-xl:disabled {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.outline-none {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.outline-white {
+  outline: 2px dotted white;
+  outline-offset: 2px;
+}
+
+.outline-black {
+  outline: 2px dotted black;
+  outline-offset: 2px;
+}
+
+.focus\\\\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focus\\\\:outline-white:focus {
+  outline: 2px dotted white;
+  outline-offset: 2px;
+}
+
+.focus\\\\:outline-black:focus {
+  outline: 2px dotted black;
+  outline-offset: 2px;
+}
+
+*, ::before, ::after {
+  --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+}
+
+.ring-0 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-1 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-2 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-4 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-8 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-0:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-1:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-2:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-4:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-8:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-0:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-1:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-2:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-4:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-8:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-0:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-1:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-2:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-4:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-8:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-inset {
+  --tw-ring-inset: inset;
+}
+
+.focus-within\\\\:ring-inset:focus-within {
+  --tw-ring-inset: inset;
+}
+
+.focus-visible\\\\:ring-inset:focus-visible {
+  --tw-ring-inset: inset;
+}
+
+.focus\\\\:ring-inset:focus {
+  --tw-ring-inset: inset;
+}
+
+.ring-current {
+  --tw-ring-color: currentColor;
+}
+
+.ring-transparent {
+  --tw-ring-color: transparent;
+}
+
+.ring-falcon {
+  --tw-ring-color: var(--falcon);
+}
+
+.ring-basement {
+  --tw-ring-color: var(--basement);
+}
+
+.ring-blue {
+  --tw-ring-color: var(--blue);
+}
+
+.ring-body-and-labels {
+  --tw-ring-color: var(--body-and-labels);
+}
+
+.ring-brand {
+  --tw-ring-color: var(--brand);
+}
+
+.ring-code-base-64 {
+  --tw-ring-color: var(--code-base-64);
+}
+
+.ring-code-bg {
+  --tw-ring-color: var(--code-bg);
+}
+
+.ring-code-outline {
+  --tw-ring-color: var(--code-outline);
+}
+
+.ring-code-text {
+  --tw-ring-color: var(--code-text);
+}
+
+.ring-critical {
+  --tw-ring-color: var(--critical);
+}
+
+.ring-destructive-hover {
+  --tw-ring-color: var(--destructive-hover);
+}
+
+.ring-destructive-idle {
+  --tw-ring-color: var(--destructive-idle);
+}
+
+.ring-destructive-pressed {
+  --tw-ring-color: var(--destructive-pressed);
+}
+
+.ring-disabled {
+  --tw-ring-color: var(--disabled);
+}
+
+.ring-disc-operations {
+  --tw-ring-color: var(--disc-operations);
+}
+
+.ring-dns-requests {
+  --tw-ring-color: var(--dns-requests);
+}
+
+.ring-focus {
+  --tw-ring-color: var(--focus);
+}
+
+.ring-graph-1 {
+  --tw-ring-color: var(--graph-1);
+}
+
+.ring-graph-10 {
+  --tw-ring-color: var(--graph-10);
+}
+
+.ring-graph-11 {
+  --tw-ring-color: var(--graph-11);
+}
+
+.ring-graph-2 {
+  --tw-ring-color: var(--graph-2);
+}
+
+.ring-graph-3 {
+  --tw-ring-color: var(--graph-3);
+}
+
+.ring-graph-4 {
+  --tw-ring-color: var(--graph-4);
+}
+
+.ring-graph-5 {
+  --tw-ring-color: var(--graph-5);
+}
+
+.ring-graph-6 {
+  --tw-ring-color: var(--graph-6);
+}
+
+.ring-graph-7 {
+  --tw-ring-color: var(--graph-7);
+}
+
+.ring-graph-8 {
+  --tw-ring-color: var(--graph-8);
+}
+
+.ring-graph-9 {
+  --tw-ring-color: var(--graph-9);
+}
+
+.ring-graph-disabled {
+  --tw-ring-color: var(--graph-disabled);
+}
+
+.ring-ground-floor {
+  --tw-ring-color: var(--ground-floor);
+}
+
+.ring-high {
+  --tw-ring-color: var(--high);
+}
+
+.ring-informational {
+  --tw-ring-color: var(--informational);
+}
+
+.ring-lines-dark {
+  --tw-ring-color: var(--lines-dark);
+}
+
+.ring-lines-light {
+  --tw-ring-color: var(--lines-light);
+}
+
+.ring-low {
+  --tw-ring-color: var(--low);
+}
+
+.ring-medium {
+  --tw-ring-color: var(--medium);
+}
+
+.ring-mezzanine {
+  --tw-ring-color: var(--mezzanine);
+}
+
+.ring-nav-text-and-icons {
+  --tw-ring-color: var(--nav-text-and-icons);
+}
+
+.ring-nav-text-secondary {
+  --tw-ring-color: var(--nav-text-secondary);
+}
+
+.ring-network-operations {
+  --tw-ring-color: var(--network-operations);
+}
+
+.ring-normal-hover {
+  --tw-ring-color: var(--normal-hover);
+}
+
+.ring-normal-idle {
+  --tw-ring-color: var(--normal-idle);
+}
+
+.ring-normal-pressed {
+  --tw-ring-color: var(--normal-pressed);
+}
+
+.ring-overlay-0\\\\.5 {
+  --tw-ring-color: var(--overlay-0\\\\.5);
+}
+
+.ring-overlay-1 {
+  --tw-ring-color: var(--overlay-1);
+}
+
+.ring-overlay-2 {
+  --tw-ring-color: var(--overlay-2);
+}
+
+.ring-positive {
+  --tw-ring-color: var(--positive);
+}
+
+.ring-primary-hover {
+  --tw-ring-color: var(--primary-hover);
+}
+
+.ring-primary-idle {
+  --tw-ring-color: var(--primary-idle);
+}
+
+.ring-primary-pressed {
+  --tw-ring-color: var(--primary-pressed);
+}
+
+.ring-process-operations {
+  --tw-ring-color: var(--process-operations);
+}
+
+.ring-purple {
+  --tw-ring-color: var(--purple);
+}
+
+.ring-registry-operations {
+  --tw-ring-color: var(--registry-operations);
+}
+
+.ring-selected {
+  --tw-ring-color: var(--selected);
+}
+
+.ring-surface-2xl {
+  --tw-ring-color: var(--surface-2xl);
+}
+
+.ring-surface-base {
+  --tw-ring-color: var(--surface-base);
+}
+
+.ring-surface-inner {
+  --tw-ring-color: var(--surface-inner);
+}
+
+.ring-surface-lg {
+  --tw-ring-color: var(--surface-lg);
+}
+
+.ring-surface-md {
+  --tw-ring-color: var(--surface-md);
+}
+
+.ring-surface-xl {
+  --tw-ring-color: var(--surface-xl);
+}
+
+.ring-text-and-icons {
+  --tw-ring-color: var(--text-and-icons);
+}
+
+.ring-titles-and-attributes {
+  --tw-ring-color: var(--titles-and-attributes);
+}
+
+.focus-within\\\\:ring-current:focus-within {
+  --tw-ring-color: currentColor;
+}
+
+.focus-within\\\\:ring-transparent:focus-within {
+  --tw-ring-color: transparent;
+}
+
+.focus-within\\\\:ring-falcon:focus-within {
+  --tw-ring-color: var(--falcon);
+}
+
+.focus-within\\\\:ring-basement:focus-within {
+  --tw-ring-color: var(--basement);
+}
+
+.focus-within\\\\:ring-blue:focus-within {
+  --tw-ring-color: var(--blue);
+}
+
+.focus-within\\\\:ring-body-and-labels:focus-within {
+  --tw-ring-color: var(--body-and-labels);
+}
+
+.focus-within\\\\:ring-brand:focus-within {
+  --tw-ring-color: var(--brand);
+}
+
+.focus-within\\\\:ring-code-base-64:focus-within {
+  --tw-ring-color: var(--code-base-64);
+}
+
+.focus-within\\\\:ring-code-bg:focus-within {
+  --tw-ring-color: var(--code-bg);
+}
+
+.focus-within\\\\:ring-code-outline:focus-within {
+  --tw-ring-color: var(--code-outline);
+}
+
+.focus-within\\\\:ring-code-text:focus-within {
+  --tw-ring-color: var(--code-text);
+}
+
+.focus-within\\\\:ring-critical:focus-within {
+  --tw-ring-color: var(--critical);
+}
+
+.focus-within\\\\:ring-destructive-hover:focus-within {
+  --tw-ring-color: var(--destructive-hover);
+}
+
+.focus-within\\\\:ring-destructive-idle:focus-within {
+  --tw-ring-color: var(--destructive-idle);
+}
+
+.focus-within\\\\:ring-destructive-pressed:focus-within {
+  --tw-ring-color: var(--destructive-pressed);
+}
+
+.focus-within\\\\:ring-disabled:focus-within {
+  --tw-ring-color: var(--disabled);
+}
+
+.focus-within\\\\:ring-disc-operations:focus-within {
+  --tw-ring-color: var(--disc-operations);
+}
+
+.focus-within\\\\:ring-dns-requests:focus-within {
+  --tw-ring-color: var(--dns-requests);
+}
+
+.focus-within\\\\:ring-focus:focus-within {
+  --tw-ring-color: var(--focus);
+}
+
+.focus-within\\\\:ring-graph-1:focus-within {
+  --tw-ring-color: var(--graph-1);
+}
+
+.focus-within\\\\:ring-graph-10:focus-within {
+  --tw-ring-color: var(--graph-10);
+}
+
+.focus-within\\\\:ring-graph-11:focus-within {
+  --tw-ring-color: var(--graph-11);
+}
+
+.focus-within\\\\:ring-graph-2:focus-within {
+  --tw-ring-color: var(--graph-2);
+}
+
+.focus-within\\\\:ring-graph-3:focus-within {
+  --tw-ring-color: var(--graph-3);
+}
+
+.focus-within\\\\:ring-graph-4:focus-within {
+  --tw-ring-color: var(--graph-4);
+}
+
+.focus-within\\\\:ring-graph-5:focus-within {
+  --tw-ring-color: var(--graph-5);
+}
+
+.focus-within\\\\:ring-graph-6:focus-within {
+  --tw-ring-color: var(--graph-6);
+}
+
+.focus-within\\\\:ring-graph-7:focus-within {
+  --tw-ring-color: var(--graph-7);
+}
+
+.focus-within\\\\:ring-graph-8:focus-within {
+  --tw-ring-color: var(--graph-8);
+}
+
+.focus-within\\\\:ring-graph-9:focus-within {
+  --tw-ring-color: var(--graph-9);
+}
+
+.focus-within\\\\:ring-graph-disabled:focus-within {
+  --tw-ring-color: var(--graph-disabled);
+}
+
+.focus-within\\\\:ring-ground-floor:focus-within {
+  --tw-ring-color: var(--ground-floor);
+}
+
+.focus-within\\\\:ring-high:focus-within {
+  --tw-ring-color: var(--high);
+}
+
+.focus-within\\\\:ring-informational:focus-within {
+  --tw-ring-color: var(--informational);
+}
+
+.focus-within\\\\:ring-lines-dark:focus-within {
+  --tw-ring-color: var(--lines-dark);
+}
+
+.focus-within\\\\:ring-lines-light:focus-within {
+  --tw-ring-color: var(--lines-light);
+}
+
+.focus-within\\\\:ring-low:focus-within {
+  --tw-ring-color: var(--low);
+}
+
+.focus-within\\\\:ring-medium:focus-within {
+  --tw-ring-color: var(--medium);
+}
+
+.focus-within\\\\:ring-mezzanine:focus-within {
+  --tw-ring-color: var(--mezzanine);
+}
+
+.focus-within\\\\:ring-nav-text-and-icons:focus-within {
+  --tw-ring-color: var(--nav-text-and-icons);
+}
+
+.focus-within\\\\:ring-nav-text-secondary:focus-within {
+  --tw-ring-color: var(--nav-text-secondary);
+}
+
+.focus-within\\\\:ring-network-operations:focus-within {
+  --tw-ring-color: var(--network-operations);
+}
+
+.focus-within\\\\:ring-normal-hover:focus-within {
+  --tw-ring-color: var(--normal-hover);
+}
+
+.focus-within\\\\:ring-normal-idle:focus-within {
+  --tw-ring-color: var(--normal-idle);
+}
+
+.focus-within\\\\:ring-normal-pressed:focus-within {
+  --tw-ring-color: var(--normal-pressed);
+}
+
+.focus-within\\\\:ring-overlay-0\\\\.5:focus-within {
+  --tw-ring-color: var(--overlay-0\\\\.5);
+}
+
+.focus-within\\\\:ring-overlay-1:focus-within {
+  --tw-ring-color: var(--overlay-1);
+}
+
+.focus-within\\\\:ring-overlay-2:focus-within {
+  --tw-ring-color: var(--overlay-2);
+}
+
+.focus-within\\\\:ring-positive:focus-within {
+  --tw-ring-color: var(--positive);
+}
+
+.focus-within\\\\:ring-primary-hover:focus-within {
+  --tw-ring-color: var(--primary-hover);
+}
+
+.focus-within\\\\:ring-primary-idle:focus-within {
+  --tw-ring-color: var(--primary-idle);
+}
+
+.focus-within\\\\:ring-primary-pressed:focus-within {
+  --tw-ring-color: var(--primary-pressed);
+}
+
+.focus-within\\\\:ring-process-operations:focus-within {
+  --tw-ring-color: var(--process-operations);
+}
+
+.focus-within\\\\:ring-purple:focus-within {
+  --tw-ring-color: var(--purple);
+}
+
+.focus-within\\\\:ring-registry-operations:focus-within {
+  --tw-ring-color: var(--registry-operations);
+}
+
+.focus-within\\\\:ring-selected:focus-within {
+  --tw-ring-color: var(--selected);
+}
+
+.focus-within\\\\:ring-surface-2xl:focus-within {
+  --tw-ring-color: var(--surface-2xl);
+}
+
+.focus-within\\\\:ring-surface-base:focus-within {
+  --tw-ring-color: var(--surface-base);
+}
+
+.focus-within\\\\:ring-surface-inner:focus-within {
+  --tw-ring-color: var(--surface-inner);
+}
+
+.focus-within\\\\:ring-surface-lg:focus-within {
+  --tw-ring-color: var(--surface-lg);
+}
+
+.focus-within\\\\:ring-surface-md:focus-within {
+  --tw-ring-color: var(--surface-md);
+}
+
+.focus-within\\\\:ring-surface-xl:focus-within {
+  --tw-ring-color: var(--surface-xl);
+}
+
+.focus-within\\\\:ring-text-and-icons:focus-within {
+  --tw-ring-color: var(--text-and-icons);
+}
+
+.focus-within\\\\:ring-titles-and-attributes:focus-within {
+  --tw-ring-color: var(--titles-and-attributes);
+}
+
+.focus\\\\:ring-current:focus {
+  --tw-ring-color: currentColor;
+}
+
+.focus\\\\:ring-transparent:focus {
+  --tw-ring-color: transparent;
+}
+
+.focus\\\\:ring-falcon:focus {
+  --tw-ring-color: var(--falcon);
+}
+
+.focus\\\\:ring-basement:focus {
+  --tw-ring-color: var(--basement);
+}
+
+.focus\\\\:ring-blue:focus {
+  --tw-ring-color: var(--blue);
+}
+
+.focus\\\\:ring-body-and-labels:focus {
+  --tw-ring-color: var(--body-and-labels);
+}
+
+.focus\\\\:ring-brand:focus {
+  --tw-ring-color: var(--brand);
+}
+
+.focus\\\\:ring-code-base-64:focus {
+  --tw-ring-color: var(--code-base-64);
+}
+
+.focus\\\\:ring-code-bg:focus {
+  --tw-ring-color: var(--code-bg);
+}
+
+.focus\\\\:ring-code-outline:focus {
+  --tw-ring-color: var(--code-outline);
+}
+
+.focus\\\\:ring-code-text:focus {
+  --tw-ring-color: var(--code-text);
+}
+
+.focus\\\\:ring-critical:focus {
+  --tw-ring-color: var(--critical);
+}
+
+.focus\\\\:ring-destructive-hover:focus {
+  --tw-ring-color: var(--destructive-hover);
+}
+
+.focus\\\\:ring-destructive-idle:focus {
+  --tw-ring-color: var(--destructive-idle);
+}
+
+.focus\\\\:ring-destructive-pressed:focus {
+  --tw-ring-color: var(--destructive-pressed);
+}
+
+.focus\\\\:ring-disabled:focus {
+  --tw-ring-color: var(--disabled);
+}
+
+.focus\\\\:ring-disc-operations:focus {
+  --tw-ring-color: var(--disc-operations);
+}
+
+.focus\\\\:ring-dns-requests:focus {
+  --tw-ring-color: var(--dns-requests);
+}
+
+.focus\\\\:ring-focus:focus {
+  --tw-ring-color: var(--focus);
+}
+
+.focus\\\\:ring-graph-1:focus {
+  --tw-ring-color: var(--graph-1);
+}
+
+.focus\\\\:ring-graph-10:focus {
+  --tw-ring-color: var(--graph-10);
+}
+
+.focus\\\\:ring-graph-11:focus {
+  --tw-ring-color: var(--graph-11);
+}
+
+.focus\\\\:ring-graph-2:focus {
+  --tw-ring-color: var(--graph-2);
+}
+
+.focus\\\\:ring-graph-3:focus {
+  --tw-ring-color: var(--graph-3);
+}
+
+.focus\\\\:ring-graph-4:focus {
+  --tw-ring-color: var(--graph-4);
+}
+
+.focus\\\\:ring-graph-5:focus {
+  --tw-ring-color: var(--graph-5);
+}
+
+.focus\\\\:ring-graph-6:focus {
+  --tw-ring-color: var(--graph-6);
+}
+
+.focus\\\\:ring-graph-7:focus {
+  --tw-ring-color: var(--graph-7);
+}
+
+.focus\\\\:ring-graph-8:focus {
+  --tw-ring-color: var(--graph-8);
+}
+
+.focus\\\\:ring-graph-9:focus {
+  --tw-ring-color: var(--graph-9);
+}
+
+.focus\\\\:ring-graph-disabled:focus {
+  --tw-ring-color: var(--graph-disabled);
+}
+
+.focus\\\\:ring-ground-floor:focus {
+  --tw-ring-color: var(--ground-floor);
+}
+
+.focus\\\\:ring-high:focus {
+  --tw-ring-color: var(--high);
+}
+
+.focus\\\\:ring-informational:focus {
+  --tw-ring-color: var(--informational);
+}
+
+.focus\\\\:ring-lines-dark:focus {
+  --tw-ring-color: var(--lines-dark);
+}
+
+.focus\\\\:ring-lines-light:focus {
+  --tw-ring-color: var(--lines-light);
+}
+
+.focus\\\\:ring-low:focus {
+  --tw-ring-color: var(--low);
+}
+
+.focus\\\\:ring-medium:focus {
+  --tw-ring-color: var(--medium);
+}
+
+.focus\\\\:ring-mezzanine:focus {
+  --tw-ring-color: var(--mezzanine);
+}
+
+.focus\\\\:ring-nav-text-and-icons:focus {
+  --tw-ring-color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:ring-nav-text-secondary:focus {
+  --tw-ring-color: var(--nav-text-secondary);
+}
+
+.focus\\\\:ring-network-operations:focus {
+  --tw-ring-color: var(--network-operations);
+}
+
+.focus\\\\:ring-normal-hover:focus {
+  --tw-ring-color: var(--normal-hover);
+}
+
+.focus\\\\:ring-normal-idle:focus {
+  --tw-ring-color: var(--normal-idle);
+}
+
+.focus\\\\:ring-normal-pressed:focus {
+  --tw-ring-color: var(--normal-pressed);
+}
+
+.focus\\\\:ring-overlay-0\\\\.5:focus {
+  --tw-ring-color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:ring-overlay-1:focus {
+  --tw-ring-color: var(--overlay-1);
+}
+
+.focus\\\\:ring-overlay-2:focus {
+  --tw-ring-color: var(--overlay-2);
+}
+
+.focus\\\\:ring-positive:focus {
+  --tw-ring-color: var(--positive);
+}
+
+.focus\\\\:ring-primary-hover:focus {
+  --tw-ring-color: var(--primary-hover);
+}
+
+.focus\\\\:ring-primary-idle:focus {
+  --tw-ring-color: var(--primary-idle);
+}
+
+.focus\\\\:ring-primary-pressed:focus {
+  --tw-ring-color: var(--primary-pressed);
+}
+
+.focus\\\\:ring-process-operations:focus {
+  --tw-ring-color: var(--process-operations);
+}
+
+.focus\\\\:ring-purple:focus {
+  --tw-ring-color: var(--purple);
+}
+
+.focus\\\\:ring-registry-operations:focus {
+  --tw-ring-color: var(--registry-operations);
+}
+
+.focus\\\\:ring-selected:focus {
+  --tw-ring-color: var(--selected);
+}
+
+.focus\\\\:ring-surface-2xl:focus {
+  --tw-ring-color: var(--surface-2xl);
+}
+
+.focus\\\\:ring-surface-base:focus {
+  --tw-ring-color: var(--surface-base);
+}
+
+.focus\\\\:ring-surface-inner:focus {
+  --tw-ring-color: var(--surface-inner);
+}
+
+.focus\\\\:ring-surface-lg:focus {
+  --tw-ring-color: var(--surface-lg);
+}
+
+.focus\\\\:ring-surface-md:focus {
+  --tw-ring-color: var(--surface-md);
+}
+
+.focus\\\\:ring-surface-xl:focus {
+  --tw-ring-color: var(--surface-xl);
+}
+
+.focus\\\\:ring-text-and-icons:focus {
+  --tw-ring-color: var(--text-and-icons);
+}
+
+.focus\\\\:ring-titles-and-attributes:focus {
+  --tw-ring-color: var(--titles-and-attributes);
+}
+
+.ring-opacity-0 {
+  --tw-ring-opacity: 0;
+}
+
+.ring-opacity-5 {
+  --tw-ring-opacity: 0.05;
+}
+
+.ring-opacity-10 {
+  --tw-ring-opacity: 0.1;
+}
+
+.ring-opacity-20 {
+  --tw-ring-opacity: 0.2;
+}
+
+.ring-opacity-25 {
+  --tw-ring-opacity: 0.25;
+}
+
+.ring-opacity-30 {
+  --tw-ring-opacity: 0.3;
+}
+
+.ring-opacity-40 {
+  --tw-ring-opacity: 0.4;
+}
+
+.ring-opacity-50 {
+  --tw-ring-opacity: 0.5;
+}
+
+.ring-opacity-60 {
+  --tw-ring-opacity: 0.6;
+}
+
+.ring-opacity-70 {
+  --tw-ring-opacity: 0.7;
+}
+
+.ring-opacity-75 {
+  --tw-ring-opacity: 0.75;
+}
+
+.ring-opacity-80 {
+  --tw-ring-opacity: 0.8;
+}
+
+.ring-opacity-90 {
+  --tw-ring-opacity: 0.9;
+}
+
+.ring-opacity-95 {
+  --tw-ring-opacity: 0.95;
+}
+
+.ring-opacity-100 {
+  --tw-ring-opacity: 1;
+}
+
+.focus-within\\\\:ring-opacity-0:focus-within {
+  --tw-ring-opacity: 0;
+}
+
+.focus-within\\\\:ring-opacity-5:focus-within {
+  --tw-ring-opacity: 0.05;
+}
+
+.focus-within\\\\:ring-opacity-10:focus-within {
+  --tw-ring-opacity: 0.1;
+}
+
+.focus-within\\\\:ring-opacity-20:focus-within {
+  --tw-ring-opacity: 0.2;
+}
+
+.focus-within\\\\:ring-opacity-25:focus-within {
+  --tw-ring-opacity: 0.25;
+}
+
+.focus-within\\\\:ring-opacity-30:focus-within {
+  --tw-ring-opacity: 0.3;
+}
+
+.focus-within\\\\:ring-opacity-40:focus-within {
+  --tw-ring-opacity: 0.4;
+}
+
+.focus-within\\\\:ring-opacity-50:focus-within {
+  --tw-ring-opacity: 0.5;
+}
+
+.focus-within\\\\:ring-opacity-60:focus-within {
+  --tw-ring-opacity: 0.6;
+}
+
+.focus-within\\\\:ring-opacity-70:focus-within {
+  --tw-ring-opacity: 0.7;
+}
+
+.focus-within\\\\:ring-opacity-75:focus-within {
+  --tw-ring-opacity: 0.75;
+}
+
+.focus-within\\\\:ring-opacity-80:focus-within {
+  --tw-ring-opacity: 0.8;
+}
+
+.focus-within\\\\:ring-opacity-90:focus-within {
+  --tw-ring-opacity: 0.9;
+}
+
+.focus-within\\\\:ring-opacity-95:focus-within {
+  --tw-ring-opacity: 0.95;
+}
+
+.focus-within\\\\:ring-opacity-100:focus-within {
+  --tw-ring-opacity: 1;
+}
+
+.focus\\\\:ring-opacity-0:focus {
+  --tw-ring-opacity: 0;
+}
+
+.focus\\\\:ring-opacity-5:focus {
+  --tw-ring-opacity: 0.05;
+}
+
+.focus\\\\:ring-opacity-10:focus {
+  --tw-ring-opacity: 0.1;
+}
+
+.focus\\\\:ring-opacity-20:focus {
+  --tw-ring-opacity: 0.2;
+}
+
+.focus\\\\:ring-opacity-25:focus {
+  --tw-ring-opacity: 0.25;
+}
+
+.focus\\\\:ring-opacity-30:focus {
+  --tw-ring-opacity: 0.3;
+}
+
+.focus\\\\:ring-opacity-40:focus {
+  --tw-ring-opacity: 0.4;
+}
+
+.focus\\\\:ring-opacity-50:focus {
+  --tw-ring-opacity: 0.5;
+}
+
+.focus\\\\:ring-opacity-60:focus {
+  --tw-ring-opacity: 0.6;
+}
+
+.focus\\\\:ring-opacity-70:focus {
+  --tw-ring-opacity: 0.7;
+}
+
+.focus\\\\:ring-opacity-75:focus {
+  --tw-ring-opacity: 0.75;
+}
+
+.focus\\\\:ring-opacity-80:focus {
+  --tw-ring-opacity: 0.8;
+}
+
+.focus\\\\:ring-opacity-90:focus {
+  --tw-ring-opacity: 0.9;
+}
+
+.focus\\\\:ring-opacity-95:focus {
+  --tw-ring-opacity: 0.95;
+}
+
+.focus\\\\:ring-opacity-100:focus {
+  --tw-ring-opacity: 1;
+}
+
+.ring-offset-0 {
+  --tw-ring-offset-width: 0px;
+}
+
+.ring-offset-1 {
+  --tw-ring-offset-width: 1px;
+}
+
+.ring-offset-2 {
+  --tw-ring-offset-width: 2px;
+}
+
+.ring-offset-4 {
+  --tw-ring-offset-width: 4px;
+}
+
+.ring-offset-8 {
+  --tw-ring-offset-width: 8px;
+}
+
+.focus-within\\\\:ring-offset-0:focus-within {
+  --tw-ring-offset-width: 0px;
+}
+
+.focus-within\\\\:ring-offset-1:focus-within {
+  --tw-ring-offset-width: 1px;
+}
+
+.focus-within\\\\:ring-offset-2:focus-within {
+  --tw-ring-offset-width: 2px;
+}
+
+.focus-within\\\\:ring-offset-4:focus-within {
+  --tw-ring-offset-width: 4px;
+}
+
+.focus-within\\\\:ring-offset-8:focus-within {
+  --tw-ring-offset-width: 8px;
+}
+
+.focus\\\\:ring-offset-0:focus {
+  --tw-ring-offset-width: 0px;
+}
+
+.focus\\\\:ring-offset-1:focus {
+  --tw-ring-offset-width: 1px;
+}
+
+.focus\\\\:ring-offset-2:focus {
+  --tw-ring-offset-width: 2px;
+}
+
+.focus\\\\:ring-offset-4:focus {
+  --tw-ring-offset-width: 4px;
+}
+
+.focus\\\\:ring-offset-8:focus {
+  --tw-ring-offset-width: 8px;
+}
+
+.ring-offset-current {
+  --tw-ring-offset-color: currentColor;
+}
+
+.ring-offset-transparent {
+  --tw-ring-offset-color: transparent;
+}
+
+.ring-offset-falcon {
+  --tw-ring-offset-color: var(--falcon);
+}
+
+.ring-offset-basement {
+  --tw-ring-offset-color: var(--basement);
+}
+
+.ring-offset-blue {
+  --tw-ring-offset-color: var(--blue);
+}
+
+.ring-offset-body-and-labels {
+  --tw-ring-offset-color: var(--body-and-labels);
+}
+
+.ring-offset-brand {
+  --tw-ring-offset-color: var(--brand);
+}
+
+.ring-offset-code-base-64 {
+  --tw-ring-offset-color: var(--code-base-64);
+}
+
+.ring-offset-code-bg {
+  --tw-ring-offset-color: var(--code-bg);
+}
+
+.ring-offset-code-outline {
+  --tw-ring-offset-color: var(--code-outline);
+}
+
+.ring-offset-code-text {
+  --tw-ring-offset-color: var(--code-text);
+}
+
+.ring-offset-critical {
+  --tw-ring-offset-color: var(--critical);
+}
+
+.ring-offset-destructive-hover {
+  --tw-ring-offset-color: var(--destructive-hover);
+}
+
+.ring-offset-destructive-idle {
+  --tw-ring-offset-color: var(--destructive-idle);
+}
+
+.ring-offset-destructive-pressed {
+  --tw-ring-offset-color: var(--destructive-pressed);
+}
+
+.ring-offset-disabled {
+  --tw-ring-offset-color: var(--disabled);
+}
+
+.ring-offset-disc-operations {
+  --tw-ring-offset-color: var(--disc-operations);
+}
+
+.ring-offset-dns-requests {
+  --tw-ring-offset-color: var(--dns-requests);
+}
+
+.ring-offset-focus {
+  --tw-ring-offset-color: var(--focus);
+}
+
+.ring-offset-graph-1 {
+  --tw-ring-offset-color: var(--graph-1);
+}
+
+.ring-offset-graph-10 {
+  --tw-ring-offset-color: var(--graph-10);
+}
+
+.ring-offset-graph-11 {
+  --tw-ring-offset-color: var(--graph-11);
+}
+
+.ring-offset-graph-2 {
+  --tw-ring-offset-color: var(--graph-2);
+}
+
+.ring-offset-graph-3 {
+  --tw-ring-offset-color: var(--graph-3);
+}
+
+.ring-offset-graph-4 {
+  --tw-ring-offset-color: var(--graph-4);
+}
+
+.ring-offset-graph-5 {
+  --tw-ring-offset-color: var(--graph-5);
+}
+
+.ring-offset-graph-6 {
+  --tw-ring-offset-color: var(--graph-6);
+}
+
+.ring-offset-graph-7 {
+  --tw-ring-offset-color: var(--graph-7);
+}
+
+.ring-offset-graph-8 {
+  --tw-ring-offset-color: var(--graph-8);
+}
+
+.ring-offset-graph-9 {
+  --tw-ring-offset-color: var(--graph-9);
+}
+
+.ring-offset-graph-disabled {
+  --tw-ring-offset-color: var(--graph-disabled);
+}
+
+.ring-offset-ground-floor {
+  --tw-ring-offset-color: var(--ground-floor);
+}
+
+.ring-offset-high {
+  --tw-ring-offset-color: var(--high);
+}
+
+.ring-offset-informational {
+  --tw-ring-offset-color: var(--informational);
+}
+
+.ring-offset-lines-dark {
+  --tw-ring-offset-color: var(--lines-dark);
+}
+
+.ring-offset-lines-light {
+  --tw-ring-offset-color: var(--lines-light);
+}
+
+.ring-offset-low {
+  --tw-ring-offset-color: var(--low);
+}
+
+.ring-offset-medium {
+  --tw-ring-offset-color: var(--medium);
+}
+
+.ring-offset-mezzanine {
+  --tw-ring-offset-color: var(--mezzanine);
+}
+
+.ring-offset-nav-text-and-icons {
+  --tw-ring-offset-color: var(--nav-text-and-icons);
+}
+
+.ring-offset-nav-text-secondary {
+  --tw-ring-offset-color: var(--nav-text-secondary);
+}
+
+.ring-offset-network-operations {
+  --tw-ring-offset-color: var(--network-operations);
+}
+
+.ring-offset-normal-hover {
+  --tw-ring-offset-color: var(--normal-hover);
+}
+
+.ring-offset-normal-idle {
+  --tw-ring-offset-color: var(--normal-idle);
+}
+
+.ring-offset-normal-pressed {
+  --tw-ring-offset-color: var(--normal-pressed);
+}
+
+.ring-offset-overlay-0\\\\.5 {
+  --tw-ring-offset-color: var(--overlay-0\\\\.5);
+}
+
+.ring-offset-overlay-1 {
+  --tw-ring-offset-color: var(--overlay-1);
+}
+
+.ring-offset-overlay-2 {
+  --tw-ring-offset-color: var(--overlay-2);
+}
+
+.ring-offset-positive {
+  --tw-ring-offset-color: var(--positive);
+}
+
+.ring-offset-primary-hover {
+  --tw-ring-offset-color: var(--primary-hover);
+}
+
+.ring-offset-primary-idle {
+  --tw-ring-offset-color: var(--primary-idle);
+}
+
+.ring-offset-primary-pressed {
+  --tw-ring-offset-color: var(--primary-pressed);
+}
+
+.ring-offset-process-operations {
+  --tw-ring-offset-color: var(--process-operations);
+}
+
+.ring-offset-purple {
+  --tw-ring-offset-color: var(--purple);
+}
+
+.ring-offset-registry-operations {
+  --tw-ring-offset-color: var(--registry-operations);
+}
+
+.ring-offset-selected {
+  --tw-ring-offset-color: var(--selected);
+}
+
+.ring-offset-surface-2xl {
+  --tw-ring-offset-color: var(--surface-2xl);
+}
+
+.ring-offset-surface-base {
+  --tw-ring-offset-color: var(--surface-base);
+}
+
+.ring-offset-surface-inner {
+  --tw-ring-offset-color: var(--surface-inner);
+}
+
+.ring-offset-surface-lg {
+  --tw-ring-offset-color: var(--surface-lg);
+}
+
+.ring-offset-surface-md {
+  --tw-ring-offset-color: var(--surface-md);
+}
+
+.ring-offset-surface-xl {
+  --tw-ring-offset-color: var(--surface-xl);
+}
+
+.ring-offset-text-and-icons {
+  --tw-ring-offset-color: var(--text-and-icons);
+}
+
+.ring-offset-titles-and-attributes {
+  --tw-ring-offset-color: var(--titles-and-attributes);
+}
+
+.focus-within\\\\:ring-offset-current:focus-within {
+  --tw-ring-offset-color: currentColor;
+}
+
+.focus-within\\\\:ring-offset-transparent:focus-within {
+  --tw-ring-offset-color: transparent;
+}
+
+.focus-within\\\\:ring-offset-falcon:focus-within {
+  --tw-ring-offset-color: var(--falcon);
+}
+
+.focus-within\\\\:ring-offset-basement:focus-within {
+  --tw-ring-offset-color: var(--basement);
+}
+
+.focus-within\\\\:ring-offset-blue:focus-within {
+  --tw-ring-offset-color: var(--blue);
+}
+
+.focus-within\\\\:ring-offset-body-and-labels:focus-within {
+  --tw-ring-offset-color: var(--body-and-labels);
+}
+
+.focus-within\\\\:ring-offset-brand:focus-within {
+  --tw-ring-offset-color: var(--brand);
+}
+
+.focus-within\\\\:ring-offset-code-base-64:focus-within {
+  --tw-ring-offset-color: var(--code-base-64);
+}
+
+.focus-within\\\\:ring-offset-code-bg:focus-within {
+  --tw-ring-offset-color: var(--code-bg);
+}
+
+.focus-within\\\\:ring-offset-code-outline:focus-within {
+  --tw-ring-offset-color: var(--code-outline);
+}
+
+.focus-within\\\\:ring-offset-code-text:focus-within {
+  --tw-ring-offset-color: var(--code-text);
+}
+
+.focus-within\\\\:ring-offset-critical:focus-within {
+  --tw-ring-offset-color: var(--critical);
+}
+
+.focus-within\\\\:ring-offset-destructive-hover:focus-within {
+  --tw-ring-offset-color: var(--destructive-hover);
+}
+
+.focus-within\\\\:ring-offset-destructive-idle:focus-within {
+  --tw-ring-offset-color: var(--destructive-idle);
+}
+
+.focus-within\\\\:ring-offset-destructive-pressed:focus-within {
+  --tw-ring-offset-color: var(--destructive-pressed);
+}
+
+.focus-within\\\\:ring-offset-disabled:focus-within {
+  --tw-ring-offset-color: var(--disabled);
+}
+
+.focus-within\\\\:ring-offset-disc-operations:focus-within {
+  --tw-ring-offset-color: var(--disc-operations);
+}
+
+.focus-within\\\\:ring-offset-dns-requests:focus-within {
+  --tw-ring-offset-color: var(--dns-requests);
+}
+
+.focus-within\\\\:ring-offset-focus:focus-within {
+  --tw-ring-offset-color: var(--focus);
+}
+
+.focus-within\\\\:ring-offset-graph-1:focus-within {
+  --tw-ring-offset-color: var(--graph-1);
+}
+
+.focus-within\\\\:ring-offset-graph-10:focus-within {
+  --tw-ring-offset-color: var(--graph-10);
+}
+
+.focus-within\\\\:ring-offset-graph-11:focus-within {
+  --tw-ring-offset-color: var(--graph-11);
+}
+
+.focus-within\\\\:ring-offset-graph-2:focus-within {
+  --tw-ring-offset-color: var(--graph-2);
+}
+
+.focus-within\\\\:ring-offset-graph-3:focus-within {
+  --tw-ring-offset-color: var(--graph-3);
+}
+
+.focus-within\\\\:ring-offset-graph-4:focus-within {
+  --tw-ring-offset-color: var(--graph-4);
+}
+
+.focus-within\\\\:ring-offset-graph-5:focus-within {
+  --tw-ring-offset-color: var(--graph-5);
+}
+
+.focus-within\\\\:ring-offset-graph-6:focus-within {
+  --tw-ring-offset-color: var(--graph-6);
+}
+
+.focus-within\\\\:ring-offset-graph-7:focus-within {
+  --tw-ring-offset-color: var(--graph-7);
+}
+
+.focus-within\\\\:ring-offset-graph-8:focus-within {
+  --tw-ring-offset-color: var(--graph-8);
+}
+
+.focus-within\\\\:ring-offset-graph-9:focus-within {
+  --tw-ring-offset-color: var(--graph-9);
+}
+
+.focus-within\\\\:ring-offset-graph-disabled:focus-within {
+  --tw-ring-offset-color: var(--graph-disabled);
+}
+
+.focus-within\\\\:ring-offset-ground-floor:focus-within {
+  --tw-ring-offset-color: var(--ground-floor);
+}
+
+.focus-within\\\\:ring-offset-high:focus-within {
+  --tw-ring-offset-color: var(--high);
+}
+
+.focus-within\\\\:ring-offset-informational:focus-within {
+  --tw-ring-offset-color: var(--informational);
+}
+
+.focus-within\\\\:ring-offset-lines-dark:focus-within {
+  --tw-ring-offset-color: var(--lines-dark);
+}
+
+.focus-within\\\\:ring-offset-lines-light:focus-within {
+  --tw-ring-offset-color: var(--lines-light);
+}
+
+.focus-within\\\\:ring-offset-low:focus-within {
+  --tw-ring-offset-color: var(--low);
+}
+
+.focus-within\\\\:ring-offset-medium:focus-within {
+  --tw-ring-offset-color: var(--medium);
+}
+
+.focus-within\\\\:ring-offset-mezzanine:focus-within {
+  --tw-ring-offset-color: var(--mezzanine);
+}
+
+.focus-within\\\\:ring-offset-nav-text-and-icons:focus-within {
+  --tw-ring-offset-color: var(--nav-text-and-icons);
+}
+
+.focus-within\\\\:ring-offset-nav-text-secondary:focus-within {
+  --tw-ring-offset-color: var(--nav-text-secondary);
+}
+
+.focus-within\\\\:ring-offset-network-operations:focus-within {
+  --tw-ring-offset-color: var(--network-operations);
+}
+
+.focus-within\\\\:ring-offset-normal-hover:focus-within {
+  --tw-ring-offset-color: var(--normal-hover);
+}
+
+.focus-within\\\\:ring-offset-normal-idle:focus-within {
+  --tw-ring-offset-color: var(--normal-idle);
+}
+
+.focus-within\\\\:ring-offset-normal-pressed:focus-within {
+  --tw-ring-offset-color: var(--normal-pressed);
+}
+
+.focus-within\\\\:ring-offset-overlay-0\\\\.5:focus-within {
+  --tw-ring-offset-color: var(--overlay-0\\\\.5);
+}
+
+.focus-within\\\\:ring-offset-overlay-1:focus-within {
+  --tw-ring-offset-color: var(--overlay-1);
+}
+
+.focus-within\\\\:ring-offset-overlay-2:focus-within {
+  --tw-ring-offset-color: var(--overlay-2);
+}
+
+.focus-within\\\\:ring-offset-positive:focus-within {
+  --tw-ring-offset-color: var(--positive);
+}
+
+.focus-within\\\\:ring-offset-primary-hover:focus-within {
+  --tw-ring-offset-color: var(--primary-hover);
+}
+
+.focus-within\\\\:ring-offset-primary-idle:focus-within {
+  --tw-ring-offset-color: var(--primary-idle);
+}
+
+.focus-within\\\\:ring-offset-primary-pressed:focus-within {
+  --tw-ring-offset-color: var(--primary-pressed);
+}
+
+.focus-within\\\\:ring-offset-process-operations:focus-within {
+  --tw-ring-offset-color: var(--process-operations);
+}
+
+.focus-within\\\\:ring-offset-purple:focus-within {
+  --tw-ring-offset-color: var(--purple);
+}
+
+.focus-within\\\\:ring-offset-registry-operations:focus-within {
+  --tw-ring-offset-color: var(--registry-operations);
+}
+
+.focus-within\\\\:ring-offset-selected:focus-within {
+  --tw-ring-offset-color: var(--selected);
+}
+
+.focus-within\\\\:ring-offset-surface-2xl:focus-within {
+  --tw-ring-offset-color: var(--surface-2xl);
+}
+
+.focus-within\\\\:ring-offset-surface-base:focus-within {
+  --tw-ring-offset-color: var(--surface-base);
+}
+
+.focus-within\\\\:ring-offset-surface-inner:focus-within {
+  --tw-ring-offset-color: var(--surface-inner);
+}
+
+.focus-within\\\\:ring-offset-surface-lg:focus-within {
+  --tw-ring-offset-color: var(--surface-lg);
+}
+
+.focus-within\\\\:ring-offset-surface-md:focus-within {
+  --tw-ring-offset-color: var(--surface-md);
+}
+
+.focus-within\\\\:ring-offset-surface-xl:focus-within {
+  --tw-ring-offset-color: var(--surface-xl);
+}
+
+.focus-within\\\\:ring-offset-text-and-icons:focus-within {
+  --tw-ring-offset-color: var(--text-and-icons);
+}
+
+.focus-within\\\\:ring-offset-titles-and-attributes:focus-within {
+  --tw-ring-offset-color: var(--titles-and-attributes);
+}
+
+.focus\\\\:ring-offset-current:focus {
+  --tw-ring-offset-color: currentColor;
+}
+
+.focus\\\\:ring-offset-transparent:focus {
+  --tw-ring-offset-color: transparent;
+}
+
+.focus\\\\:ring-offset-falcon:focus {
+  --tw-ring-offset-color: var(--falcon);
+}
+
+.focus\\\\:ring-offset-basement:focus {
+  --tw-ring-offset-color: var(--basement);
+}
+
+.focus\\\\:ring-offset-blue:focus {
+  --tw-ring-offset-color: var(--blue);
+}
+
+.focus\\\\:ring-offset-body-and-labels:focus {
+  --tw-ring-offset-color: var(--body-and-labels);
+}
+
+.focus\\\\:ring-offset-brand:focus {
+  --tw-ring-offset-color: var(--brand);
+}
+
+.focus\\\\:ring-offset-code-base-64:focus {
+  --tw-ring-offset-color: var(--code-base-64);
+}
+
+.focus\\\\:ring-offset-code-bg:focus {
+  --tw-ring-offset-color: var(--code-bg);
+}
+
+.focus\\\\:ring-offset-code-outline:focus {
+  --tw-ring-offset-color: var(--code-outline);
+}
+
+.focus\\\\:ring-offset-code-text:focus {
+  --tw-ring-offset-color: var(--code-text);
+}
+
+.focus\\\\:ring-offset-critical:focus {
+  --tw-ring-offset-color: var(--critical);
+}
+
+.focus\\\\:ring-offset-destructive-hover:focus {
+  --tw-ring-offset-color: var(--destructive-hover);
+}
+
+.focus\\\\:ring-offset-destructive-idle:focus {
+  --tw-ring-offset-color: var(--destructive-idle);
+}
+
+.focus\\\\:ring-offset-destructive-pressed:focus {
+  --tw-ring-offset-color: var(--destructive-pressed);
+}
+
+.focus\\\\:ring-offset-disabled:focus {
+  --tw-ring-offset-color: var(--disabled);
+}
+
+.focus\\\\:ring-offset-disc-operations:focus {
+  --tw-ring-offset-color: var(--disc-operations);
+}
+
+.focus\\\\:ring-offset-dns-requests:focus {
+  --tw-ring-offset-color: var(--dns-requests);
+}
+
+.focus\\\\:ring-offset-focus:focus {
+  --tw-ring-offset-color: var(--focus);
+}
+
+.focus\\\\:ring-offset-graph-1:focus {
+  --tw-ring-offset-color: var(--graph-1);
+}
+
+.focus\\\\:ring-offset-graph-10:focus {
+  --tw-ring-offset-color: var(--graph-10);
+}
+
+.focus\\\\:ring-offset-graph-11:focus {
+  --tw-ring-offset-color: var(--graph-11);
+}
+
+.focus\\\\:ring-offset-graph-2:focus {
+  --tw-ring-offset-color: var(--graph-2);
+}
+
+.focus\\\\:ring-offset-graph-3:focus {
+  --tw-ring-offset-color: var(--graph-3);
+}
+
+.focus\\\\:ring-offset-graph-4:focus {
+  --tw-ring-offset-color: var(--graph-4);
+}
+
+.focus\\\\:ring-offset-graph-5:focus {
+  --tw-ring-offset-color: var(--graph-5);
+}
+
+.focus\\\\:ring-offset-graph-6:focus {
+  --tw-ring-offset-color: var(--graph-6);
+}
+
+.focus\\\\:ring-offset-graph-7:focus {
+  --tw-ring-offset-color: var(--graph-7);
+}
+
+.focus\\\\:ring-offset-graph-8:focus {
+  --tw-ring-offset-color: var(--graph-8);
+}
+
+.focus\\\\:ring-offset-graph-9:focus {
+  --tw-ring-offset-color: var(--graph-9);
+}
+
+.focus\\\\:ring-offset-graph-disabled:focus {
+  --tw-ring-offset-color: var(--graph-disabled);
+}
+
+.focus\\\\:ring-offset-ground-floor:focus {
+  --tw-ring-offset-color: var(--ground-floor);
+}
+
+.focus\\\\:ring-offset-high:focus {
+  --tw-ring-offset-color: var(--high);
+}
+
+.focus\\\\:ring-offset-informational:focus {
+  --tw-ring-offset-color: var(--informational);
+}
+
+.focus\\\\:ring-offset-lines-dark:focus {
+  --tw-ring-offset-color: var(--lines-dark);
+}
+
+.focus\\\\:ring-offset-lines-light:focus {
+  --tw-ring-offset-color: var(--lines-light);
+}
+
+.focus\\\\:ring-offset-low:focus {
+  --tw-ring-offset-color: var(--low);
+}
+
+.focus\\\\:ring-offset-medium:focus {
+  --tw-ring-offset-color: var(--medium);
+}
+
+.focus\\\\:ring-offset-mezzanine:focus {
+  --tw-ring-offset-color: var(--mezzanine);
+}
+
+.focus\\\\:ring-offset-nav-text-and-icons:focus {
+  --tw-ring-offset-color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:ring-offset-nav-text-secondary:focus {
+  --tw-ring-offset-color: var(--nav-text-secondary);
+}
+
+.focus\\\\:ring-offset-network-operations:focus {
+  --tw-ring-offset-color: var(--network-operations);
+}
+
+.focus\\\\:ring-offset-normal-hover:focus {
+  --tw-ring-offset-color: var(--normal-hover);
+}
+
+.focus\\\\:ring-offset-normal-idle:focus {
+  --tw-ring-offset-color: var(--normal-idle);
+}
+
+.focus\\\\:ring-offset-normal-pressed:focus {
+  --tw-ring-offset-color: var(--normal-pressed);
+}
+
+.focus\\\\:ring-offset-overlay-0\\\\.5:focus {
+  --tw-ring-offset-color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:ring-offset-overlay-1:focus {
+  --tw-ring-offset-color: var(--overlay-1);
+}
+
+.focus\\\\:ring-offset-overlay-2:focus {
+  --tw-ring-offset-color: var(--overlay-2);
+}
+
+.focus\\\\:ring-offset-positive:focus {
+  --tw-ring-offset-color: var(--positive);
+}
+
+.focus\\\\:ring-offset-primary-hover:focus {
+  --tw-ring-offset-color: var(--primary-hover);
+}
+
+.focus\\\\:ring-offset-primary-idle:focus {
+  --tw-ring-offset-color: var(--primary-idle);
+}
+
+.focus\\\\:ring-offset-primary-pressed:focus {
+  --tw-ring-offset-color: var(--primary-pressed);
+}
+
+.focus\\\\:ring-offset-process-operations:focus {
+  --tw-ring-offset-color: var(--process-operations);
+}
+
+.focus\\\\:ring-offset-purple:focus {
+  --tw-ring-offset-color: var(--purple);
+}
+
+.focus\\\\:ring-offset-registry-operations:focus {
+  --tw-ring-offset-color: var(--registry-operations);
+}
+
+.focus\\\\:ring-offset-selected:focus {
+  --tw-ring-offset-color: var(--selected);
+}
+
+.focus\\\\:ring-offset-surface-2xl:focus {
+  --tw-ring-offset-color: var(--surface-2xl);
+}
+
+.focus\\\\:ring-offset-surface-base:focus {
+  --tw-ring-offset-color: var(--surface-base);
+}
+
+.focus\\\\:ring-offset-surface-inner:focus {
+  --tw-ring-offset-color: var(--surface-inner);
+}
+
+.focus\\\\:ring-offset-surface-lg:focus {
+  --tw-ring-offset-color: var(--surface-lg);
+}
+
+.focus\\\\:ring-offset-surface-md:focus {
+  --tw-ring-offset-color: var(--surface-md);
+}
+
+.focus\\\\:ring-offset-surface-xl:focus {
+  --tw-ring-offset-color: var(--surface-xl);
+}
+
+.focus\\\\:ring-offset-text-and-icons:focus {
+  --tw-ring-offset-color: var(--text-and-icons);
+}
+
+.focus\\\\:ring-offset-titles-and-attributes:focus {
+  --tw-ring-offset-color: var(--titles-and-attributes);
+}
+
+.filter {
+  --tw-blur: var(--tw-empty,/*!*/ /*!*/);
+  --tw-brightness: var(--tw-empty,/*!*/ /*!*/);
+  --tw-contrast: var(--tw-empty,/*!*/ /*!*/);
+  --tw-grayscale: var(--tw-empty,/*!*/ /*!*/);
+  --tw-hue-rotate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-invert: var(--tw-empty,/*!*/ /*!*/);
+  --tw-saturate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-sepia: var(--tw-empty,/*!*/ /*!*/);
+  --tw-drop-shadow: var(--tw-empty,/*!*/ /*!*/);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.filter-none {
+  filter: none;
+}
+
+.blur-0 {
+  --tw-blur: blur(0);
+}
+
+.blur-none {
+  --tw-blur: blur(0);
+}
+
+.blur-sm {
+  --tw-blur: blur(4px);
+}
+
+.blur {
+  --tw-blur: blur(8px);
+}
+
+.blur-md {
+  --tw-blur: blur(12px);
+}
+
+.blur-lg {
+  --tw-blur: blur(16px);
+}
+
+.blur-xl {
+  --tw-blur: blur(24px);
+}
+
+.blur-2xl {
+  --tw-blur: blur(40px);
+}
+
+.blur-3xl {
+  --tw-blur: blur(64px);
+}
+
+.brightness-0 {
+  --tw-brightness: brightness(0);
+}
+
+.brightness-50 {
+  --tw-brightness: brightness(.5);
+}
+
+.brightness-75 {
+  --tw-brightness: brightness(.75);
+}
+
+.brightness-90 {
+  --tw-brightness: brightness(.9);
+}
+
+.brightness-95 {
+  --tw-brightness: brightness(.95);
+}
+
+.brightness-100 {
+  --tw-brightness: brightness(1);
+}
+
+.brightness-105 {
+  --tw-brightness: brightness(1.05);
+}
+
+.brightness-110 {
+  --tw-brightness: brightness(1.1);
+}
+
+.brightness-125 {
+  --tw-brightness: brightness(1.25);
+}
+
+.brightness-150 {
+  --tw-brightness: brightness(1.5);
+}
+
+.brightness-200 {
+  --tw-brightness: brightness(2);
+}
+
+.contrast-0 {
+  --tw-contrast: contrast(0);
+}
+
+.contrast-50 {
+  --tw-contrast: contrast(.5);
+}
+
+.contrast-75 {
+  --tw-contrast: contrast(.75);
+}
+
+.contrast-100 {
+  --tw-contrast: contrast(1);
+}
+
+.contrast-125 {
+  --tw-contrast: contrast(1.25);
+}
+
+.contrast-150 {
+  --tw-contrast: contrast(1.5);
+}
+
+.contrast-200 {
+  --tw-contrast: contrast(2);
+}
+
+.drop-shadow-sm {
+  --tw-drop-shadow: drop-shadow(0 1px 1px rgba(0,0,0,0.05));
+}
+
+.drop-shadow {
+  --tw-drop-shadow: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.06));
+}
+
+.drop-shadow-md {
+  --tw-drop-shadow: drop-shadow(0 4px 3px rgba(0, 0, 0, 0.07)) drop-shadow(0 2px 2px rgba(0, 0, 0, 0.06));
+}
+
+.drop-shadow-lg {
+  --tw-drop-shadow: drop-shadow(0 10px 8px rgba(0, 0, 0, 0.04)) drop-shadow(0 4px 3px rgba(0, 0, 0, 0.1));
+}
+
+.drop-shadow-xl {
+  --tw-drop-shadow: drop-shadow(0 20px 13px rgba(0, 0, 0, 0.03)) drop-shadow(0 8px 5px rgba(0, 0, 0, 0.08));
+}
+
+.drop-shadow-2xl {
+  --tw-drop-shadow: drop-shadow(0 25px 25px rgba(0, 0, 0, 0.15));
+}
+
+.drop-shadow-none {
+  --tw-drop-shadow: drop-shadow(0 0 #0000);
+}
+
+.grayscale-0 {
+  --tw-grayscale: grayscale(0);
+}
+
+.grayscale {
+  --tw-grayscale: grayscale(100%);
+}
+
+.hue-rotate-0 {
+  --tw-hue-rotate: hue-rotate(0deg);
+}
+
+.hue-rotate-15 {
+  --tw-hue-rotate: hue-rotate(15deg);
+}
+
+.hue-rotate-30 {
+  --tw-hue-rotate: hue-rotate(30deg);
+}
+
+.hue-rotate-60 {
+  --tw-hue-rotate: hue-rotate(60deg);
+}
+
+.hue-rotate-90 {
+  --tw-hue-rotate: hue-rotate(90deg);
+}
+
+.hue-rotate-180 {
+  --tw-hue-rotate: hue-rotate(180deg);
+}
+
+.-hue-rotate-180 {
+  --tw-hue-rotate: hue-rotate(-180deg);
+}
+
+.-hue-rotate-90 {
+  --tw-hue-rotate: hue-rotate(-90deg);
+}
+
+.-hue-rotate-60 {
+  --tw-hue-rotate: hue-rotate(-60deg);
+}
+
+.-hue-rotate-30 {
+  --tw-hue-rotate: hue-rotate(-30deg);
+}
+
+.-hue-rotate-15 {
+  --tw-hue-rotate: hue-rotate(-15deg);
+}
+
+.invert-0 {
+  --tw-invert: invert(0);
+}
+
+.invert {
+  --tw-invert: invert(100%);
+}
+
+.saturate-0 {
+  --tw-saturate: saturate(0);
+}
+
+.saturate-50 {
+  --tw-saturate: saturate(.5);
+}
+
+.saturate-100 {
+  --tw-saturate: saturate(1);
+}
+
+.saturate-150 {
+  --tw-saturate: saturate(1.5);
+}
+
+.saturate-200 {
+  --tw-saturate: saturate(2);
+}
+
+.sepia-0 {
+  --tw-sepia: sepia(0);
+}
+
+.sepia {
+  --tw-sepia: sepia(100%);
+}
+
+.backdrop-filter {
+  --tw-backdrop-blur: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-brightness: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-contrast: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-grayscale: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-hue-rotate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-invert: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-opacity: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-saturate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-sepia: var(--tw-empty,/*!*/ /*!*/);
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+          backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
+.backdrop-filter-none {
+  -webkit-backdrop-filter: none;
+          backdrop-filter: none;
+}
+
+.backdrop-blur-0 {
+  --tw-backdrop-blur: blur(0);
+}
+
+.backdrop-blur-none {
+  --tw-backdrop-blur: blur(0);
+}
+
+.backdrop-blur-sm {
+  --tw-backdrop-blur: blur(4px);
+}
+
+.backdrop-blur {
+  --tw-backdrop-blur: blur(8px);
+}
+
+.backdrop-blur-md {
+  --tw-backdrop-blur: blur(12px);
+}
+
+.backdrop-blur-lg {
+  --tw-backdrop-blur: blur(16px);
+}
+
+.backdrop-blur-xl {
+  --tw-backdrop-blur: blur(24px);
+}
+
+.backdrop-blur-2xl {
+  --tw-backdrop-blur: blur(40px);
+}
+
+.backdrop-blur-3xl {
+  --tw-backdrop-blur: blur(64px);
+}
+
+.backdrop-brightness-0 {
+  --tw-backdrop-brightness: brightness(0);
+}
+
+.backdrop-brightness-50 {
+  --tw-backdrop-brightness: brightness(.5);
+}
+
+.backdrop-brightness-75 {
+  --tw-backdrop-brightness: brightness(.75);
+}
+
+.backdrop-brightness-90 {
+  --tw-backdrop-brightness: brightness(.9);
+}
+
+.backdrop-brightness-95 {
+  --tw-backdrop-brightness: brightness(.95);
+}
+
+.backdrop-brightness-100 {
+  --tw-backdrop-brightness: brightness(1);
+}
+
+.backdrop-brightness-105 {
+  --tw-backdrop-brightness: brightness(1.05);
+}
+
+.backdrop-brightness-110 {
+  --tw-backdrop-brightness: brightness(1.1);
+}
+
+.backdrop-brightness-125 {
+  --tw-backdrop-brightness: brightness(1.25);
+}
+
+.backdrop-brightness-150 {
+  --tw-backdrop-brightness: brightness(1.5);
+}
+
+.backdrop-brightness-200 {
+  --tw-backdrop-brightness: brightness(2);
+}
+
+.backdrop-contrast-0 {
+  --tw-backdrop-contrast: contrast(0);
+}
+
+.backdrop-contrast-50 {
+  --tw-backdrop-contrast: contrast(.5);
+}
+
+.backdrop-contrast-75 {
+  --tw-backdrop-contrast: contrast(.75);
+}
+
+.backdrop-contrast-100 {
+  --tw-backdrop-contrast: contrast(1);
+}
+
+.backdrop-contrast-125 {
+  --tw-backdrop-contrast: contrast(1.25);
+}
+
+.backdrop-contrast-150 {
+  --tw-backdrop-contrast: contrast(1.5);
+}
+
+.backdrop-contrast-200 {
+  --tw-backdrop-contrast: contrast(2);
+}
+
+.backdrop-grayscale-0 {
+  --tw-backdrop-grayscale: grayscale(0);
+}
+
+.backdrop-grayscale {
+  --tw-backdrop-grayscale: grayscale(100%);
+}
+
+.backdrop-hue-rotate-0 {
+  --tw-backdrop-hue-rotate: hue-rotate(0deg);
+}
+
+.backdrop-hue-rotate-15 {
+  --tw-backdrop-hue-rotate: hue-rotate(15deg);
+}
+
+.backdrop-hue-rotate-30 {
+  --tw-backdrop-hue-rotate: hue-rotate(30deg);
+}
+
+.backdrop-hue-rotate-60 {
+  --tw-backdrop-hue-rotate: hue-rotate(60deg);
+}
+
+.backdrop-hue-rotate-90 {
+  --tw-backdrop-hue-rotate: hue-rotate(90deg);
+}
+
+.backdrop-hue-rotate-180 {
+  --tw-backdrop-hue-rotate: hue-rotate(180deg);
+}
+
+.-backdrop-hue-rotate-180 {
+  --tw-backdrop-hue-rotate: hue-rotate(-180deg);
+}
+
+.-backdrop-hue-rotate-90 {
+  --tw-backdrop-hue-rotate: hue-rotate(-90deg);
+}
+
+.-backdrop-hue-rotate-60 {
+  --tw-backdrop-hue-rotate: hue-rotate(-60deg);
+}
+
+.-backdrop-hue-rotate-30 {
+  --tw-backdrop-hue-rotate: hue-rotate(-30deg);
+}
+
+.-backdrop-hue-rotate-15 {
+  --tw-backdrop-hue-rotate: hue-rotate(-15deg);
+}
+
+.backdrop-invert-0 {
+  --tw-backdrop-invert: invert(0);
+}
+
+.backdrop-invert {
+  --tw-backdrop-invert: invert(100%);
+}
+
+.backdrop-opacity-0 {
+  --tw-backdrop-opacity: opacity(0);
+}
+
+.backdrop-opacity-5 {
+  --tw-backdrop-opacity: opacity(0.05);
+}
+
+.backdrop-opacity-10 {
+  --tw-backdrop-opacity: opacity(0.1);
+}
+
+.backdrop-opacity-20 {
+  --tw-backdrop-opacity: opacity(0.2);
+}
+
+.backdrop-opacity-25 {
+  --tw-backdrop-opacity: opacity(0.25);
+}
+
+.backdrop-opacity-30 {
+  --tw-backdrop-opacity: opacity(0.3);
+}
+
+.backdrop-opacity-40 {
+  --tw-backdrop-opacity: opacity(0.4);
+}
+
+.backdrop-opacity-50 {
+  --tw-backdrop-opacity: opacity(0.5);
+}
+
+.backdrop-opacity-60 {
+  --tw-backdrop-opacity: opacity(0.6);
+}
+
+.backdrop-opacity-70 {
+  --tw-backdrop-opacity: opacity(0.7);
+}
+
+.backdrop-opacity-75 {
+  --tw-backdrop-opacity: opacity(0.75);
+}
+
+.backdrop-opacity-80 {
+  --tw-backdrop-opacity: opacity(0.8);
+}
+
+.backdrop-opacity-90 {
+  --tw-backdrop-opacity: opacity(0.9);
+}
+
+.backdrop-opacity-95 {
+  --tw-backdrop-opacity: opacity(0.95);
+}
+
+.backdrop-opacity-100 {
+  --tw-backdrop-opacity: opacity(1);
+}
+
+.backdrop-saturate-0 {
+  --tw-backdrop-saturate: saturate(0);
+}
+
+.backdrop-saturate-50 {
+  --tw-backdrop-saturate: saturate(.5);
+}
+
+.backdrop-saturate-100 {
+  --tw-backdrop-saturate: saturate(1);
+}
+
+.backdrop-saturate-150 {
+  --tw-backdrop-saturate: saturate(1.5);
+}
+
+.backdrop-saturate-200 {
+  --tw-backdrop-saturate: saturate(2);
+}
+
+.backdrop-sepia-0 {
+  --tw-backdrop-sepia: sepia(0);
+}
+
+.backdrop-sepia {
+  --tw-backdrop-sepia: sepia(100%);
+}
+
+.transition-none {
+  transition-property: none;
+}
+
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition {
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-colors {
+  transition-property: background-color, border-color, color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-opacity {
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-shadow {
+  transition-property: box-shadow;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-width {
+  transition-property: width;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-none:active {
+  transition-property: none;
+}
+
+.active\\\\:transition-all:active {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition:active {
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-colors:active {
+  transition-property: background-color, border-color, color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-opacity:active {
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-shadow:active {
+  transition-property: box-shadow;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-transform:active {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-width:active {
+  transition-property: width;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.delay-75 {
+  transition-delay: 75ms;
+}
+
+.delay-100 {
+  transition-delay: 100ms;
+}
+
+.delay-150 {
+  transition-delay: 150ms;
+}
+
+.delay-200 {
+  transition-delay: 200ms;
+}
+
+.delay-300 {
+  transition-delay: 300ms;
+}
+
+.delay-500 {
+  transition-delay: 500ms;
+}
+
+.delay-700 {
+  transition-delay: 700ms;
+}
+
+.delay-1000 {
+  transition-delay: 1000ms;
+}
+
+.duration-75 {
+  transition-duration: 75ms;
+}
+
+.duration-100 {
+  transition-duration: 100ms;
+}
+
+.duration-150 {
+  transition-duration: 150ms;
+}
+
+.duration-200 {
+  transition-duration: 200ms;
+}
+
+.duration-300 {
+  transition-duration: 300ms;
+}
+
+.duration-500 {
+  transition-duration: 500ms;
+}
+
+.duration-700 {
+  transition-duration: 700ms;
+}
+
+.duration-1000 {
+  transition-duration: 1000ms;
+}
+
+.ease-linear {
+  transition-timing-function: linear;
+}
+
+.ease-in {
+  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+}
+
+.ease-out {
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+
+.ease-in-out {
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.content-none {
+  content: none;
+}
+
+.clamp-1 {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-4 {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-5 {
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-6 {
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-7 {
+  display: -webkit-box;
+  -webkit-line-clamp: 7;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-8 {
+  display: -webkit-box;
+  -webkit-line-clamp: 8;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-9 {
+  display: -webkit-box;
+  -webkit-line-clamp: 9;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-10 {
+  display: -webkit-box;
+  -webkit-line-clamp: 10;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+@media print {
+  .print\\\\:block {
+    display: block;
+  }
+
+  .print\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .print\\\\:inline {
+    display: inline;
+  }
+
+  .print\\\\:flex {
+    display: flex;
+  }
+
+  .print\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .print\\\\:table {
+    display: table;
+  }
+
+  .print\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .print\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .print\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .print\\\\:table-column {
+    display: table-column;
+  }
+
+  .print\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .print\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .print\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .print\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .print\\\\:table-row {
+    display: table-row;
+  }
+
+  .print\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .print\\\\:grid {
+    display: grid;
+  }
+
+  .print\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .print\\\\:contents {
+    display: contents;
+  }
+
+  .print\\\\:list-item {
+    display: list-item;
+  }
+
+  .print\\\\:hidden {
+    display: none;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:block {
+    display: block;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline {
+    display: inline;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:flex {
+    display: flex;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table {
+    display: table;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-column {
+    display: table-column;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-row {
+    display: table-row;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:grid {
+    display: grid;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:contents {
+    display: contents;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:list-item {
+    display: list-item;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:hidden {
+    display: none;
+  }
+
+  .print\\\\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-8 {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-9 {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-10 {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-11 {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-none {
+    grid-template-columns: none;
+  }
+
+  .print\\\\:grid-cols-centered-2\\\\/3 {
+    grid-template-columns: 2fr 8fr 2fr;
+  }
+
+  .print\\\\:grid-cols-auto-2 {
+    grid-template-columns: auto auto;
+  }
+
+  .print\\\\:grid-cols-max-content-4 {
+    grid-template-columns: repeat(4, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(4, minmax(max-content, 1fr));
+  }
+
+  .print\\\\:grid-cols-max-content-6 {
+    grid-template-columns: repeat(6, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(6, minmax(max-content, 1fr));
+  }
+
+  .print\\\\:bg-origin-border {
+    background-origin: border-box;
+  }
+
+  .print\\\\:bg-origin-padding {
+    background-origin: padding-box;
+  }
+
+  .print\\\\:bg-origin-content {
+    background-origin: content-box;
+  }
+
+  .print\\\\:backdrop-opacity-0 {
+    --tw-backdrop-opacity: opacity(0);
+  }
+
+  .print\\\\:backdrop-opacity-5 {
+    --tw-backdrop-opacity: opacity(0.05);
+  }
+
+  .print\\\\:backdrop-opacity-10 {
+    --tw-backdrop-opacity: opacity(0.1);
+  }
+
+  .print\\\\:backdrop-opacity-20 {
+    --tw-backdrop-opacity: opacity(0.2);
+  }
+
+  .print\\\\:backdrop-opacity-25 {
+    --tw-backdrop-opacity: opacity(0.25);
+  }
+
+  .print\\\\:backdrop-opacity-30 {
+    --tw-backdrop-opacity: opacity(0.3);
+  }
+
+  .print\\\\:backdrop-opacity-40 {
+    --tw-backdrop-opacity: opacity(0.4);
+  }
+
+  .print\\\\:backdrop-opacity-50 {
+    --tw-backdrop-opacity: opacity(0.5);
+  }
+
+  .print\\\\:backdrop-opacity-60 {
+    --tw-backdrop-opacity: opacity(0.6);
+  }
+
+  .print\\\\:backdrop-opacity-70 {
+    --tw-backdrop-opacity: opacity(0.7);
+  }
+
+  .print\\\\:backdrop-opacity-75 {
+    --tw-backdrop-opacity: opacity(0.75);
+  }
+
+  .print\\\\:backdrop-opacity-80 {
+    --tw-backdrop-opacity: opacity(0.8);
+  }
+
+  .print\\\\:backdrop-opacity-90 {
+    --tw-backdrop-opacity: opacity(0.9);
+  }
+
+  .print\\\\:backdrop-opacity-95 {
+    --tw-backdrop-opacity: opacity(0.95);
+  }
+
+  .print\\\\:backdrop-opacity-100 {
+    --tw-backdrop-opacity: opacity(1);
+  }
+}
+
+@media (min-width: 1120px) {
+  .lg\\\\:block {
+    display: block;
+  }
+
+  .lg\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .lg\\\\:inline {
+    display: inline;
+  }
+
+  .lg\\\\:flex {
+    display: flex;
+  }
+
+  .lg\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .lg\\\\:table {
+    display: table;
+  }
+
+  .lg\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .lg\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .lg\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .lg\\\\:table-column {
+    display: table-column;
+  }
+
+  .lg\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .lg\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .lg\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .lg\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .lg\\\\:table-row {
+    display: table-row;
+  }
+
+  .lg\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .lg\\\\:grid {
+    display: grid;
+  }
+
+  .lg\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .lg\\\\:contents {
+    display: contents;
+  }
+
+  .lg\\\\:list-item {
+    display: list-item;
+  }
+
+  .lg\\\\:hidden {
+    display: none;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:block {
+    display: block;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline {
+    display: inline;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:flex {
+    display: flex;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table {
+    display: table;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-column {
+    display: table-column;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-row {
+    display: table-row;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:grid {
+    display: grid;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:contents {
+    display: contents;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:list-item {
+    display: list-item;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:hidden {
+    display: none;
+  }
+
+  .lg\\\\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-8 {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-9 {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-10 {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-11 {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-none {
+    grid-template-columns: none;
+  }
+
+  .lg\\\\:grid-cols-centered-2\\\\/3 {
+    grid-template-columns: 2fr 8fr 2fr;
+  }
+
+  .lg\\\\:grid-cols-auto-2 {
+    grid-template-columns: auto auto;
+  }
+
+  .lg\\\\:grid-cols-max-content-4 {
+    grid-template-columns: repeat(4, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(4, minmax(max-content, 1fr));
+  }
+
+  .lg\\\\:grid-cols-max-content-6 {
+    grid-template-columns: repeat(6, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(6, minmax(max-content, 1fr));
+  }
+
+  .lg\\\\:bg-origin-border {
+    background-origin: border-box;
+  }
+
+  .lg\\\\:bg-origin-padding {
+    background-origin: padding-box;
+  }
+
+  .lg\\\\:bg-origin-content {
+    background-origin: content-box;
+  }
+
+  .lg\\\\:backdrop-opacity-0 {
+    --tw-backdrop-opacity: opacity(0);
+  }
+
+  .lg\\\\:backdrop-opacity-5 {
+    --tw-backdrop-opacity: opacity(0.05);
+  }
+
+  .lg\\\\:backdrop-opacity-10 {
+    --tw-backdrop-opacity: opacity(0.1);
+  }
+
+  .lg\\\\:backdrop-opacity-20 {
+    --tw-backdrop-opacity: opacity(0.2);
+  }
+
+  .lg\\\\:backdrop-opacity-25 {
+    --tw-backdrop-opacity: opacity(0.25);
+  }
+
+  .lg\\\\:backdrop-opacity-30 {
+    --tw-backdrop-opacity: opacity(0.3);
+  }
+
+  .lg\\\\:backdrop-opacity-40 {
+    --tw-backdrop-opacity: opacity(0.4);
+  }
+
+  .lg\\\\:backdrop-opacity-50 {
+    --tw-backdrop-opacity: opacity(0.5);
+  }
+
+  .lg\\\\:backdrop-opacity-60 {
+    --tw-backdrop-opacity: opacity(0.6);
+  }
+
+  .lg\\\\:backdrop-opacity-70 {
+    --tw-backdrop-opacity: opacity(0.7);
+  }
+
+  .lg\\\\:backdrop-opacity-75 {
+    --tw-backdrop-opacity: opacity(0.75);
+  }
+
+  .lg\\\\:backdrop-opacity-80 {
+    --tw-backdrop-opacity: opacity(0.8);
+  }
+
+  .lg\\\\:backdrop-opacity-90 {
+    --tw-backdrop-opacity: opacity(0.9);
+  }
+
+  .lg\\\\:backdrop-opacity-95 {
+    --tw-backdrop-opacity: opacity(0.95);
+  }
+
+  .lg\\\\:backdrop-opacity-100 {
+    --tw-backdrop-opacity: opacity(1);
+  }
+}
+
+@media (min-width: 1536px) {
+  .\\\\32xl\\\\:block {
+    display: block;
+  }
+
+  .\\\\32xl\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .\\\\32xl\\\\:inline {
+    display: inline;
+  }
+
+  .\\\\32xl\\\\:flex {
+    display: flex;
+  }
+
+  .\\\\32xl\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .\\\\32xl\\\\:table {
+    display: table;
+  }
+
+  .\\\\32xl\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .\\\\32xl\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .\\\\32xl\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .\\\\32xl\\\\:table-column {
+    display: table-column;
+  }
+
+  .\\\\32xl\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .\\\\32xl\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .\\\\32xl\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .\\\\32xl\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .\\\\32xl\\\\:table-row {
+    display: table-row;
+  }
+
+  .\\\\32xl\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .\\\\32xl\\\\:grid {
+    display: grid;
+  }
+
+  .\\\\32xl\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .\\\\32xl\\\\:contents {
+    display: contents;
+  }
+
+  .\\\\32xl\\\\:list-item {
+    display: list-item;
+  }
+
+  .\\\\32xl\\\\:hidden {
+    display: none;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:block {
+    display: block;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline {
+    display: inline;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:flex {
+    display: flex;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table {
+    display: table;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-column {
+    display: table-column;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-row {
+    display: table-row;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:grid {
+    display: grid;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:contents {
+    display: contents;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:list-item {
+    display: list-item;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:hidden {
+    display: none;
+  }
+
+  .\\\\32xl\\\\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-8 {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-9 {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-10 {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-11 {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-none {
+    grid-template-columns: none;
+  }
+
+  .\\\\32xl\\\\:grid-cols-centered-2\\\\/3 {
+    grid-template-columns: 2fr 8fr 2fr;
+  }
+
+  .\\\\32xl\\\\:grid-cols-auto-2 {
+    grid-template-columns: auto auto;
+  }
+
+  .\\\\32xl\\\\:grid-cols-max-content-4 {
+    grid-template-columns: repeat(4, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(4, minmax(max-content, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-max-content-6 {
+    grid-template-columns: repeat(6, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(6, minmax(max-content, 1fr));
+  }
+
+  .\\\\32xl\\\\:bg-origin-border {
+    background-origin: border-box;
+  }
+
+  .\\\\32xl\\\\:bg-origin-padding {
+    background-origin: padding-box;
+  }
+
+  .\\\\32xl\\\\:bg-origin-content {
+    background-origin: content-box;
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-0 {
+    --tw-backdrop-opacity: opacity(0);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-5 {
+    --tw-backdrop-opacity: opacity(0.05);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-10 {
+    --tw-backdrop-opacity: opacity(0.1);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-20 {
+    --tw-backdrop-opacity: opacity(0.2);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-25 {
+    --tw-backdrop-opacity: opacity(0.25);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-30 {
+    --tw-backdrop-opacity: opacity(0.3);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-40 {
+    --tw-backdrop-opacity: opacity(0.4);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-50 {
+    --tw-backdrop-opacity: opacity(0.5);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-60 {
+    --tw-backdrop-opacity: opacity(0.6);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-70 {
+    --tw-backdrop-opacity: opacity(0.7);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-75 {
+    --tw-backdrop-opacity: opacity(0.75);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-80 {
+    --tw-backdrop-opacity: opacity(0.8);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-90 {
+    --tw-backdrop-opacity: opacity(0.9);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-95 {
+    --tw-backdrop-opacity: opacity(0.95);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-100 {
+    --tw-backdrop-opacity: opacity(1);
+  }
+}
+"
+`;

--- a/tests/__snapshots__/css-import.test.ts.snap
+++ b/tests/__snapshots__/css-import.test.ts.snap
@@ -1,0 +1,38954 @@
+// Vitest Snapshot v1
+
+exports[`CSS @import > does not change unexpectedly 1`] = `
+"/*! tailwindcss v2.2.19 | MIT License | https://tailwindcss.com */
+
+/*! modern-normalize v1.1.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
+
+/*
+Document
+========
+*/
+
+/**
+Use a better box model (opinionated).
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
+
+/**
+Use a more readable tab size (opinionated).
+*/
+
+html {
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+     tab-size: 4;
+}
+
+/**
+1. Correct the line height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+*/
+
+html {
+  line-height: 1.15;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+}
+
+/*
+Sections
+========
+*/
+
+/**
+Remove the margin in all browsers.
+*/
+
+body {
+  margin: 0;
+}
+
+/**
+Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+*/
+
+body {
+  font-family:
+		system-ui,
+		-apple-system, /* Firefox supports this but not yet \`system-ui\` */
+		'Segoe UI',
+		Roboto,
+		Helvetica,
+		Arial,
+		sans-serif,
+		'Apple Color Emoji',
+		'Segoe UI Emoji';
+}
+
+/*
+Grouping content
+================
+*/
+
+/**
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+*/
+
+hr {
+  height: 0;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+}
+
+/*
+Text-level semantics
+====================
+*/
+
+/**
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr[title] {
+  -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
+}
+
+/**
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the odd 'em' font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family:
+		ui-monospace,
+		SFMono-Regular,
+		Consolas,
+		'Liberation Mono',
+		Menlo,
+		monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
+}
+
+/**
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/**
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+Tabular data
+============
+*/
+
+/**
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+*/
+
+table {
+  text-indent: 0;
+  /* 1 */
+  border-color: inherit;
+  /* 2 */
+}
+
+/*
+Forms
+=====
+*/
+
+/**
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  line-height: 1.15;
+  /* 1 */
+  margin: 0;
+  /* 2 */
+}
+
+/**
+Remove the inheritance of text transform in Edge and Firefox.
+1. Remove the inheritance of text transform in Firefox.
+*/
+
+button,
+select {
+  /* 1 */
+  text-transform: none;
+}
+
+/**
+Correct the inability to style clickable types in iOS and Safari.
+*/
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+}
+
+/**
+Remove the inner border and padding in Firefox.
+*/
+
+::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+Restore the focus styles unset by the previous rule.
+*/
+
+:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+Remove the additional ':invalid' styles in Firefox.
+See: https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737
+*/
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/**
+Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+*/
+
+legend {
+  padding: 0;
+}
+
+/**
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
+}
+
+/**
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to 'inherit' in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+}
+
+/*
+Interactive
+===========
+*/
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/**
+ * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * A thin layer on top of normalize.css that provides a starting point more
+ * suitable for web applications.
+ */
+
+/**
+ * Removes the default spacing and border for appropriate elements.
+ */
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+button {
+  background-color: transparent;
+  background-image: none;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+ol,
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/**
+ * Tailwind custom reset styles
+ */
+
+/**
+ * 1. Use the user's configured \`sans\` font-family (with Tailwind's default
+ *    sans-serif font stack as a fallback) as a sane default.
+ * 2. Use Tailwind's default \\"normal\\" line-height so the user isn't forced
+ *    to override it to ensure consistency even when using the default theme.
+ */
+
+html {
+  font-family: Calibre, sans-serif;
+  /* 1 */
+  line-height: 1.5;
+  /* 2 */
+}
+
+/**
+ * Inherit font-family and line-height from \`html\` so users can set them as
+ * a class directly on the \`html\` element.
+ */
+
+body {
+  font-family: inherit;
+  line-height: inherit;
+}
+
+/**
+ * 1. Prevent padding and border from affecting element width.
+ *
+ *    We used to set this in the html element and inherit from
+ *    the parent element for everything else. This caused issues
+ *    in shadow-dom-enhanced elements like <details> where the content
+ *    is wrapped by a div with box-sizing set to \`content-box\`.
+ *
+ *    https://github.com/mozdevs/cssremedy/issues/4
+ *
+ *
+ * 2. Allow adding a border to an element by just adding a border-width.
+ *
+ *    By default, the way the browser specifies that an element should have no
+ *    border is by setting it's border-style to \`none\` in the user-agent
+ *    stylesheet.
+ *
+ *    In order to easily add borders to elements by just setting the \`border-width\`
+ *    property, we change the default border-style for all elements to \`solid\`, and
+ *    use border-width to hide them instead. This way our \`border\` utilities only
+ *    need to set the \`border-width\` property instead of the entire \`border\`
+ *    shorthand, making our border utilities much more straightforward to compose.
+ *
+ *    https://github.com/tailwindcss/tailwindcss/pull/116
+ */
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  /* 1 */
+  border-width: 0;
+  /* 2 */
+  border-style: solid;
+  /* 2 */
+  border-color: currentColor;
+  /* 2 */
+}
+
+/*
+ * Ensure horizontal rules are visible by default
+ */
+
+hr {
+  border-top-width: 1px;
+}
+
+/**
+ * Undo the \`border-style: none\` reset that Normalize applies to images so that
+ * our \`border-{width}\` utilities have the expected effect.
+ *
+ * The Normalize reset is unnecessary for us since we default the border-width
+ * to 0 on all elements.
+ *
+ * https://github.com/tailwindcss/tailwindcss/issues/362
+ */
+
+img {
+  border-style: solid;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input::-moz-placeholder, textarea::-moz-placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+input:-ms-input-placeholder, textarea:-ms-input-placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+button,
+[role=\\"button\\"] {
+  cursor: pointer;
+}
+
+/**
+ * Override legacy focus reset from Normalize with modern Firefox focus styles.
+ *
+ * This is actually an improvement over the new defaults in Firefox in our testing,
+ * as it triggers the better focus styles even for links, which still use a dotted
+ * outline in Firefox by default.
+ */
+
+:-moz-focusring {
+  outline: auto;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/**
+ * Reset links to optimize for opt-in styling instead of
+ * opt-out.
+ */
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/**
+ * Reset form element properties that are easy to forget to
+ * style explicitly so you don't inadvertently introduce
+ * styles that deviate from your design system. These styles
+ * supplement a partial reset that is already applied by
+ * normalize.css.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  padding: 0;
+  line-height: inherit;
+  color: inherit;
+}
+
+/**
+ * Use the configured 'mono' font family for elements that
+ * are expected to be rendered with a monospace font, falling
+ * back to the system monospace stack if there is no configured
+ * 'mono' font family.
+ */
+
+pre,
+code,
+kbd,
+samp {
+  font-family: Monaco, monospace;
+}
+
+/**
+ * 1. Make replaced elements \`display: block\` by default as that's
+ *    the behavior you want almost all of the time. Inspired by
+ *    CSS Remedy, with \`svg\` added as well.
+ *
+ *    https://github.com/mozdevs/cssremedy/issues/14
+ * 
+ * 2. Add \`vertical-align: middle\` to align replaced elements more
+ *    sensibly by default when overriding \`display\` by adding a
+ *    utility like \`inline\`.
+ *
+ *    This can trigger a poorly considered linting error in some
+ *    tools but is included by design.
+ * 
+ *    https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210
+ */
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+  /* 1 */
+  vertical-align: middle;
+  /* 2 */
+}
+
+/**
+ * Constrain images and videos to the parent width and preserve
+ * their intrinsic aspect ratio.
+ *
+ * https://github.com/mozdevs/cssremedy/issues/14
+ */
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/**
+ * Ensure the default browser behavior of the \`hidden\` attribute.
+ */
+
+[hidden] {
+  display: none;
+}
+
+*, ::before, ::after {
+  border-color: currentColor;
+}
+
+.theme-dark {
+  --basement: #131217;
+  --blue: #1c9cfe;
+  --body-and-labels: #a6acb0;
+  --brand: #d31912;
+  --code-base-64: #e96e9d;
+  --code-bg: #232326;
+  --code-outline: #1c1c21;
+  --code-text: #9dc1fd;
+  --critical: #f64147;
+  --destructive-hover: #fa9497;
+  --destructive-idle: #1e1d20;
+  --destructive-pressed: #f9585d;
+  --disabled: #77798f;
+  --disc-operations: #db62f9;
+  --dns-requests: #8556fe;
+  --focus: #6688ff;
+  --graph-1: #4cd7f5;
+  --graph-10: #b7b7b7;
+  --graph-11: #efefef;
+  --graph-2: #8280ff;
+  --graph-3: #c179f6;
+  --graph-4: #ffc6c6;
+  --graph-5: #ef91b3;
+  --graph-6: #f69667;
+  --graph-7: #9cefae;
+  --graph-8: #fcdc5c;
+  --graph-9: #a06e6e;
+  --graph-disabled: #505265;
+  --ground-floor: #27262c;
+  --high: #f77d40;
+  --informational: #9dc1fd;
+  --lines-dark: #09090c;
+  --lines-light: #14141a;
+  --low: #cef2ce;
+  --medium: #ffcc00;
+  --mezzanine: #212121;
+  --nav-text-and-icons: #fafafa;
+  --nav-text-secondary: #a6acb0;
+  --network-operations: #fb5093;
+  --normal-hover: #63646e;
+  --normal-idle: #4e4f5a;
+  --normal-pressed: #3d3d48;
+  --overlay-0\\\\.5: #00000021;
+  --overlay-1: #00000040;
+  --overlay-2: #00000099;
+  --positive: #06e5b7;
+  --primary-hover: #e1ecfe;
+  --primary-idle: #c8dcfe;
+  --primary-pressed: #7d9bff;
+  --process-operations: #629cfb;
+  --purple: #b15af2;
+  --registry-operations: #5d63fe;
+  --selected: #7d9bff1a;
+  --surface-2xl: #3d3c40;
+  --surface-base: #26252a;
+  --surface-inner: #17161a;
+  --surface-lg: #343337;
+  --surface-md: #2d2c31;
+  --surface-xl: #38373c;
+  --text-and-icons: #fafafa;
+  --titles-and-attributes: #e2e2e4;
+}
+
+.theme-light {
+  --basement: #ebebeb;
+  --blue: #2469f0;
+  --body-and-labels: #767676;
+  --brand: #d31c12;
+  --code-base-64: #a8154e;
+  --code-bg: #ffffff;
+  --code-outline: #e5e5e5;
+  --code-text: #0b54c1;
+  --critical: #e9181f;
+  --destructive-hover: #f47479;
+  --destructive-idle: #ffffff;
+  --destructive-pressed: #e8121a;
+  --disabled: #949494;
+  --disc-operations: #b308dd;
+  --dns-requests: #4902fd;
+  --focus: #039eba;
+  --graph-1: #0f99a1;
+  --graph-10: #7478a1;
+  --graph-11: #3b364a;
+  --graph-2: #1c3cae;
+  --graph-3: #6b30ab;
+  --graph-4: #961574;
+  --graph-5: #ce4789;
+  --graph-6: #bf4815;
+  --graph-7: #946613;
+  --graph-8: #2e5c0e;
+  --graph-9: #684444;
+  --graph-disabled: #d3d3d3;
+  --ground-floor: #ffffff;
+  --high: #ff7e00;
+  --informational: #5082d2;
+  --lines-dark: #d9d9d9;
+  --lines-light: #eeeeee;
+  --low: #649f64;
+  --medium: #edb000;
+  --mezzanine: #242424;
+  --nav-text-and-icons: #fafafa;
+  --nav-text-secondary: #adadad;
+  --network-operations: #c70f57;
+  --normal-hover: #e8e8e8;
+  --normal-idle: #e0e0e0;
+  --normal-pressed: #adadad;
+  --overlay-0\\\\.5: #00000008;
+  --overlay-1: #0000000d;
+  --overlay-2: #00000026;
+  --positive: #1b8e67;
+  --primary-hover: #168093;
+  --primary-idle: #036678;
+  --primary-pressed: #025564;
+  --process-operations: #1055c6;
+  --purple: #8532c2;
+  --registry-operations: #0108c6;
+  --selected: #036d801a;
+  --surface-2xl: #ffffff;
+  --surface-base: #ffffff;
+  --surface-inner: #ededed;
+  --surface-lg: #ffffff;
+  --surface-md: #ffffff;
+  --surface-xl: #ffffff;
+  --text-and-icons: #202020;
+  --titles-and-attributes: #3d3d3d;
+}
+
+.theme-light .theme-mezzanine {
+  --blue: #1c9cfe;
+  --body-and-labels: #a6acb0;
+  --code-base-64: #e96e9d;
+  --code-text: #9dc1fd;
+  --critical: #f64147;
+  --destructive-hover: #fa9497;
+  --destructive-idle: #1e1d20;
+  --destructive-pressed: #f9585d;
+  --disabled: #77798f;
+  --disc-operations: #db62f9;
+  --dns-requests: #8556fe;
+  --focus: #039eba;
+  --ground-floor: #27262c;
+  --high: #f77d40;
+  --informational: #9dc1fd;
+  --lines-dark: #09090c;
+  --lines-light: #14141a;
+  --low: #cef2ce;
+  --medium: #ffcc00;
+  --mezzanine: #212121;
+  --network-operations: #fb5093;
+  --normal-hover: #5b5b5b;
+  --normal-idle: #454545;
+  --normal-pressed: #3a3a3a;
+  --overlay-1: #00000040;
+  --overlay-2: #00000099;
+  --positive: #06e5b7;
+  --primary-hover: #e9fbfb;
+  --primary-idle: #c9f8fd;
+  --primary-pressed: #039eba;
+  --process-operations: #629cfb;
+  --purple: #b15af2;
+  --registry-operations: #5d63fe;
+  --selected: #039eba1a;
+  --surface-2xl: #3c3c3c;
+  --surface-base: #252525;
+  --surface-inner: #1a1a1a;
+  --surface-lg: #333333;
+  --surface-md: #2c2c2c;
+  --surface-xl: #373737;
+  --text-and-icons: #fafafa;
+  --titles-and-attributes: #e2e2e4;
+}
+
+.theme-dark {
+  --elevation-2xl: 0px 25px 50px 0px rgba(0, 0, 0, 0.62);
+  --elevation-base: 0px 1px 2px 0px rgba(0, 0, 0, 0.46), 0px 1px 3px 0px rgba(0, 0, 0, 0.1);
+  --elevation-inner-lg: inset 0px 2px 4px 0px rgba(0, 0, 0, 0.36);
+  --elevation-inner-md: inset 0px 1px 2px 0px rgba(0, 0, 0, 0.25);
+  --elevation-lg: 0px 10px 15px 0px rgba(0, 0, 0, 0.3), 0px 4px 6px 0px rgba(0, 0, 0, 0.15);
+  --elevation-md: 0px 2px 4px 0px rgba(0, 0, 0, 0.33), 0px 4px 6px 0px rgba(0, 0, 0, 0.1);
+  --elevation-xl: 0px 20px 25px 0px rgba(0, 0, 0, 0.3), 0px 10px 10px 0px rgba(0, 0, 0, 0.12);
+}
+
+.theme-light {
+  --elevation-2xl: 0px 0px 7px 0px rgba(0, 0, 0, 0.08), 0px 25px 50px 0px rgba(0, 0, 0, 0.15);
+  --elevation-base: 0px 0px 1px 0px rgba(0, 0, 0, 0.07), 0px 1px 2px 0px rgba(0, 0, 0, 0.15);
+  --elevation-inner-lg: inset 0px 2px 5px 0px rgba(0, 0, 0, 0.09);
+  --elevation-inner-md: inset 0px 2px 4px 0px rgba(0, 0, 0, 0.08);
+  --elevation-lg: 0px 10px 15px 0px rgba(0, 0, 0, 0.08), 0px 0px 3px 0px rgba(0, 0, 0, 0.07);
+  --elevation-md: 0px 0px 4px 0px rgba(0, 0, 0, 0.06), 0px 3px 6px 0px rgba(0, 0, 0, 0.1);
+  --elevation-xl: 0px 20px 25px 0px rgba(0, 0, 0, 0.08), 0px 0px 4px 0px rgba(0, 0, 0, 0.08);
+}
+
+.theme-light .theme-mezzanine {
+  --elevation-2xl: 0px 25px 50px 0px rgba(0, 0, 0, 0.2);
+  --elevation-base: 0px 1px 2px 0px rgba(0, 0, 0, 0.06), 0px 1px 3px 0px rgba(0, 0, 0, 0.1);
+  --elevation-inner-lg: inset 0px 2px 5px 0px rgba(0, 0, 0, 0.09);
+  --elevation-inner-md: inset 0px 2px 4px 0px rgba(0, 0, 0, 0.08);
+  --elevation-lg: 0px 10px 15px 0px rgba(0, 0, 0, 0.1), 0px 4px 6px 0px rgba(0, 0, 0, 0.05);
+  --elevation-md: 0px 2px 4px 0px rgba(0, 0, 0, 0.06), 0px 4px 6px 0px rgba(0, 0, 0, 0.1);
+  --elevation-xl: 0px 20px 25px 0px rgba(0, 0, 0, 0.1), 0px 10px 10px 0px rgba(0, 0, 0, 0.04);
+}
+
+.container {
+  width: 100%;
+}
+
+@media (min-width: 1120px) {
+  .container {
+    max-width: 1120px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
+.focusable {
+  --tw-ring-color: var(--ground-floor);
+  --tw-ring-inset: inset;
+  --tw-ring-offset-width: 2px;
+  --tw-ring-offset-color: var(--focus);
+}
+
+.focusable:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focusable:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focusable-destructive {
+  --tw-ring-offset-color: var(--destructive-pressed);
+}
+
+.focusable-outer {
+  --tw-ring-offset-color: var(--ground-floor);
+  --tw-ring-offset-width: 1px;
+  --tw-ring-color: var(--focus);
+}
+
+.focusable-outer:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focusable-outer:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.interactive-normal {
+  background-color: var(--normal-idle);
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  color: var(--text-and-icons);
+}
+
+.interactive-normal:not(.interactive-disabled):hover {
+  background-color: var(--normal-hover);
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-normal:not(.interactive-disabled):focus-visible {
+  background-color: var(--normal-hover);
+}
+
+.interactive-normal:not(.interactive-disabled):active {
+  background-color: var(--normal-pressed);
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-primary {
+  background-color: var(--primary-idle);
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  color: var(--ground-floor);
+}
+
+.interactive-primary:not(.interactive-disabled):focus-visible {
+  background-color: var(--primary-hover);
+}
+
+.interactive-primary:not(.interactive-disabled):hover {
+  background-color: var(--primary-hover);
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-primary:not(.interactive-disabled):active {
+  background-color: var(--primary-pressed);
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-destructive {
+  background-color: var(--destructive-idle);
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  color: var(--destructive-pressed);
+}
+
+.interactive-destructive:not(.interactive-disabled):focus-visible {
+  background-color: var(--destructive-hover);
+  color: var(--ground-floor);
+}
+
+.interactive-destructive:not(.interactive-disabled):hover {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  background-color: var(--destructive-hover);
+  color: var(--ground-floor);
+}
+
+.interactive-destructive:not(.interactive-disabled):active {
+  background-color: var(--destructive-pressed);
+  color: var(--ground-floor);
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-link {
+  background-color: transparent;
+  color: var(--primary-idle);
+}
+
+.interactive-link:not(.interactive-disabled):hover {
+  --tw-bg-opacity: 0;
+  color: var(--primary-hover);
+}
+
+.interactive-link:not(.interactive-disabled):active {
+  color: var(--primary-pressed);
+}
+
+.interactive-quiet {
+  background-color: transparent;
+  color: var(--text-and-icons);
+}
+
+.interactive-quiet:not(.interactive-disabled):focus-visible {
+  background-color: var(--normal-hover);
+}
+
+.interactive-quiet:not(.interactive-disabled):hover {
+  background-color: var(--normal-hover);
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-quiet:not(.interactive-disabled):active {
+  background-color: var(--normal-pressed);
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.interactive-disabled {
+  background-color: var(--overlay-1);
+  cursor: default;
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  color: var(--disabled);
+}
+
+.interactive-quiet.interactive-disabled {
+  background-color: transparent;
+}
+
+.textbox {
+  background-color: var(--overlay-1);
+  border-radius: var(--border-radius);
+  box-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  color: var(--titles-and-attributes);
+  display: block;
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: var(--space-1) var(--space-2);
+  width: 100%;
+}
+
+.textbox:focus {
+  box-shadow: inset 0 0 0 2px var(--focus);;
+  outline: 0;
+}
+
+.textbox::-moz-placeholder {
+  color: var(--disabled);
+}
+
+.textbox:-ms-input-placeholder {
+  color: var(--disabled);
+}
+
+.textbox::placeholder {
+  color: var(--disabled);
+}
+
+.textarea {
+  background-color: var(--overlay-1);
+  border-radius: var(--border-radius);
+  box-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  color: var(--titles-and-attributes);
+  display: block;
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: var(--space-1) var(--space-2);
+  width: 100%;
+}
+
+.textarea:focus {
+  box-shadow: inset 0 0 0 2px var(--focus);;
+  outline: 0;
+}
+
+.textarea::-moz-placeholder {
+  color: var(--disabled);
+}
+
+.textarea:-ms-input-placeholder {
+  color: var(--disabled);
+}
+
+.textarea::placeholder {
+  color: var(--disabled);
+}
+
+.textarea {
+  min-height: 150px;
+  resize: vertical;
+}
+
+.type-4xl {
+  font-size: 3rem;
+  line-height: 3.25rem;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
+.type-3xl {
+  font-size: 2.5rem;
+  line-height: 3rem;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
+.type-2xl {
+  font-size: 2rem;
+  line-height: 2.5rem;
+  font-weight: 500;
+}
+
+.type-xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 500;
+  text-rendering: geometricPrecision;
+}
+
+.type-lg {
+  font-size: 1.25rem;
+  line-height: 2rem;
+}
+
+.type-lg-medium {
+  font-size: 1.25rem;
+  line-height: 2rem;
+  font-weight: 500;
+}
+
+.type-lg-tight-medium {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  font-weight: 500;
+  text-rendering: geometricPrecision;
+}
+
+.type-md {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.type-md-medium {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 500;
+}
+
+.type-md-underline {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  text-decoration: underline;
+}
+
+.type-md-tight {
+  font-size: 1rem;
+  line-height: 1.25rem;
+}
+
+.type-md-tight-medium {
+  font-size: 1rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  text-rendering: geometricPrecision;
+}
+
+.type-md-tight-underline {
+  font-size: 1rem;
+  line-height: 1.25rem;
+  text-decoration: underline;
+}
+
+.type-sm-mono {
+  font-size: .875rem;
+  line-height: 1.5rem;
+  font-family: Monaco, monospace;
+}
+
+.type-sm-mono-tight {
+  font-size: .875rem;
+  font-family: Monaco, monospace;
+  line-height: 1.25rem;
+}
+
+.type-sm-mono-underline {
+  font-size: .875rem;
+  line-height: 1.5rem;
+  font-family: Monaco, monospace;
+  text-decoration: underline;
+}
+
+.type-xs {
+  font-size: .75rem;
+  line-height: 1.25rem;
+}
+
+.type-xs-tight {
+  font-size: .75rem;
+  line-height: 1rem;
+}
+
+.type-xs-tight-underline {
+  font-size: .75rem;
+  line-height: 1rem;
+  text-decoration: underline;
+}
+
+.type-xs-mono {
+  font-size: .75rem;
+  line-height: 1.5rem;
+  font-family: Monaco, monospace;
+}
+
+.type-xxs-mono {
+  font-size: .5625rem;
+  line-height: 1rem;
+  font-family: Monaco, monospace;
+}
+
+.geometric-precision-text {
+  text-rendering: geometricPrecision;
+}
+
+:root {
+  --space-0: 0px;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-7: 1.75rem;
+  --space-8: 2rem;
+  --space-9: 2.25rem;
+  --space-10: 2.5rem;
+  --space-11: 2.75rem;
+  --space-12: 3rem;
+  --space-14: 3.5rem;
+  --space-16: 4rem;
+  --space-20: 5rem;
+  --space-24: 6rem;
+  --space-28: 7rem;
+  --space-32: 8rem;
+  --space-36: 9rem;
+  --space-40: 10rem;
+  --space-44: 11rem;
+  --space-48: 12rem;
+  --space-52: 13rem;
+  --space-56: 14rem;
+  --space-60: 15rem;
+  --space-64: 16rem;
+  --space-72: 18rem;
+  --space-80: 20rem;
+  --space-96: 24rem;
+  --space-px: 1px;
+  --space-0.5: 0.125rem;
+  --space-1.5: 0.375rem;
+  --space-2.5: 0.625rem;
+  --space-3.5: 0.875rem;
+  --space--0: 0px;
+  --space--1: -0.25rem;
+  --space--2: -0.5rem;
+  --space--3: -0.75rem;
+  --space--4: -1rem;
+  --space--5: -1.25rem;
+  --space--6: -1.5rem;
+  --space--7: -1.75rem;
+  --space--8: -2rem;
+  --space--9: -2.25rem;
+  --space--10: -2.5rem;
+  --space--11: -2.75rem;
+  --space--12: -3rem;
+  --space--14: -3.5rem;
+  --space--16: -4rem;
+  --space--20: -5rem;
+  --space--24: -6rem;
+  --space--28: -7rem;
+  --space--32: -8rem;
+  --space--36: -9rem;
+  --space--40: -10rem;
+  --space--44: -11rem;
+  --space--48: -12rem;
+  --space--52: -13rem;
+  --space--56: -14rem;
+  --space--60: -15rem;
+  --space--64: -16rem;
+  --space--72: -18rem;
+  --space--80: -20rem;
+  --space--96: -24rem;
+  --space--px: -1px;
+  --space--0.5: -0.125rem;
+  --space--1.5: -0.375rem;
+  --space--2.5: -0.625rem;
+  --space--3.5: -0.875rem;
+  --side-nav-width-collapsed: 122px;
+  --side-nav-width-expanded: 247px;
+  --tab-list-height: 40px;
+  --tab-height: 40px;
+  --tab-border-radius: 8px;
+  --process-offset-top: 40px;
+  --default-animation-duration: 125ms;
+  --default-animation-timing-function: ease-out;
+  --default-animation-settings: var(--default-animation-duration) var(--default-animation-timing-function);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.not-sr-only {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
+.focus\\\\:sr-only:focus {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.focus\\\\:not-sr-only:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
+.pointer-events-none {
+  pointer-events: none;
+}
+
+.pointer-events-auto {
+  pointer-events: auto;
+}
+
+.disabled\\\\:pointer-events-none:disabled {
+  pointer-events: none;
+}
+
+.disabled\\\\:pointer-events-auto:disabled {
+  pointer-events: auto;
+}
+
+.visible {
+  visibility: visible;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.static {
+  position: static;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.sticky {
+  position: -webkit-sticky;
+  position: sticky;
+}
+
+.hover\\\\:static:hover {
+  position: static;
+}
+
+.hover\\\\:fixed:hover {
+  position: fixed;
+}
+
+.hover\\\\:absolute:hover {
+  position: absolute;
+}
+
+.hover\\\\:relative:hover {
+  position: relative;
+}
+
+.hover\\\\:sticky:hover {
+  position: -webkit-sticky;
+  position: sticky;
+}
+
+.inset-0 {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.inset-1 {
+  top: 0.25rem;
+  right: 0.25rem;
+  bottom: 0.25rem;
+  left: 0.25rem;
+}
+
+.inset-2 {
+  top: 0.5rem;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  left: 0.5rem;
+}
+
+.inset-3 {
+  top: 0.75rem;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  left: 0.75rem;
+}
+
+.inset-4 {
+  top: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+}
+
+.inset-5 {
+  top: 1.25rem;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  left: 1.25rem;
+}
+
+.inset-6 {
+  top: 1.5rem;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  left: 1.5rem;
+}
+
+.inset-7 {
+  top: 1.75rem;
+  right: 1.75rem;
+  bottom: 1.75rem;
+  left: 1.75rem;
+}
+
+.inset-8 {
+  top: 2rem;
+  right: 2rem;
+  bottom: 2rem;
+  left: 2rem;
+}
+
+.inset-9 {
+  top: 2.25rem;
+  right: 2.25rem;
+  bottom: 2.25rem;
+  left: 2.25rem;
+}
+
+.inset-10 {
+  top: 2.5rem;
+  right: 2.5rem;
+  bottom: 2.5rem;
+  left: 2.5rem;
+}
+
+.inset-11 {
+  top: 2.75rem;
+  right: 2.75rem;
+  bottom: 2.75rem;
+  left: 2.75rem;
+}
+
+.inset-12 {
+  top: 3rem;
+  right: 3rem;
+  bottom: 3rem;
+  left: 3rem;
+}
+
+.inset-14 {
+  top: 3.5rem;
+  right: 3.5rem;
+  bottom: 3.5rem;
+  left: 3.5rem;
+}
+
+.inset-16 {
+  top: 4rem;
+  right: 4rem;
+  bottom: 4rem;
+  left: 4rem;
+}
+
+.inset-20 {
+  top: 5rem;
+  right: 5rem;
+  bottom: 5rem;
+  left: 5rem;
+}
+
+.inset-24 {
+  top: 6rem;
+  right: 6rem;
+  bottom: 6rem;
+  left: 6rem;
+}
+
+.inset-28 {
+  top: 7rem;
+  right: 7rem;
+  bottom: 7rem;
+  left: 7rem;
+}
+
+.inset-32 {
+  top: 8rem;
+  right: 8rem;
+  bottom: 8rem;
+  left: 8rem;
+}
+
+.inset-36 {
+  top: 9rem;
+  right: 9rem;
+  bottom: 9rem;
+  left: 9rem;
+}
+
+.inset-40 {
+  top: 10rem;
+  right: 10rem;
+  bottom: 10rem;
+  left: 10rem;
+}
+
+.inset-44 {
+  top: 11rem;
+  right: 11rem;
+  bottom: 11rem;
+  left: 11rem;
+}
+
+.inset-48 {
+  top: 12rem;
+  right: 12rem;
+  bottom: 12rem;
+  left: 12rem;
+}
+
+.inset-52 {
+  top: 13rem;
+  right: 13rem;
+  bottom: 13rem;
+  left: 13rem;
+}
+
+.inset-56 {
+  top: 14rem;
+  right: 14rem;
+  bottom: 14rem;
+  left: 14rem;
+}
+
+.inset-60 {
+  top: 15rem;
+  right: 15rem;
+  bottom: 15rem;
+  left: 15rem;
+}
+
+.inset-64 {
+  top: 16rem;
+  right: 16rem;
+  bottom: 16rem;
+  left: 16rem;
+}
+
+.inset-72 {
+  top: 18rem;
+  right: 18rem;
+  bottom: 18rem;
+  left: 18rem;
+}
+
+.inset-80 {
+  top: 20rem;
+  right: 20rem;
+  bottom: 20rem;
+  left: 20rem;
+}
+
+.inset-96 {
+  top: 24rem;
+  right: 24rem;
+  bottom: 24rem;
+  left: 24rem;
+}
+
+.inset-auto {
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+}
+
+.inset-px {
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  left: 1px;
+}
+
+.inset-0\\\\.5 {
+  top: 0.125rem;
+  right: 0.125rem;
+  bottom: 0.125rem;
+  left: 0.125rem;
+}
+
+.inset-1\\\\.5 {
+  top: 0.375rem;
+  right: 0.375rem;
+  bottom: 0.375rem;
+  left: 0.375rem;
+}
+
+.inset-2\\\\.5 {
+  top: 0.625rem;
+  right: 0.625rem;
+  bottom: 0.625rem;
+  left: 0.625rem;
+}
+
+.inset-3\\\\.5 {
+  top: 0.875rem;
+  right: 0.875rem;
+  bottom: 0.875rem;
+  left: 0.875rem;
+}
+
+.-inset-0 {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.-inset-1 {
+  top: -0.25rem;
+  right: -0.25rem;
+  bottom: -0.25rem;
+  left: -0.25rem;
+}
+
+.-inset-2 {
+  top: -0.5rem;
+  right: -0.5rem;
+  bottom: -0.5rem;
+  left: -0.5rem;
+}
+
+.-inset-3 {
+  top: -0.75rem;
+  right: -0.75rem;
+  bottom: -0.75rem;
+  left: -0.75rem;
+}
+
+.-inset-4 {
+  top: -1rem;
+  right: -1rem;
+  bottom: -1rem;
+  left: -1rem;
+}
+
+.-inset-5 {
+  top: -1.25rem;
+  right: -1.25rem;
+  bottom: -1.25rem;
+  left: -1.25rem;
+}
+
+.-inset-6 {
+  top: -1.5rem;
+  right: -1.5rem;
+  bottom: -1.5rem;
+  left: -1.5rem;
+}
+
+.-inset-7 {
+  top: -1.75rem;
+  right: -1.75rem;
+  bottom: -1.75rem;
+  left: -1.75rem;
+}
+
+.-inset-8 {
+  top: -2rem;
+  right: -2rem;
+  bottom: -2rem;
+  left: -2rem;
+}
+
+.-inset-9 {
+  top: -2.25rem;
+  right: -2.25rem;
+  bottom: -2.25rem;
+  left: -2.25rem;
+}
+
+.-inset-10 {
+  top: -2.5rem;
+  right: -2.5rem;
+  bottom: -2.5rem;
+  left: -2.5rem;
+}
+
+.-inset-11 {
+  top: -2.75rem;
+  right: -2.75rem;
+  bottom: -2.75rem;
+  left: -2.75rem;
+}
+
+.-inset-12 {
+  top: -3rem;
+  right: -3rem;
+  bottom: -3rem;
+  left: -3rem;
+}
+
+.-inset-14 {
+  top: -3.5rem;
+  right: -3.5rem;
+  bottom: -3.5rem;
+  left: -3.5rem;
+}
+
+.-inset-16 {
+  top: -4rem;
+  right: -4rem;
+  bottom: -4rem;
+  left: -4rem;
+}
+
+.-inset-20 {
+  top: -5rem;
+  right: -5rem;
+  bottom: -5rem;
+  left: -5rem;
+}
+
+.-inset-24 {
+  top: -6rem;
+  right: -6rem;
+  bottom: -6rem;
+  left: -6rem;
+}
+
+.-inset-28 {
+  top: -7rem;
+  right: -7rem;
+  bottom: -7rem;
+  left: -7rem;
+}
+
+.-inset-32 {
+  top: -8rem;
+  right: -8rem;
+  bottom: -8rem;
+  left: -8rem;
+}
+
+.-inset-36 {
+  top: -9rem;
+  right: -9rem;
+  bottom: -9rem;
+  left: -9rem;
+}
+
+.-inset-40 {
+  top: -10rem;
+  right: -10rem;
+  bottom: -10rem;
+  left: -10rem;
+}
+
+.-inset-44 {
+  top: -11rem;
+  right: -11rem;
+  bottom: -11rem;
+  left: -11rem;
+}
+
+.-inset-48 {
+  top: -12rem;
+  right: -12rem;
+  bottom: -12rem;
+  left: -12rem;
+}
+
+.-inset-52 {
+  top: -13rem;
+  right: -13rem;
+  bottom: -13rem;
+  left: -13rem;
+}
+
+.-inset-56 {
+  top: -14rem;
+  right: -14rem;
+  bottom: -14rem;
+  left: -14rem;
+}
+
+.-inset-60 {
+  top: -15rem;
+  right: -15rem;
+  bottom: -15rem;
+  left: -15rem;
+}
+
+.-inset-64 {
+  top: -16rem;
+  right: -16rem;
+  bottom: -16rem;
+  left: -16rem;
+}
+
+.-inset-72 {
+  top: -18rem;
+  right: -18rem;
+  bottom: -18rem;
+  left: -18rem;
+}
+
+.-inset-80 {
+  top: -20rem;
+  right: -20rem;
+  bottom: -20rem;
+  left: -20rem;
+}
+
+.-inset-96 {
+  top: -24rem;
+  right: -24rem;
+  bottom: -24rem;
+  left: -24rem;
+}
+
+.-inset-px {
+  top: -1px;
+  right: -1px;
+  bottom: -1px;
+  left: -1px;
+}
+
+.-inset-0\\\\.5 {
+  top: -0.125rem;
+  right: -0.125rem;
+  bottom: -0.125rem;
+  left: -0.125rem;
+}
+
+.-inset-1\\\\.5 {
+  top: -0.375rem;
+  right: -0.375rem;
+  bottom: -0.375rem;
+  left: -0.375rem;
+}
+
+.-inset-2\\\\.5 {
+  top: -0.625rem;
+  right: -0.625rem;
+  bottom: -0.625rem;
+  left: -0.625rem;
+}
+
+.-inset-3\\\\.5 {
+  top: -0.875rem;
+  right: -0.875rem;
+  bottom: -0.875rem;
+  left: -0.875rem;
+}
+
+.inset-1\\\\/2 {
+  top: 50%;
+  right: 50%;
+  bottom: 50%;
+  left: 50%;
+}
+
+.inset-1\\\\/3 {
+  top: 33.333333%;
+  right: 33.333333%;
+  bottom: 33.333333%;
+  left: 33.333333%;
+}
+
+.inset-2\\\\/3 {
+  top: 66.666667%;
+  right: 66.666667%;
+  bottom: 66.666667%;
+  left: 66.666667%;
+}
+
+.inset-1\\\\/4 {
+  top: 25%;
+  right: 25%;
+  bottom: 25%;
+  left: 25%;
+}
+
+.inset-2\\\\/4 {
+  top: 50%;
+  right: 50%;
+  bottom: 50%;
+  left: 50%;
+}
+
+.inset-3\\\\/4 {
+  top: 75%;
+  right: 75%;
+  bottom: 75%;
+  left: 75%;
+}
+
+.inset-full {
+  top: 100%;
+  right: 100%;
+  bottom: 100%;
+  left: 100%;
+}
+
+.-inset-1\\\\/2 {
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+}
+
+.-inset-1\\\\/3 {
+  top: -33.333333%;
+  right: -33.333333%;
+  bottom: -33.333333%;
+  left: -33.333333%;
+}
+
+.-inset-2\\\\/3 {
+  top: -66.666667%;
+  right: -66.666667%;
+  bottom: -66.666667%;
+  left: -66.666667%;
+}
+
+.-inset-1\\\\/4 {
+  top: -25%;
+  right: -25%;
+  bottom: -25%;
+  left: -25%;
+}
+
+.-inset-2\\\\/4 {
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+}
+
+.-inset-3\\\\/4 {
+  top: -75%;
+  right: -75%;
+  bottom: -75%;
+  left: -75%;
+}
+
+.-inset-full {
+  top: -100%;
+  right: -100%;
+  bottom: -100%;
+  left: -100%;
+}
+
+.focus\\\\:inset-0:focus {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.focus\\\\:inset-1:focus {
+  top: 0.25rem;
+  right: 0.25rem;
+  bottom: 0.25rem;
+  left: 0.25rem;
+}
+
+.focus\\\\:inset-2:focus {
+  top: 0.5rem;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  left: 0.5rem;
+}
+
+.focus\\\\:inset-3:focus {
+  top: 0.75rem;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  left: 0.75rem;
+}
+
+.focus\\\\:inset-4:focus {
+  top: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+}
+
+.focus\\\\:inset-5:focus {
+  top: 1.25rem;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  left: 1.25rem;
+}
+
+.focus\\\\:inset-6:focus {
+  top: 1.5rem;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  left: 1.5rem;
+}
+
+.focus\\\\:inset-7:focus {
+  top: 1.75rem;
+  right: 1.75rem;
+  bottom: 1.75rem;
+  left: 1.75rem;
+}
+
+.focus\\\\:inset-8:focus {
+  top: 2rem;
+  right: 2rem;
+  bottom: 2rem;
+  left: 2rem;
+}
+
+.focus\\\\:inset-9:focus {
+  top: 2.25rem;
+  right: 2.25rem;
+  bottom: 2.25rem;
+  left: 2.25rem;
+}
+
+.focus\\\\:inset-10:focus {
+  top: 2.5rem;
+  right: 2.5rem;
+  bottom: 2.5rem;
+  left: 2.5rem;
+}
+
+.focus\\\\:inset-11:focus {
+  top: 2.75rem;
+  right: 2.75rem;
+  bottom: 2.75rem;
+  left: 2.75rem;
+}
+
+.focus\\\\:inset-12:focus {
+  top: 3rem;
+  right: 3rem;
+  bottom: 3rem;
+  left: 3rem;
+}
+
+.focus\\\\:inset-14:focus {
+  top: 3.5rem;
+  right: 3.5rem;
+  bottom: 3.5rem;
+  left: 3.5rem;
+}
+
+.focus\\\\:inset-16:focus {
+  top: 4rem;
+  right: 4rem;
+  bottom: 4rem;
+  left: 4rem;
+}
+
+.focus\\\\:inset-20:focus {
+  top: 5rem;
+  right: 5rem;
+  bottom: 5rem;
+  left: 5rem;
+}
+
+.focus\\\\:inset-24:focus {
+  top: 6rem;
+  right: 6rem;
+  bottom: 6rem;
+  left: 6rem;
+}
+
+.focus\\\\:inset-28:focus {
+  top: 7rem;
+  right: 7rem;
+  bottom: 7rem;
+  left: 7rem;
+}
+
+.focus\\\\:inset-32:focus {
+  top: 8rem;
+  right: 8rem;
+  bottom: 8rem;
+  left: 8rem;
+}
+
+.focus\\\\:inset-36:focus {
+  top: 9rem;
+  right: 9rem;
+  bottom: 9rem;
+  left: 9rem;
+}
+
+.focus\\\\:inset-40:focus {
+  top: 10rem;
+  right: 10rem;
+  bottom: 10rem;
+  left: 10rem;
+}
+
+.focus\\\\:inset-44:focus {
+  top: 11rem;
+  right: 11rem;
+  bottom: 11rem;
+  left: 11rem;
+}
+
+.focus\\\\:inset-48:focus {
+  top: 12rem;
+  right: 12rem;
+  bottom: 12rem;
+  left: 12rem;
+}
+
+.focus\\\\:inset-52:focus {
+  top: 13rem;
+  right: 13rem;
+  bottom: 13rem;
+  left: 13rem;
+}
+
+.focus\\\\:inset-56:focus {
+  top: 14rem;
+  right: 14rem;
+  bottom: 14rem;
+  left: 14rem;
+}
+
+.focus\\\\:inset-60:focus {
+  top: 15rem;
+  right: 15rem;
+  bottom: 15rem;
+  left: 15rem;
+}
+
+.focus\\\\:inset-64:focus {
+  top: 16rem;
+  right: 16rem;
+  bottom: 16rem;
+  left: 16rem;
+}
+
+.focus\\\\:inset-72:focus {
+  top: 18rem;
+  right: 18rem;
+  bottom: 18rem;
+  left: 18rem;
+}
+
+.focus\\\\:inset-80:focus {
+  top: 20rem;
+  right: 20rem;
+  bottom: 20rem;
+  left: 20rem;
+}
+
+.focus\\\\:inset-96:focus {
+  top: 24rem;
+  right: 24rem;
+  bottom: 24rem;
+  left: 24rem;
+}
+
+.focus\\\\:inset-auto:focus {
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+}
+
+.focus\\\\:inset-px:focus {
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  left: 1px;
+}
+
+.focus\\\\:inset-0\\\\.5:focus {
+  top: 0.125rem;
+  right: 0.125rem;
+  bottom: 0.125rem;
+  left: 0.125rem;
+}
+
+.focus\\\\:inset-1\\\\.5:focus {
+  top: 0.375rem;
+  right: 0.375rem;
+  bottom: 0.375rem;
+  left: 0.375rem;
+}
+
+.focus\\\\:inset-2\\\\.5:focus {
+  top: 0.625rem;
+  right: 0.625rem;
+  bottom: 0.625rem;
+  left: 0.625rem;
+}
+
+.focus\\\\:inset-3\\\\.5:focus {
+  top: 0.875rem;
+  right: 0.875rem;
+  bottom: 0.875rem;
+  left: 0.875rem;
+}
+
+.focus\\\\:-inset-0:focus {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.focus\\\\:-inset-1:focus {
+  top: -0.25rem;
+  right: -0.25rem;
+  bottom: -0.25rem;
+  left: -0.25rem;
+}
+
+.focus\\\\:-inset-2:focus {
+  top: -0.5rem;
+  right: -0.5rem;
+  bottom: -0.5rem;
+  left: -0.5rem;
+}
+
+.focus\\\\:-inset-3:focus {
+  top: -0.75rem;
+  right: -0.75rem;
+  bottom: -0.75rem;
+  left: -0.75rem;
+}
+
+.focus\\\\:-inset-4:focus {
+  top: -1rem;
+  right: -1rem;
+  bottom: -1rem;
+  left: -1rem;
+}
+
+.focus\\\\:-inset-5:focus {
+  top: -1.25rem;
+  right: -1.25rem;
+  bottom: -1.25rem;
+  left: -1.25rem;
+}
+
+.focus\\\\:-inset-6:focus {
+  top: -1.5rem;
+  right: -1.5rem;
+  bottom: -1.5rem;
+  left: -1.5rem;
+}
+
+.focus\\\\:-inset-7:focus {
+  top: -1.75rem;
+  right: -1.75rem;
+  bottom: -1.75rem;
+  left: -1.75rem;
+}
+
+.focus\\\\:-inset-8:focus {
+  top: -2rem;
+  right: -2rem;
+  bottom: -2rem;
+  left: -2rem;
+}
+
+.focus\\\\:-inset-9:focus {
+  top: -2.25rem;
+  right: -2.25rem;
+  bottom: -2.25rem;
+  left: -2.25rem;
+}
+
+.focus\\\\:-inset-10:focus {
+  top: -2.5rem;
+  right: -2.5rem;
+  bottom: -2.5rem;
+  left: -2.5rem;
+}
+
+.focus\\\\:-inset-11:focus {
+  top: -2.75rem;
+  right: -2.75rem;
+  bottom: -2.75rem;
+  left: -2.75rem;
+}
+
+.focus\\\\:-inset-12:focus {
+  top: -3rem;
+  right: -3rem;
+  bottom: -3rem;
+  left: -3rem;
+}
+
+.focus\\\\:-inset-14:focus {
+  top: -3.5rem;
+  right: -3.5rem;
+  bottom: -3.5rem;
+  left: -3.5rem;
+}
+
+.focus\\\\:-inset-16:focus {
+  top: -4rem;
+  right: -4rem;
+  bottom: -4rem;
+  left: -4rem;
+}
+
+.focus\\\\:-inset-20:focus {
+  top: -5rem;
+  right: -5rem;
+  bottom: -5rem;
+  left: -5rem;
+}
+
+.focus\\\\:-inset-24:focus {
+  top: -6rem;
+  right: -6rem;
+  bottom: -6rem;
+  left: -6rem;
+}
+
+.focus\\\\:-inset-28:focus {
+  top: -7rem;
+  right: -7rem;
+  bottom: -7rem;
+  left: -7rem;
+}
+
+.focus\\\\:-inset-32:focus {
+  top: -8rem;
+  right: -8rem;
+  bottom: -8rem;
+  left: -8rem;
+}
+
+.focus\\\\:-inset-36:focus {
+  top: -9rem;
+  right: -9rem;
+  bottom: -9rem;
+  left: -9rem;
+}
+
+.focus\\\\:-inset-40:focus {
+  top: -10rem;
+  right: -10rem;
+  bottom: -10rem;
+  left: -10rem;
+}
+
+.focus\\\\:-inset-44:focus {
+  top: -11rem;
+  right: -11rem;
+  bottom: -11rem;
+  left: -11rem;
+}
+
+.focus\\\\:-inset-48:focus {
+  top: -12rem;
+  right: -12rem;
+  bottom: -12rem;
+  left: -12rem;
+}
+
+.focus\\\\:-inset-52:focus {
+  top: -13rem;
+  right: -13rem;
+  bottom: -13rem;
+  left: -13rem;
+}
+
+.focus\\\\:-inset-56:focus {
+  top: -14rem;
+  right: -14rem;
+  bottom: -14rem;
+  left: -14rem;
+}
+
+.focus\\\\:-inset-60:focus {
+  top: -15rem;
+  right: -15rem;
+  bottom: -15rem;
+  left: -15rem;
+}
+
+.focus\\\\:-inset-64:focus {
+  top: -16rem;
+  right: -16rem;
+  bottom: -16rem;
+  left: -16rem;
+}
+
+.focus\\\\:-inset-72:focus {
+  top: -18rem;
+  right: -18rem;
+  bottom: -18rem;
+  left: -18rem;
+}
+
+.focus\\\\:-inset-80:focus {
+  top: -20rem;
+  right: -20rem;
+  bottom: -20rem;
+  left: -20rem;
+}
+
+.focus\\\\:-inset-96:focus {
+  top: -24rem;
+  right: -24rem;
+  bottom: -24rem;
+  left: -24rem;
+}
+
+.focus\\\\:-inset-px:focus {
+  top: -1px;
+  right: -1px;
+  bottom: -1px;
+  left: -1px;
+}
+
+.focus\\\\:-inset-0\\\\.5:focus {
+  top: -0.125rem;
+  right: -0.125rem;
+  bottom: -0.125rem;
+  left: -0.125rem;
+}
+
+.focus\\\\:-inset-1\\\\.5:focus {
+  top: -0.375rem;
+  right: -0.375rem;
+  bottom: -0.375rem;
+  left: -0.375rem;
+}
+
+.focus\\\\:-inset-2\\\\.5:focus {
+  top: -0.625rem;
+  right: -0.625rem;
+  bottom: -0.625rem;
+  left: -0.625rem;
+}
+
+.focus\\\\:-inset-3\\\\.5:focus {
+  top: -0.875rem;
+  right: -0.875rem;
+  bottom: -0.875rem;
+  left: -0.875rem;
+}
+
+.focus\\\\:inset-1\\\\/2:focus {
+  top: 50%;
+  right: 50%;
+  bottom: 50%;
+  left: 50%;
+}
+
+.focus\\\\:inset-1\\\\/3:focus {
+  top: 33.333333%;
+  right: 33.333333%;
+  bottom: 33.333333%;
+  left: 33.333333%;
+}
+
+.focus\\\\:inset-2\\\\/3:focus {
+  top: 66.666667%;
+  right: 66.666667%;
+  bottom: 66.666667%;
+  left: 66.666667%;
+}
+
+.focus\\\\:inset-1\\\\/4:focus {
+  top: 25%;
+  right: 25%;
+  bottom: 25%;
+  left: 25%;
+}
+
+.focus\\\\:inset-2\\\\/4:focus {
+  top: 50%;
+  right: 50%;
+  bottom: 50%;
+  left: 50%;
+}
+
+.focus\\\\:inset-3\\\\/4:focus {
+  top: 75%;
+  right: 75%;
+  bottom: 75%;
+  left: 75%;
+}
+
+.focus\\\\:inset-full:focus {
+  top: 100%;
+  right: 100%;
+  bottom: 100%;
+  left: 100%;
+}
+
+.focus\\\\:-inset-1\\\\/2:focus {
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+}
+
+.focus\\\\:-inset-1\\\\/3:focus {
+  top: -33.333333%;
+  right: -33.333333%;
+  bottom: -33.333333%;
+  left: -33.333333%;
+}
+
+.focus\\\\:-inset-2\\\\/3:focus {
+  top: -66.666667%;
+  right: -66.666667%;
+  bottom: -66.666667%;
+  left: -66.666667%;
+}
+
+.focus\\\\:-inset-1\\\\/4:focus {
+  top: -25%;
+  right: -25%;
+  bottom: -25%;
+  left: -25%;
+}
+
+.focus\\\\:-inset-2\\\\/4:focus {
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+}
+
+.focus\\\\:-inset-3\\\\/4:focus {
+  top: -75%;
+  right: -75%;
+  bottom: -75%;
+  left: -75%;
+}
+
+.focus\\\\:-inset-full:focus {
+  top: -100%;
+  right: -100%;
+  bottom: -100%;
+  left: -100%;
+}
+
+.inset-x-0 {
+  left: 0px;
+  right: 0px;
+}
+
+.inset-x-1 {
+  left: 0.25rem;
+  right: 0.25rem;
+}
+
+.inset-x-2 {
+  left: 0.5rem;
+  right: 0.5rem;
+}
+
+.inset-x-3 {
+  left: 0.75rem;
+  right: 0.75rem;
+}
+
+.inset-x-4 {
+  left: 1rem;
+  right: 1rem;
+}
+
+.inset-x-5 {
+  left: 1.25rem;
+  right: 1.25rem;
+}
+
+.inset-x-6 {
+  left: 1.5rem;
+  right: 1.5rem;
+}
+
+.inset-x-7 {
+  left: 1.75rem;
+  right: 1.75rem;
+}
+
+.inset-x-8 {
+  left: 2rem;
+  right: 2rem;
+}
+
+.inset-x-9 {
+  left: 2.25rem;
+  right: 2.25rem;
+}
+
+.inset-x-10 {
+  left: 2.5rem;
+  right: 2.5rem;
+}
+
+.inset-x-11 {
+  left: 2.75rem;
+  right: 2.75rem;
+}
+
+.inset-x-12 {
+  left: 3rem;
+  right: 3rem;
+}
+
+.inset-x-14 {
+  left: 3.5rem;
+  right: 3.5rem;
+}
+
+.inset-x-16 {
+  left: 4rem;
+  right: 4rem;
+}
+
+.inset-x-20 {
+  left: 5rem;
+  right: 5rem;
+}
+
+.inset-x-24 {
+  left: 6rem;
+  right: 6rem;
+}
+
+.inset-x-28 {
+  left: 7rem;
+  right: 7rem;
+}
+
+.inset-x-32 {
+  left: 8rem;
+  right: 8rem;
+}
+
+.inset-x-36 {
+  left: 9rem;
+  right: 9rem;
+}
+
+.inset-x-40 {
+  left: 10rem;
+  right: 10rem;
+}
+
+.inset-x-44 {
+  left: 11rem;
+  right: 11rem;
+}
+
+.inset-x-48 {
+  left: 12rem;
+  right: 12rem;
+}
+
+.inset-x-52 {
+  left: 13rem;
+  right: 13rem;
+}
+
+.inset-x-56 {
+  left: 14rem;
+  right: 14rem;
+}
+
+.inset-x-60 {
+  left: 15rem;
+  right: 15rem;
+}
+
+.inset-x-64 {
+  left: 16rem;
+  right: 16rem;
+}
+
+.inset-x-72 {
+  left: 18rem;
+  right: 18rem;
+}
+
+.inset-x-80 {
+  left: 20rem;
+  right: 20rem;
+}
+
+.inset-x-96 {
+  left: 24rem;
+  right: 24rem;
+}
+
+.inset-x-auto {
+  left: auto;
+  right: auto;
+}
+
+.inset-x-px {
+  left: 1px;
+  right: 1px;
+}
+
+.inset-x-0\\\\.5 {
+  left: 0.125rem;
+  right: 0.125rem;
+}
+
+.inset-x-1\\\\.5 {
+  left: 0.375rem;
+  right: 0.375rem;
+}
+
+.inset-x-2\\\\.5 {
+  left: 0.625rem;
+  right: 0.625rem;
+}
+
+.inset-x-3\\\\.5 {
+  left: 0.875rem;
+  right: 0.875rem;
+}
+
+.-inset-x-0 {
+  left: 0px;
+  right: 0px;
+}
+
+.-inset-x-1 {
+  left: -0.25rem;
+  right: -0.25rem;
+}
+
+.-inset-x-2 {
+  left: -0.5rem;
+  right: -0.5rem;
+}
+
+.-inset-x-3 {
+  left: -0.75rem;
+  right: -0.75rem;
+}
+
+.-inset-x-4 {
+  left: -1rem;
+  right: -1rem;
+}
+
+.-inset-x-5 {
+  left: -1.25rem;
+  right: -1.25rem;
+}
+
+.-inset-x-6 {
+  left: -1.5rem;
+  right: -1.5rem;
+}
+
+.-inset-x-7 {
+  left: -1.75rem;
+  right: -1.75rem;
+}
+
+.-inset-x-8 {
+  left: -2rem;
+  right: -2rem;
+}
+
+.-inset-x-9 {
+  left: -2.25rem;
+  right: -2.25rem;
+}
+
+.-inset-x-10 {
+  left: -2.5rem;
+  right: -2.5rem;
+}
+
+.-inset-x-11 {
+  left: -2.75rem;
+  right: -2.75rem;
+}
+
+.-inset-x-12 {
+  left: -3rem;
+  right: -3rem;
+}
+
+.-inset-x-14 {
+  left: -3.5rem;
+  right: -3.5rem;
+}
+
+.-inset-x-16 {
+  left: -4rem;
+  right: -4rem;
+}
+
+.-inset-x-20 {
+  left: -5rem;
+  right: -5rem;
+}
+
+.-inset-x-24 {
+  left: -6rem;
+  right: -6rem;
+}
+
+.-inset-x-28 {
+  left: -7rem;
+  right: -7rem;
+}
+
+.-inset-x-32 {
+  left: -8rem;
+  right: -8rem;
+}
+
+.-inset-x-36 {
+  left: -9rem;
+  right: -9rem;
+}
+
+.-inset-x-40 {
+  left: -10rem;
+  right: -10rem;
+}
+
+.-inset-x-44 {
+  left: -11rem;
+  right: -11rem;
+}
+
+.-inset-x-48 {
+  left: -12rem;
+  right: -12rem;
+}
+
+.-inset-x-52 {
+  left: -13rem;
+  right: -13rem;
+}
+
+.-inset-x-56 {
+  left: -14rem;
+  right: -14rem;
+}
+
+.-inset-x-60 {
+  left: -15rem;
+  right: -15rem;
+}
+
+.-inset-x-64 {
+  left: -16rem;
+  right: -16rem;
+}
+
+.-inset-x-72 {
+  left: -18rem;
+  right: -18rem;
+}
+
+.-inset-x-80 {
+  left: -20rem;
+  right: -20rem;
+}
+
+.-inset-x-96 {
+  left: -24rem;
+  right: -24rem;
+}
+
+.-inset-x-px {
+  left: -1px;
+  right: -1px;
+}
+
+.-inset-x-0\\\\.5 {
+  left: -0.125rem;
+  right: -0.125rem;
+}
+
+.-inset-x-1\\\\.5 {
+  left: -0.375rem;
+  right: -0.375rem;
+}
+
+.-inset-x-2\\\\.5 {
+  left: -0.625rem;
+  right: -0.625rem;
+}
+
+.-inset-x-3\\\\.5 {
+  left: -0.875rem;
+  right: -0.875rem;
+}
+
+.inset-x-1\\\\/2 {
+  left: 50%;
+  right: 50%;
+}
+
+.inset-x-1\\\\/3 {
+  left: 33.333333%;
+  right: 33.333333%;
+}
+
+.inset-x-2\\\\/3 {
+  left: 66.666667%;
+  right: 66.666667%;
+}
+
+.inset-x-1\\\\/4 {
+  left: 25%;
+  right: 25%;
+}
+
+.inset-x-2\\\\/4 {
+  left: 50%;
+  right: 50%;
+}
+
+.inset-x-3\\\\/4 {
+  left: 75%;
+  right: 75%;
+}
+
+.inset-x-full {
+  left: 100%;
+  right: 100%;
+}
+
+.-inset-x-1\\\\/2 {
+  left: -50%;
+  right: -50%;
+}
+
+.-inset-x-1\\\\/3 {
+  left: -33.333333%;
+  right: -33.333333%;
+}
+
+.-inset-x-2\\\\/3 {
+  left: -66.666667%;
+  right: -66.666667%;
+}
+
+.-inset-x-1\\\\/4 {
+  left: -25%;
+  right: -25%;
+}
+
+.-inset-x-2\\\\/4 {
+  left: -50%;
+  right: -50%;
+}
+
+.-inset-x-3\\\\/4 {
+  left: -75%;
+  right: -75%;
+}
+
+.-inset-x-full {
+  left: -100%;
+  right: -100%;
+}
+
+.inset-y-0 {
+  top: 0px;
+  bottom: 0px;
+}
+
+.inset-y-1 {
+  top: 0.25rem;
+  bottom: 0.25rem;
+}
+
+.inset-y-2 {
+  top: 0.5rem;
+  bottom: 0.5rem;
+}
+
+.inset-y-3 {
+  top: 0.75rem;
+  bottom: 0.75rem;
+}
+
+.inset-y-4 {
+  top: 1rem;
+  bottom: 1rem;
+}
+
+.inset-y-5 {
+  top: 1.25rem;
+  bottom: 1.25rem;
+}
+
+.inset-y-6 {
+  top: 1.5rem;
+  bottom: 1.5rem;
+}
+
+.inset-y-7 {
+  top: 1.75rem;
+  bottom: 1.75rem;
+}
+
+.inset-y-8 {
+  top: 2rem;
+  bottom: 2rem;
+}
+
+.inset-y-9 {
+  top: 2.25rem;
+  bottom: 2.25rem;
+}
+
+.inset-y-10 {
+  top: 2.5rem;
+  bottom: 2.5rem;
+}
+
+.inset-y-11 {
+  top: 2.75rem;
+  bottom: 2.75rem;
+}
+
+.inset-y-12 {
+  top: 3rem;
+  bottom: 3rem;
+}
+
+.inset-y-14 {
+  top: 3.5rem;
+  bottom: 3.5rem;
+}
+
+.inset-y-16 {
+  top: 4rem;
+  bottom: 4rem;
+}
+
+.inset-y-20 {
+  top: 5rem;
+  bottom: 5rem;
+}
+
+.inset-y-24 {
+  top: 6rem;
+  bottom: 6rem;
+}
+
+.inset-y-28 {
+  top: 7rem;
+  bottom: 7rem;
+}
+
+.inset-y-32 {
+  top: 8rem;
+  bottom: 8rem;
+}
+
+.inset-y-36 {
+  top: 9rem;
+  bottom: 9rem;
+}
+
+.inset-y-40 {
+  top: 10rem;
+  bottom: 10rem;
+}
+
+.inset-y-44 {
+  top: 11rem;
+  bottom: 11rem;
+}
+
+.inset-y-48 {
+  top: 12rem;
+  bottom: 12rem;
+}
+
+.inset-y-52 {
+  top: 13rem;
+  bottom: 13rem;
+}
+
+.inset-y-56 {
+  top: 14rem;
+  bottom: 14rem;
+}
+
+.inset-y-60 {
+  top: 15rem;
+  bottom: 15rem;
+}
+
+.inset-y-64 {
+  top: 16rem;
+  bottom: 16rem;
+}
+
+.inset-y-72 {
+  top: 18rem;
+  bottom: 18rem;
+}
+
+.inset-y-80 {
+  top: 20rem;
+  bottom: 20rem;
+}
+
+.inset-y-96 {
+  top: 24rem;
+  bottom: 24rem;
+}
+
+.inset-y-auto {
+  top: auto;
+  bottom: auto;
+}
+
+.inset-y-px {
+  top: 1px;
+  bottom: 1px;
+}
+
+.inset-y-0\\\\.5 {
+  top: 0.125rem;
+  bottom: 0.125rem;
+}
+
+.inset-y-1\\\\.5 {
+  top: 0.375rem;
+  bottom: 0.375rem;
+}
+
+.inset-y-2\\\\.5 {
+  top: 0.625rem;
+  bottom: 0.625rem;
+}
+
+.inset-y-3\\\\.5 {
+  top: 0.875rem;
+  bottom: 0.875rem;
+}
+
+.-inset-y-0 {
+  top: 0px;
+  bottom: 0px;
+}
+
+.-inset-y-1 {
+  top: -0.25rem;
+  bottom: -0.25rem;
+}
+
+.-inset-y-2 {
+  top: -0.5rem;
+  bottom: -0.5rem;
+}
+
+.-inset-y-3 {
+  top: -0.75rem;
+  bottom: -0.75rem;
+}
+
+.-inset-y-4 {
+  top: -1rem;
+  bottom: -1rem;
+}
+
+.-inset-y-5 {
+  top: -1.25rem;
+  bottom: -1.25rem;
+}
+
+.-inset-y-6 {
+  top: -1.5rem;
+  bottom: -1.5rem;
+}
+
+.-inset-y-7 {
+  top: -1.75rem;
+  bottom: -1.75rem;
+}
+
+.-inset-y-8 {
+  top: -2rem;
+  bottom: -2rem;
+}
+
+.-inset-y-9 {
+  top: -2.25rem;
+  bottom: -2.25rem;
+}
+
+.-inset-y-10 {
+  top: -2.5rem;
+  bottom: -2.5rem;
+}
+
+.-inset-y-11 {
+  top: -2.75rem;
+  bottom: -2.75rem;
+}
+
+.-inset-y-12 {
+  top: -3rem;
+  bottom: -3rem;
+}
+
+.-inset-y-14 {
+  top: -3.5rem;
+  bottom: -3.5rem;
+}
+
+.-inset-y-16 {
+  top: -4rem;
+  bottom: -4rem;
+}
+
+.-inset-y-20 {
+  top: -5rem;
+  bottom: -5rem;
+}
+
+.-inset-y-24 {
+  top: -6rem;
+  bottom: -6rem;
+}
+
+.-inset-y-28 {
+  top: -7rem;
+  bottom: -7rem;
+}
+
+.-inset-y-32 {
+  top: -8rem;
+  bottom: -8rem;
+}
+
+.-inset-y-36 {
+  top: -9rem;
+  bottom: -9rem;
+}
+
+.-inset-y-40 {
+  top: -10rem;
+  bottom: -10rem;
+}
+
+.-inset-y-44 {
+  top: -11rem;
+  bottom: -11rem;
+}
+
+.-inset-y-48 {
+  top: -12rem;
+  bottom: -12rem;
+}
+
+.-inset-y-52 {
+  top: -13rem;
+  bottom: -13rem;
+}
+
+.-inset-y-56 {
+  top: -14rem;
+  bottom: -14rem;
+}
+
+.-inset-y-60 {
+  top: -15rem;
+  bottom: -15rem;
+}
+
+.-inset-y-64 {
+  top: -16rem;
+  bottom: -16rem;
+}
+
+.-inset-y-72 {
+  top: -18rem;
+  bottom: -18rem;
+}
+
+.-inset-y-80 {
+  top: -20rem;
+  bottom: -20rem;
+}
+
+.-inset-y-96 {
+  top: -24rem;
+  bottom: -24rem;
+}
+
+.-inset-y-px {
+  top: -1px;
+  bottom: -1px;
+}
+
+.-inset-y-0\\\\.5 {
+  top: -0.125rem;
+  bottom: -0.125rem;
+}
+
+.-inset-y-1\\\\.5 {
+  top: -0.375rem;
+  bottom: -0.375rem;
+}
+
+.-inset-y-2\\\\.5 {
+  top: -0.625rem;
+  bottom: -0.625rem;
+}
+
+.-inset-y-3\\\\.5 {
+  top: -0.875rem;
+  bottom: -0.875rem;
+}
+
+.inset-y-1\\\\/2 {
+  top: 50%;
+  bottom: 50%;
+}
+
+.inset-y-1\\\\/3 {
+  top: 33.333333%;
+  bottom: 33.333333%;
+}
+
+.inset-y-2\\\\/3 {
+  top: 66.666667%;
+  bottom: 66.666667%;
+}
+
+.inset-y-1\\\\/4 {
+  top: 25%;
+  bottom: 25%;
+}
+
+.inset-y-2\\\\/4 {
+  top: 50%;
+  bottom: 50%;
+}
+
+.inset-y-3\\\\/4 {
+  top: 75%;
+  bottom: 75%;
+}
+
+.inset-y-full {
+  top: 100%;
+  bottom: 100%;
+}
+
+.-inset-y-1\\\\/2 {
+  top: -50%;
+  bottom: -50%;
+}
+
+.-inset-y-1\\\\/3 {
+  top: -33.333333%;
+  bottom: -33.333333%;
+}
+
+.-inset-y-2\\\\/3 {
+  top: -66.666667%;
+  bottom: -66.666667%;
+}
+
+.-inset-y-1\\\\/4 {
+  top: -25%;
+  bottom: -25%;
+}
+
+.-inset-y-2\\\\/4 {
+  top: -50%;
+  bottom: -50%;
+}
+
+.-inset-y-3\\\\/4 {
+  top: -75%;
+  bottom: -75%;
+}
+
+.-inset-y-full {
+  top: -100%;
+  bottom: -100%;
+}
+
+.focus\\\\:inset-x-0:focus {
+  left: 0px;
+  right: 0px;
+}
+
+.focus\\\\:inset-x-1:focus {
+  left: 0.25rem;
+  right: 0.25rem;
+}
+
+.focus\\\\:inset-x-2:focus {
+  left: 0.5rem;
+  right: 0.5rem;
+}
+
+.focus\\\\:inset-x-3:focus {
+  left: 0.75rem;
+  right: 0.75rem;
+}
+
+.focus\\\\:inset-x-4:focus {
+  left: 1rem;
+  right: 1rem;
+}
+
+.focus\\\\:inset-x-5:focus {
+  left: 1.25rem;
+  right: 1.25rem;
+}
+
+.focus\\\\:inset-x-6:focus {
+  left: 1.5rem;
+  right: 1.5rem;
+}
+
+.focus\\\\:inset-x-7:focus {
+  left: 1.75rem;
+  right: 1.75rem;
+}
+
+.focus\\\\:inset-x-8:focus {
+  left: 2rem;
+  right: 2rem;
+}
+
+.focus\\\\:inset-x-9:focus {
+  left: 2.25rem;
+  right: 2.25rem;
+}
+
+.focus\\\\:inset-x-10:focus {
+  left: 2.5rem;
+  right: 2.5rem;
+}
+
+.focus\\\\:inset-x-11:focus {
+  left: 2.75rem;
+  right: 2.75rem;
+}
+
+.focus\\\\:inset-x-12:focus {
+  left: 3rem;
+  right: 3rem;
+}
+
+.focus\\\\:inset-x-14:focus {
+  left: 3.5rem;
+  right: 3.5rem;
+}
+
+.focus\\\\:inset-x-16:focus {
+  left: 4rem;
+  right: 4rem;
+}
+
+.focus\\\\:inset-x-20:focus {
+  left: 5rem;
+  right: 5rem;
+}
+
+.focus\\\\:inset-x-24:focus {
+  left: 6rem;
+  right: 6rem;
+}
+
+.focus\\\\:inset-x-28:focus {
+  left: 7rem;
+  right: 7rem;
+}
+
+.focus\\\\:inset-x-32:focus {
+  left: 8rem;
+  right: 8rem;
+}
+
+.focus\\\\:inset-x-36:focus {
+  left: 9rem;
+  right: 9rem;
+}
+
+.focus\\\\:inset-x-40:focus {
+  left: 10rem;
+  right: 10rem;
+}
+
+.focus\\\\:inset-x-44:focus {
+  left: 11rem;
+  right: 11rem;
+}
+
+.focus\\\\:inset-x-48:focus {
+  left: 12rem;
+  right: 12rem;
+}
+
+.focus\\\\:inset-x-52:focus {
+  left: 13rem;
+  right: 13rem;
+}
+
+.focus\\\\:inset-x-56:focus {
+  left: 14rem;
+  right: 14rem;
+}
+
+.focus\\\\:inset-x-60:focus {
+  left: 15rem;
+  right: 15rem;
+}
+
+.focus\\\\:inset-x-64:focus {
+  left: 16rem;
+  right: 16rem;
+}
+
+.focus\\\\:inset-x-72:focus {
+  left: 18rem;
+  right: 18rem;
+}
+
+.focus\\\\:inset-x-80:focus {
+  left: 20rem;
+  right: 20rem;
+}
+
+.focus\\\\:inset-x-96:focus {
+  left: 24rem;
+  right: 24rem;
+}
+
+.focus\\\\:inset-x-auto:focus {
+  left: auto;
+  right: auto;
+}
+
+.focus\\\\:inset-x-px:focus {
+  left: 1px;
+  right: 1px;
+}
+
+.focus\\\\:inset-x-0\\\\.5:focus {
+  left: 0.125rem;
+  right: 0.125rem;
+}
+
+.focus\\\\:inset-x-1\\\\.5:focus {
+  left: 0.375rem;
+  right: 0.375rem;
+}
+
+.focus\\\\:inset-x-2\\\\.5:focus {
+  left: 0.625rem;
+  right: 0.625rem;
+}
+
+.focus\\\\:inset-x-3\\\\.5:focus {
+  left: 0.875rem;
+  right: 0.875rem;
+}
+
+.focus\\\\:-inset-x-0:focus {
+  left: 0px;
+  right: 0px;
+}
+
+.focus\\\\:-inset-x-1:focus {
+  left: -0.25rem;
+  right: -0.25rem;
+}
+
+.focus\\\\:-inset-x-2:focus {
+  left: -0.5rem;
+  right: -0.5rem;
+}
+
+.focus\\\\:-inset-x-3:focus {
+  left: -0.75rem;
+  right: -0.75rem;
+}
+
+.focus\\\\:-inset-x-4:focus {
+  left: -1rem;
+  right: -1rem;
+}
+
+.focus\\\\:-inset-x-5:focus {
+  left: -1.25rem;
+  right: -1.25rem;
+}
+
+.focus\\\\:-inset-x-6:focus {
+  left: -1.5rem;
+  right: -1.5rem;
+}
+
+.focus\\\\:-inset-x-7:focus {
+  left: -1.75rem;
+  right: -1.75rem;
+}
+
+.focus\\\\:-inset-x-8:focus {
+  left: -2rem;
+  right: -2rem;
+}
+
+.focus\\\\:-inset-x-9:focus {
+  left: -2.25rem;
+  right: -2.25rem;
+}
+
+.focus\\\\:-inset-x-10:focus {
+  left: -2.5rem;
+  right: -2.5rem;
+}
+
+.focus\\\\:-inset-x-11:focus {
+  left: -2.75rem;
+  right: -2.75rem;
+}
+
+.focus\\\\:-inset-x-12:focus {
+  left: -3rem;
+  right: -3rem;
+}
+
+.focus\\\\:-inset-x-14:focus {
+  left: -3.5rem;
+  right: -3.5rem;
+}
+
+.focus\\\\:-inset-x-16:focus {
+  left: -4rem;
+  right: -4rem;
+}
+
+.focus\\\\:-inset-x-20:focus {
+  left: -5rem;
+  right: -5rem;
+}
+
+.focus\\\\:-inset-x-24:focus {
+  left: -6rem;
+  right: -6rem;
+}
+
+.focus\\\\:-inset-x-28:focus {
+  left: -7rem;
+  right: -7rem;
+}
+
+.focus\\\\:-inset-x-32:focus {
+  left: -8rem;
+  right: -8rem;
+}
+
+.focus\\\\:-inset-x-36:focus {
+  left: -9rem;
+  right: -9rem;
+}
+
+.focus\\\\:-inset-x-40:focus {
+  left: -10rem;
+  right: -10rem;
+}
+
+.focus\\\\:-inset-x-44:focus {
+  left: -11rem;
+  right: -11rem;
+}
+
+.focus\\\\:-inset-x-48:focus {
+  left: -12rem;
+  right: -12rem;
+}
+
+.focus\\\\:-inset-x-52:focus {
+  left: -13rem;
+  right: -13rem;
+}
+
+.focus\\\\:-inset-x-56:focus {
+  left: -14rem;
+  right: -14rem;
+}
+
+.focus\\\\:-inset-x-60:focus {
+  left: -15rem;
+  right: -15rem;
+}
+
+.focus\\\\:-inset-x-64:focus {
+  left: -16rem;
+  right: -16rem;
+}
+
+.focus\\\\:-inset-x-72:focus {
+  left: -18rem;
+  right: -18rem;
+}
+
+.focus\\\\:-inset-x-80:focus {
+  left: -20rem;
+  right: -20rem;
+}
+
+.focus\\\\:-inset-x-96:focus {
+  left: -24rem;
+  right: -24rem;
+}
+
+.focus\\\\:-inset-x-px:focus {
+  left: -1px;
+  right: -1px;
+}
+
+.focus\\\\:-inset-x-0\\\\.5:focus {
+  left: -0.125rem;
+  right: -0.125rem;
+}
+
+.focus\\\\:-inset-x-1\\\\.5:focus {
+  left: -0.375rem;
+  right: -0.375rem;
+}
+
+.focus\\\\:-inset-x-2\\\\.5:focus {
+  left: -0.625rem;
+  right: -0.625rem;
+}
+
+.focus\\\\:-inset-x-3\\\\.5:focus {
+  left: -0.875rem;
+  right: -0.875rem;
+}
+
+.focus\\\\:inset-x-1\\\\/2:focus {
+  left: 50%;
+  right: 50%;
+}
+
+.focus\\\\:inset-x-1\\\\/3:focus {
+  left: 33.333333%;
+  right: 33.333333%;
+}
+
+.focus\\\\:inset-x-2\\\\/3:focus {
+  left: 66.666667%;
+  right: 66.666667%;
+}
+
+.focus\\\\:inset-x-1\\\\/4:focus {
+  left: 25%;
+  right: 25%;
+}
+
+.focus\\\\:inset-x-2\\\\/4:focus {
+  left: 50%;
+  right: 50%;
+}
+
+.focus\\\\:inset-x-3\\\\/4:focus {
+  left: 75%;
+  right: 75%;
+}
+
+.focus\\\\:inset-x-full:focus {
+  left: 100%;
+  right: 100%;
+}
+
+.focus\\\\:-inset-x-1\\\\/2:focus {
+  left: -50%;
+  right: -50%;
+}
+
+.focus\\\\:-inset-x-1\\\\/3:focus {
+  left: -33.333333%;
+  right: -33.333333%;
+}
+
+.focus\\\\:-inset-x-2\\\\/3:focus {
+  left: -66.666667%;
+  right: -66.666667%;
+}
+
+.focus\\\\:-inset-x-1\\\\/4:focus {
+  left: -25%;
+  right: -25%;
+}
+
+.focus\\\\:-inset-x-2\\\\/4:focus {
+  left: -50%;
+  right: -50%;
+}
+
+.focus\\\\:-inset-x-3\\\\/4:focus {
+  left: -75%;
+  right: -75%;
+}
+
+.focus\\\\:-inset-x-full:focus {
+  left: -100%;
+  right: -100%;
+}
+
+.focus\\\\:inset-y-0:focus {
+  top: 0px;
+  bottom: 0px;
+}
+
+.focus\\\\:inset-y-1:focus {
+  top: 0.25rem;
+  bottom: 0.25rem;
+}
+
+.focus\\\\:inset-y-2:focus {
+  top: 0.5rem;
+  bottom: 0.5rem;
+}
+
+.focus\\\\:inset-y-3:focus {
+  top: 0.75rem;
+  bottom: 0.75rem;
+}
+
+.focus\\\\:inset-y-4:focus {
+  top: 1rem;
+  bottom: 1rem;
+}
+
+.focus\\\\:inset-y-5:focus {
+  top: 1.25rem;
+  bottom: 1.25rem;
+}
+
+.focus\\\\:inset-y-6:focus {
+  top: 1.5rem;
+  bottom: 1.5rem;
+}
+
+.focus\\\\:inset-y-7:focus {
+  top: 1.75rem;
+  bottom: 1.75rem;
+}
+
+.focus\\\\:inset-y-8:focus {
+  top: 2rem;
+  bottom: 2rem;
+}
+
+.focus\\\\:inset-y-9:focus {
+  top: 2.25rem;
+  bottom: 2.25rem;
+}
+
+.focus\\\\:inset-y-10:focus {
+  top: 2.5rem;
+  bottom: 2.5rem;
+}
+
+.focus\\\\:inset-y-11:focus {
+  top: 2.75rem;
+  bottom: 2.75rem;
+}
+
+.focus\\\\:inset-y-12:focus {
+  top: 3rem;
+  bottom: 3rem;
+}
+
+.focus\\\\:inset-y-14:focus {
+  top: 3.5rem;
+  bottom: 3.5rem;
+}
+
+.focus\\\\:inset-y-16:focus {
+  top: 4rem;
+  bottom: 4rem;
+}
+
+.focus\\\\:inset-y-20:focus {
+  top: 5rem;
+  bottom: 5rem;
+}
+
+.focus\\\\:inset-y-24:focus {
+  top: 6rem;
+  bottom: 6rem;
+}
+
+.focus\\\\:inset-y-28:focus {
+  top: 7rem;
+  bottom: 7rem;
+}
+
+.focus\\\\:inset-y-32:focus {
+  top: 8rem;
+  bottom: 8rem;
+}
+
+.focus\\\\:inset-y-36:focus {
+  top: 9rem;
+  bottom: 9rem;
+}
+
+.focus\\\\:inset-y-40:focus {
+  top: 10rem;
+  bottom: 10rem;
+}
+
+.focus\\\\:inset-y-44:focus {
+  top: 11rem;
+  bottom: 11rem;
+}
+
+.focus\\\\:inset-y-48:focus {
+  top: 12rem;
+  bottom: 12rem;
+}
+
+.focus\\\\:inset-y-52:focus {
+  top: 13rem;
+  bottom: 13rem;
+}
+
+.focus\\\\:inset-y-56:focus {
+  top: 14rem;
+  bottom: 14rem;
+}
+
+.focus\\\\:inset-y-60:focus {
+  top: 15rem;
+  bottom: 15rem;
+}
+
+.focus\\\\:inset-y-64:focus {
+  top: 16rem;
+  bottom: 16rem;
+}
+
+.focus\\\\:inset-y-72:focus {
+  top: 18rem;
+  bottom: 18rem;
+}
+
+.focus\\\\:inset-y-80:focus {
+  top: 20rem;
+  bottom: 20rem;
+}
+
+.focus\\\\:inset-y-96:focus {
+  top: 24rem;
+  bottom: 24rem;
+}
+
+.focus\\\\:inset-y-auto:focus {
+  top: auto;
+  bottom: auto;
+}
+
+.focus\\\\:inset-y-px:focus {
+  top: 1px;
+  bottom: 1px;
+}
+
+.focus\\\\:inset-y-0\\\\.5:focus {
+  top: 0.125rem;
+  bottom: 0.125rem;
+}
+
+.focus\\\\:inset-y-1\\\\.5:focus {
+  top: 0.375rem;
+  bottom: 0.375rem;
+}
+
+.focus\\\\:inset-y-2\\\\.5:focus {
+  top: 0.625rem;
+  bottom: 0.625rem;
+}
+
+.focus\\\\:inset-y-3\\\\.5:focus {
+  top: 0.875rem;
+  bottom: 0.875rem;
+}
+
+.focus\\\\:-inset-y-0:focus {
+  top: 0px;
+  bottom: 0px;
+}
+
+.focus\\\\:-inset-y-1:focus {
+  top: -0.25rem;
+  bottom: -0.25rem;
+}
+
+.focus\\\\:-inset-y-2:focus {
+  top: -0.5rem;
+  bottom: -0.5rem;
+}
+
+.focus\\\\:-inset-y-3:focus {
+  top: -0.75rem;
+  bottom: -0.75rem;
+}
+
+.focus\\\\:-inset-y-4:focus {
+  top: -1rem;
+  bottom: -1rem;
+}
+
+.focus\\\\:-inset-y-5:focus {
+  top: -1.25rem;
+  bottom: -1.25rem;
+}
+
+.focus\\\\:-inset-y-6:focus {
+  top: -1.5rem;
+  bottom: -1.5rem;
+}
+
+.focus\\\\:-inset-y-7:focus {
+  top: -1.75rem;
+  bottom: -1.75rem;
+}
+
+.focus\\\\:-inset-y-8:focus {
+  top: -2rem;
+  bottom: -2rem;
+}
+
+.focus\\\\:-inset-y-9:focus {
+  top: -2.25rem;
+  bottom: -2.25rem;
+}
+
+.focus\\\\:-inset-y-10:focus {
+  top: -2.5rem;
+  bottom: -2.5rem;
+}
+
+.focus\\\\:-inset-y-11:focus {
+  top: -2.75rem;
+  bottom: -2.75rem;
+}
+
+.focus\\\\:-inset-y-12:focus {
+  top: -3rem;
+  bottom: -3rem;
+}
+
+.focus\\\\:-inset-y-14:focus {
+  top: -3.5rem;
+  bottom: -3.5rem;
+}
+
+.focus\\\\:-inset-y-16:focus {
+  top: -4rem;
+  bottom: -4rem;
+}
+
+.focus\\\\:-inset-y-20:focus {
+  top: -5rem;
+  bottom: -5rem;
+}
+
+.focus\\\\:-inset-y-24:focus {
+  top: -6rem;
+  bottom: -6rem;
+}
+
+.focus\\\\:-inset-y-28:focus {
+  top: -7rem;
+  bottom: -7rem;
+}
+
+.focus\\\\:-inset-y-32:focus {
+  top: -8rem;
+  bottom: -8rem;
+}
+
+.focus\\\\:-inset-y-36:focus {
+  top: -9rem;
+  bottom: -9rem;
+}
+
+.focus\\\\:-inset-y-40:focus {
+  top: -10rem;
+  bottom: -10rem;
+}
+
+.focus\\\\:-inset-y-44:focus {
+  top: -11rem;
+  bottom: -11rem;
+}
+
+.focus\\\\:-inset-y-48:focus {
+  top: -12rem;
+  bottom: -12rem;
+}
+
+.focus\\\\:-inset-y-52:focus {
+  top: -13rem;
+  bottom: -13rem;
+}
+
+.focus\\\\:-inset-y-56:focus {
+  top: -14rem;
+  bottom: -14rem;
+}
+
+.focus\\\\:-inset-y-60:focus {
+  top: -15rem;
+  bottom: -15rem;
+}
+
+.focus\\\\:-inset-y-64:focus {
+  top: -16rem;
+  bottom: -16rem;
+}
+
+.focus\\\\:-inset-y-72:focus {
+  top: -18rem;
+  bottom: -18rem;
+}
+
+.focus\\\\:-inset-y-80:focus {
+  top: -20rem;
+  bottom: -20rem;
+}
+
+.focus\\\\:-inset-y-96:focus {
+  top: -24rem;
+  bottom: -24rem;
+}
+
+.focus\\\\:-inset-y-px:focus {
+  top: -1px;
+  bottom: -1px;
+}
+
+.focus\\\\:-inset-y-0\\\\.5:focus {
+  top: -0.125rem;
+  bottom: -0.125rem;
+}
+
+.focus\\\\:-inset-y-1\\\\.5:focus {
+  top: -0.375rem;
+  bottom: -0.375rem;
+}
+
+.focus\\\\:-inset-y-2\\\\.5:focus {
+  top: -0.625rem;
+  bottom: -0.625rem;
+}
+
+.focus\\\\:-inset-y-3\\\\.5:focus {
+  top: -0.875rem;
+  bottom: -0.875rem;
+}
+
+.focus\\\\:inset-y-1\\\\/2:focus {
+  top: 50%;
+  bottom: 50%;
+}
+
+.focus\\\\:inset-y-1\\\\/3:focus {
+  top: 33.333333%;
+  bottom: 33.333333%;
+}
+
+.focus\\\\:inset-y-2\\\\/3:focus {
+  top: 66.666667%;
+  bottom: 66.666667%;
+}
+
+.focus\\\\:inset-y-1\\\\/4:focus {
+  top: 25%;
+  bottom: 25%;
+}
+
+.focus\\\\:inset-y-2\\\\/4:focus {
+  top: 50%;
+  bottom: 50%;
+}
+
+.focus\\\\:inset-y-3\\\\/4:focus {
+  top: 75%;
+  bottom: 75%;
+}
+
+.focus\\\\:inset-y-full:focus {
+  top: 100%;
+  bottom: 100%;
+}
+
+.focus\\\\:-inset-y-1\\\\/2:focus {
+  top: -50%;
+  bottom: -50%;
+}
+
+.focus\\\\:-inset-y-1\\\\/3:focus {
+  top: -33.333333%;
+  bottom: -33.333333%;
+}
+
+.focus\\\\:-inset-y-2\\\\/3:focus {
+  top: -66.666667%;
+  bottom: -66.666667%;
+}
+
+.focus\\\\:-inset-y-1\\\\/4:focus {
+  top: -25%;
+  bottom: -25%;
+}
+
+.focus\\\\:-inset-y-2\\\\/4:focus {
+  top: -50%;
+  bottom: -50%;
+}
+
+.focus\\\\:-inset-y-3\\\\/4:focus {
+  top: -75%;
+  bottom: -75%;
+}
+
+.focus\\\\:-inset-y-full:focus {
+  top: -100%;
+  bottom: -100%;
+}
+
+.top-0 {
+  top: 0px;
+}
+
+.top-1 {
+  top: 0.25rem;
+}
+
+.top-2 {
+  top: 0.5rem;
+}
+
+.top-3 {
+  top: 0.75rem;
+}
+
+.top-4 {
+  top: 1rem;
+}
+
+.top-5 {
+  top: 1.25rem;
+}
+
+.top-6 {
+  top: 1.5rem;
+}
+
+.top-7 {
+  top: 1.75rem;
+}
+
+.top-8 {
+  top: 2rem;
+}
+
+.top-9 {
+  top: 2.25rem;
+}
+
+.top-10 {
+  top: 2.5rem;
+}
+
+.top-11 {
+  top: 2.75rem;
+}
+
+.top-12 {
+  top: 3rem;
+}
+
+.top-14 {
+  top: 3.5rem;
+}
+
+.top-16 {
+  top: 4rem;
+}
+
+.top-20 {
+  top: 5rem;
+}
+
+.top-24 {
+  top: 6rem;
+}
+
+.top-28 {
+  top: 7rem;
+}
+
+.top-32 {
+  top: 8rem;
+}
+
+.top-36 {
+  top: 9rem;
+}
+
+.top-40 {
+  top: 10rem;
+}
+
+.top-44 {
+  top: 11rem;
+}
+
+.top-48 {
+  top: 12rem;
+}
+
+.top-52 {
+  top: 13rem;
+}
+
+.top-56 {
+  top: 14rem;
+}
+
+.top-60 {
+  top: 15rem;
+}
+
+.top-64 {
+  top: 16rem;
+}
+
+.top-72 {
+  top: 18rem;
+}
+
+.top-80 {
+  top: 20rem;
+}
+
+.top-96 {
+  top: 24rem;
+}
+
+.top-auto {
+  top: auto;
+}
+
+.top-px {
+  top: 1px;
+}
+
+.top-0\\\\.5 {
+  top: 0.125rem;
+}
+
+.top-1\\\\.5 {
+  top: 0.375rem;
+}
+
+.top-2\\\\.5 {
+  top: 0.625rem;
+}
+
+.top-3\\\\.5 {
+  top: 0.875rem;
+}
+
+.-top-0 {
+  top: 0px;
+}
+
+.-top-1 {
+  top: -0.25rem;
+}
+
+.-top-2 {
+  top: -0.5rem;
+}
+
+.-top-3 {
+  top: -0.75rem;
+}
+
+.-top-4 {
+  top: -1rem;
+}
+
+.-top-5 {
+  top: -1.25rem;
+}
+
+.-top-6 {
+  top: -1.5rem;
+}
+
+.-top-7 {
+  top: -1.75rem;
+}
+
+.-top-8 {
+  top: -2rem;
+}
+
+.-top-9 {
+  top: -2.25rem;
+}
+
+.-top-10 {
+  top: -2.5rem;
+}
+
+.-top-11 {
+  top: -2.75rem;
+}
+
+.-top-12 {
+  top: -3rem;
+}
+
+.-top-14 {
+  top: -3.5rem;
+}
+
+.-top-16 {
+  top: -4rem;
+}
+
+.-top-20 {
+  top: -5rem;
+}
+
+.-top-24 {
+  top: -6rem;
+}
+
+.-top-28 {
+  top: -7rem;
+}
+
+.-top-32 {
+  top: -8rem;
+}
+
+.-top-36 {
+  top: -9rem;
+}
+
+.-top-40 {
+  top: -10rem;
+}
+
+.-top-44 {
+  top: -11rem;
+}
+
+.-top-48 {
+  top: -12rem;
+}
+
+.-top-52 {
+  top: -13rem;
+}
+
+.-top-56 {
+  top: -14rem;
+}
+
+.-top-60 {
+  top: -15rem;
+}
+
+.-top-64 {
+  top: -16rem;
+}
+
+.-top-72 {
+  top: -18rem;
+}
+
+.-top-80 {
+  top: -20rem;
+}
+
+.-top-96 {
+  top: -24rem;
+}
+
+.-top-px {
+  top: -1px;
+}
+
+.-top-0\\\\.5 {
+  top: -0.125rem;
+}
+
+.-top-1\\\\.5 {
+  top: -0.375rem;
+}
+
+.-top-2\\\\.5 {
+  top: -0.625rem;
+}
+
+.-top-3\\\\.5 {
+  top: -0.875rem;
+}
+
+.top-1\\\\/2 {
+  top: 50%;
+}
+
+.top-1\\\\/3 {
+  top: 33.333333%;
+}
+
+.top-2\\\\/3 {
+  top: 66.666667%;
+}
+
+.top-1\\\\/4 {
+  top: 25%;
+}
+
+.top-2\\\\/4 {
+  top: 50%;
+}
+
+.top-3\\\\/4 {
+  top: 75%;
+}
+
+.top-full {
+  top: 100%;
+}
+
+.-top-1\\\\/2 {
+  top: -50%;
+}
+
+.-top-1\\\\/3 {
+  top: -33.333333%;
+}
+
+.-top-2\\\\/3 {
+  top: -66.666667%;
+}
+
+.-top-1\\\\/4 {
+  top: -25%;
+}
+
+.-top-2\\\\/4 {
+  top: -50%;
+}
+
+.-top-3\\\\/4 {
+  top: -75%;
+}
+
+.-top-full {
+  top: -100%;
+}
+
+.right-0 {
+  right: 0px;
+}
+
+.right-1 {
+  right: 0.25rem;
+}
+
+.right-2 {
+  right: 0.5rem;
+}
+
+.right-3 {
+  right: 0.75rem;
+}
+
+.right-4 {
+  right: 1rem;
+}
+
+.right-5 {
+  right: 1.25rem;
+}
+
+.right-6 {
+  right: 1.5rem;
+}
+
+.right-7 {
+  right: 1.75rem;
+}
+
+.right-8 {
+  right: 2rem;
+}
+
+.right-9 {
+  right: 2.25rem;
+}
+
+.right-10 {
+  right: 2.5rem;
+}
+
+.right-11 {
+  right: 2.75rem;
+}
+
+.right-12 {
+  right: 3rem;
+}
+
+.right-14 {
+  right: 3.5rem;
+}
+
+.right-16 {
+  right: 4rem;
+}
+
+.right-20 {
+  right: 5rem;
+}
+
+.right-24 {
+  right: 6rem;
+}
+
+.right-28 {
+  right: 7rem;
+}
+
+.right-32 {
+  right: 8rem;
+}
+
+.right-36 {
+  right: 9rem;
+}
+
+.right-40 {
+  right: 10rem;
+}
+
+.right-44 {
+  right: 11rem;
+}
+
+.right-48 {
+  right: 12rem;
+}
+
+.right-52 {
+  right: 13rem;
+}
+
+.right-56 {
+  right: 14rem;
+}
+
+.right-60 {
+  right: 15rem;
+}
+
+.right-64 {
+  right: 16rem;
+}
+
+.right-72 {
+  right: 18rem;
+}
+
+.right-80 {
+  right: 20rem;
+}
+
+.right-96 {
+  right: 24rem;
+}
+
+.right-auto {
+  right: auto;
+}
+
+.right-px {
+  right: 1px;
+}
+
+.right-0\\\\.5 {
+  right: 0.125rem;
+}
+
+.right-1\\\\.5 {
+  right: 0.375rem;
+}
+
+.right-2\\\\.5 {
+  right: 0.625rem;
+}
+
+.right-3\\\\.5 {
+  right: 0.875rem;
+}
+
+.-right-0 {
+  right: 0px;
+}
+
+.-right-1 {
+  right: -0.25rem;
+}
+
+.-right-2 {
+  right: -0.5rem;
+}
+
+.-right-3 {
+  right: -0.75rem;
+}
+
+.-right-4 {
+  right: -1rem;
+}
+
+.-right-5 {
+  right: -1.25rem;
+}
+
+.-right-6 {
+  right: -1.5rem;
+}
+
+.-right-7 {
+  right: -1.75rem;
+}
+
+.-right-8 {
+  right: -2rem;
+}
+
+.-right-9 {
+  right: -2.25rem;
+}
+
+.-right-10 {
+  right: -2.5rem;
+}
+
+.-right-11 {
+  right: -2.75rem;
+}
+
+.-right-12 {
+  right: -3rem;
+}
+
+.-right-14 {
+  right: -3.5rem;
+}
+
+.-right-16 {
+  right: -4rem;
+}
+
+.-right-20 {
+  right: -5rem;
+}
+
+.-right-24 {
+  right: -6rem;
+}
+
+.-right-28 {
+  right: -7rem;
+}
+
+.-right-32 {
+  right: -8rem;
+}
+
+.-right-36 {
+  right: -9rem;
+}
+
+.-right-40 {
+  right: -10rem;
+}
+
+.-right-44 {
+  right: -11rem;
+}
+
+.-right-48 {
+  right: -12rem;
+}
+
+.-right-52 {
+  right: -13rem;
+}
+
+.-right-56 {
+  right: -14rem;
+}
+
+.-right-60 {
+  right: -15rem;
+}
+
+.-right-64 {
+  right: -16rem;
+}
+
+.-right-72 {
+  right: -18rem;
+}
+
+.-right-80 {
+  right: -20rem;
+}
+
+.-right-96 {
+  right: -24rem;
+}
+
+.-right-px {
+  right: -1px;
+}
+
+.-right-0\\\\.5 {
+  right: -0.125rem;
+}
+
+.-right-1\\\\.5 {
+  right: -0.375rem;
+}
+
+.-right-2\\\\.5 {
+  right: -0.625rem;
+}
+
+.-right-3\\\\.5 {
+  right: -0.875rem;
+}
+
+.right-1\\\\/2 {
+  right: 50%;
+}
+
+.right-1\\\\/3 {
+  right: 33.333333%;
+}
+
+.right-2\\\\/3 {
+  right: 66.666667%;
+}
+
+.right-1\\\\/4 {
+  right: 25%;
+}
+
+.right-2\\\\/4 {
+  right: 50%;
+}
+
+.right-3\\\\/4 {
+  right: 75%;
+}
+
+.right-full {
+  right: 100%;
+}
+
+.-right-1\\\\/2 {
+  right: -50%;
+}
+
+.-right-1\\\\/3 {
+  right: -33.333333%;
+}
+
+.-right-2\\\\/3 {
+  right: -66.666667%;
+}
+
+.-right-1\\\\/4 {
+  right: -25%;
+}
+
+.-right-2\\\\/4 {
+  right: -50%;
+}
+
+.-right-3\\\\/4 {
+  right: -75%;
+}
+
+.-right-full {
+  right: -100%;
+}
+
+.bottom-0 {
+  bottom: 0px;
+}
+
+.bottom-1 {
+  bottom: 0.25rem;
+}
+
+.bottom-2 {
+  bottom: 0.5rem;
+}
+
+.bottom-3 {
+  bottom: 0.75rem;
+}
+
+.bottom-4 {
+  bottom: 1rem;
+}
+
+.bottom-5 {
+  bottom: 1.25rem;
+}
+
+.bottom-6 {
+  bottom: 1.5rem;
+}
+
+.bottom-7 {
+  bottom: 1.75rem;
+}
+
+.bottom-8 {
+  bottom: 2rem;
+}
+
+.bottom-9 {
+  bottom: 2.25rem;
+}
+
+.bottom-10 {
+  bottom: 2.5rem;
+}
+
+.bottom-11 {
+  bottom: 2.75rem;
+}
+
+.bottom-12 {
+  bottom: 3rem;
+}
+
+.bottom-14 {
+  bottom: 3.5rem;
+}
+
+.bottom-16 {
+  bottom: 4rem;
+}
+
+.bottom-20 {
+  bottom: 5rem;
+}
+
+.bottom-24 {
+  bottom: 6rem;
+}
+
+.bottom-28 {
+  bottom: 7rem;
+}
+
+.bottom-32 {
+  bottom: 8rem;
+}
+
+.bottom-36 {
+  bottom: 9rem;
+}
+
+.bottom-40 {
+  bottom: 10rem;
+}
+
+.bottom-44 {
+  bottom: 11rem;
+}
+
+.bottom-48 {
+  bottom: 12rem;
+}
+
+.bottom-52 {
+  bottom: 13rem;
+}
+
+.bottom-56 {
+  bottom: 14rem;
+}
+
+.bottom-60 {
+  bottom: 15rem;
+}
+
+.bottom-64 {
+  bottom: 16rem;
+}
+
+.bottom-72 {
+  bottom: 18rem;
+}
+
+.bottom-80 {
+  bottom: 20rem;
+}
+
+.bottom-96 {
+  bottom: 24rem;
+}
+
+.bottom-auto {
+  bottom: auto;
+}
+
+.bottom-px {
+  bottom: 1px;
+}
+
+.bottom-0\\\\.5 {
+  bottom: 0.125rem;
+}
+
+.bottom-1\\\\.5 {
+  bottom: 0.375rem;
+}
+
+.bottom-2\\\\.5 {
+  bottom: 0.625rem;
+}
+
+.bottom-3\\\\.5 {
+  bottom: 0.875rem;
+}
+
+.-bottom-0 {
+  bottom: 0px;
+}
+
+.-bottom-1 {
+  bottom: -0.25rem;
+}
+
+.-bottom-2 {
+  bottom: -0.5rem;
+}
+
+.-bottom-3 {
+  bottom: -0.75rem;
+}
+
+.-bottom-4 {
+  bottom: -1rem;
+}
+
+.-bottom-5 {
+  bottom: -1.25rem;
+}
+
+.-bottom-6 {
+  bottom: -1.5rem;
+}
+
+.-bottom-7 {
+  bottom: -1.75rem;
+}
+
+.-bottom-8 {
+  bottom: -2rem;
+}
+
+.-bottom-9 {
+  bottom: -2.25rem;
+}
+
+.-bottom-10 {
+  bottom: -2.5rem;
+}
+
+.-bottom-11 {
+  bottom: -2.75rem;
+}
+
+.-bottom-12 {
+  bottom: -3rem;
+}
+
+.-bottom-14 {
+  bottom: -3.5rem;
+}
+
+.-bottom-16 {
+  bottom: -4rem;
+}
+
+.-bottom-20 {
+  bottom: -5rem;
+}
+
+.-bottom-24 {
+  bottom: -6rem;
+}
+
+.-bottom-28 {
+  bottom: -7rem;
+}
+
+.-bottom-32 {
+  bottom: -8rem;
+}
+
+.-bottom-36 {
+  bottom: -9rem;
+}
+
+.-bottom-40 {
+  bottom: -10rem;
+}
+
+.-bottom-44 {
+  bottom: -11rem;
+}
+
+.-bottom-48 {
+  bottom: -12rem;
+}
+
+.-bottom-52 {
+  bottom: -13rem;
+}
+
+.-bottom-56 {
+  bottom: -14rem;
+}
+
+.-bottom-60 {
+  bottom: -15rem;
+}
+
+.-bottom-64 {
+  bottom: -16rem;
+}
+
+.-bottom-72 {
+  bottom: -18rem;
+}
+
+.-bottom-80 {
+  bottom: -20rem;
+}
+
+.-bottom-96 {
+  bottom: -24rem;
+}
+
+.-bottom-px {
+  bottom: -1px;
+}
+
+.-bottom-0\\\\.5 {
+  bottom: -0.125rem;
+}
+
+.-bottom-1\\\\.5 {
+  bottom: -0.375rem;
+}
+
+.-bottom-2\\\\.5 {
+  bottom: -0.625rem;
+}
+
+.-bottom-3\\\\.5 {
+  bottom: -0.875rem;
+}
+
+.bottom-1\\\\/2 {
+  bottom: 50%;
+}
+
+.bottom-1\\\\/3 {
+  bottom: 33.333333%;
+}
+
+.bottom-2\\\\/3 {
+  bottom: 66.666667%;
+}
+
+.bottom-1\\\\/4 {
+  bottom: 25%;
+}
+
+.bottom-2\\\\/4 {
+  bottom: 50%;
+}
+
+.bottom-3\\\\/4 {
+  bottom: 75%;
+}
+
+.bottom-full {
+  bottom: 100%;
+}
+
+.-bottom-1\\\\/2 {
+  bottom: -50%;
+}
+
+.-bottom-1\\\\/3 {
+  bottom: -33.333333%;
+}
+
+.-bottom-2\\\\/3 {
+  bottom: -66.666667%;
+}
+
+.-bottom-1\\\\/4 {
+  bottom: -25%;
+}
+
+.-bottom-2\\\\/4 {
+  bottom: -50%;
+}
+
+.-bottom-3\\\\/4 {
+  bottom: -75%;
+}
+
+.-bottom-full {
+  bottom: -100%;
+}
+
+.left-0 {
+  left: 0px;
+}
+
+.left-1 {
+  left: 0.25rem;
+}
+
+.left-2 {
+  left: 0.5rem;
+}
+
+.left-3 {
+  left: 0.75rem;
+}
+
+.left-4 {
+  left: 1rem;
+}
+
+.left-5 {
+  left: 1.25rem;
+}
+
+.left-6 {
+  left: 1.5rem;
+}
+
+.left-7 {
+  left: 1.75rem;
+}
+
+.left-8 {
+  left: 2rem;
+}
+
+.left-9 {
+  left: 2.25rem;
+}
+
+.left-10 {
+  left: 2.5rem;
+}
+
+.left-11 {
+  left: 2.75rem;
+}
+
+.left-12 {
+  left: 3rem;
+}
+
+.left-14 {
+  left: 3.5rem;
+}
+
+.left-16 {
+  left: 4rem;
+}
+
+.left-20 {
+  left: 5rem;
+}
+
+.left-24 {
+  left: 6rem;
+}
+
+.left-28 {
+  left: 7rem;
+}
+
+.left-32 {
+  left: 8rem;
+}
+
+.left-36 {
+  left: 9rem;
+}
+
+.left-40 {
+  left: 10rem;
+}
+
+.left-44 {
+  left: 11rem;
+}
+
+.left-48 {
+  left: 12rem;
+}
+
+.left-52 {
+  left: 13rem;
+}
+
+.left-56 {
+  left: 14rem;
+}
+
+.left-60 {
+  left: 15rem;
+}
+
+.left-64 {
+  left: 16rem;
+}
+
+.left-72 {
+  left: 18rem;
+}
+
+.left-80 {
+  left: 20rem;
+}
+
+.left-96 {
+  left: 24rem;
+}
+
+.left-auto {
+  left: auto;
+}
+
+.left-px {
+  left: 1px;
+}
+
+.left-0\\\\.5 {
+  left: 0.125rem;
+}
+
+.left-1\\\\.5 {
+  left: 0.375rem;
+}
+
+.left-2\\\\.5 {
+  left: 0.625rem;
+}
+
+.left-3\\\\.5 {
+  left: 0.875rem;
+}
+
+.-left-0 {
+  left: 0px;
+}
+
+.-left-1 {
+  left: -0.25rem;
+}
+
+.-left-2 {
+  left: -0.5rem;
+}
+
+.-left-3 {
+  left: -0.75rem;
+}
+
+.-left-4 {
+  left: -1rem;
+}
+
+.-left-5 {
+  left: -1.25rem;
+}
+
+.-left-6 {
+  left: -1.5rem;
+}
+
+.-left-7 {
+  left: -1.75rem;
+}
+
+.-left-8 {
+  left: -2rem;
+}
+
+.-left-9 {
+  left: -2.25rem;
+}
+
+.-left-10 {
+  left: -2.5rem;
+}
+
+.-left-11 {
+  left: -2.75rem;
+}
+
+.-left-12 {
+  left: -3rem;
+}
+
+.-left-14 {
+  left: -3.5rem;
+}
+
+.-left-16 {
+  left: -4rem;
+}
+
+.-left-20 {
+  left: -5rem;
+}
+
+.-left-24 {
+  left: -6rem;
+}
+
+.-left-28 {
+  left: -7rem;
+}
+
+.-left-32 {
+  left: -8rem;
+}
+
+.-left-36 {
+  left: -9rem;
+}
+
+.-left-40 {
+  left: -10rem;
+}
+
+.-left-44 {
+  left: -11rem;
+}
+
+.-left-48 {
+  left: -12rem;
+}
+
+.-left-52 {
+  left: -13rem;
+}
+
+.-left-56 {
+  left: -14rem;
+}
+
+.-left-60 {
+  left: -15rem;
+}
+
+.-left-64 {
+  left: -16rem;
+}
+
+.-left-72 {
+  left: -18rem;
+}
+
+.-left-80 {
+  left: -20rem;
+}
+
+.-left-96 {
+  left: -24rem;
+}
+
+.-left-px {
+  left: -1px;
+}
+
+.-left-0\\\\.5 {
+  left: -0.125rem;
+}
+
+.-left-1\\\\.5 {
+  left: -0.375rem;
+}
+
+.-left-2\\\\.5 {
+  left: -0.625rem;
+}
+
+.-left-3\\\\.5 {
+  left: -0.875rem;
+}
+
+.left-1\\\\/2 {
+  left: 50%;
+}
+
+.left-1\\\\/3 {
+  left: 33.333333%;
+}
+
+.left-2\\\\/3 {
+  left: 66.666667%;
+}
+
+.left-1\\\\/4 {
+  left: 25%;
+}
+
+.left-2\\\\/4 {
+  left: 50%;
+}
+
+.left-3\\\\/4 {
+  left: 75%;
+}
+
+.left-full {
+  left: 100%;
+}
+
+.-left-1\\\\/2 {
+  left: -50%;
+}
+
+.-left-1\\\\/3 {
+  left: -33.333333%;
+}
+
+.-left-2\\\\/3 {
+  left: -66.666667%;
+}
+
+.-left-1\\\\/4 {
+  left: -25%;
+}
+
+.-left-2\\\\/4 {
+  left: -50%;
+}
+
+.-left-3\\\\/4 {
+  left: -75%;
+}
+
+.-left-full {
+  left: -100%;
+}
+
+.focus\\\\:top-0:focus {
+  top: 0px;
+}
+
+.focus\\\\:top-1:focus {
+  top: 0.25rem;
+}
+
+.focus\\\\:top-2:focus {
+  top: 0.5rem;
+}
+
+.focus\\\\:top-3:focus {
+  top: 0.75rem;
+}
+
+.focus\\\\:top-4:focus {
+  top: 1rem;
+}
+
+.focus\\\\:top-5:focus {
+  top: 1.25rem;
+}
+
+.focus\\\\:top-6:focus {
+  top: 1.5rem;
+}
+
+.focus\\\\:top-7:focus {
+  top: 1.75rem;
+}
+
+.focus\\\\:top-8:focus {
+  top: 2rem;
+}
+
+.focus\\\\:top-9:focus {
+  top: 2.25rem;
+}
+
+.focus\\\\:top-10:focus {
+  top: 2.5rem;
+}
+
+.focus\\\\:top-11:focus {
+  top: 2.75rem;
+}
+
+.focus\\\\:top-12:focus {
+  top: 3rem;
+}
+
+.focus\\\\:top-14:focus {
+  top: 3.5rem;
+}
+
+.focus\\\\:top-16:focus {
+  top: 4rem;
+}
+
+.focus\\\\:top-20:focus {
+  top: 5rem;
+}
+
+.focus\\\\:top-24:focus {
+  top: 6rem;
+}
+
+.focus\\\\:top-28:focus {
+  top: 7rem;
+}
+
+.focus\\\\:top-32:focus {
+  top: 8rem;
+}
+
+.focus\\\\:top-36:focus {
+  top: 9rem;
+}
+
+.focus\\\\:top-40:focus {
+  top: 10rem;
+}
+
+.focus\\\\:top-44:focus {
+  top: 11rem;
+}
+
+.focus\\\\:top-48:focus {
+  top: 12rem;
+}
+
+.focus\\\\:top-52:focus {
+  top: 13rem;
+}
+
+.focus\\\\:top-56:focus {
+  top: 14rem;
+}
+
+.focus\\\\:top-60:focus {
+  top: 15rem;
+}
+
+.focus\\\\:top-64:focus {
+  top: 16rem;
+}
+
+.focus\\\\:top-72:focus {
+  top: 18rem;
+}
+
+.focus\\\\:top-80:focus {
+  top: 20rem;
+}
+
+.focus\\\\:top-96:focus {
+  top: 24rem;
+}
+
+.focus\\\\:top-auto:focus {
+  top: auto;
+}
+
+.focus\\\\:top-px:focus {
+  top: 1px;
+}
+
+.focus\\\\:top-0\\\\.5:focus {
+  top: 0.125rem;
+}
+
+.focus\\\\:top-1\\\\.5:focus {
+  top: 0.375rem;
+}
+
+.focus\\\\:top-2\\\\.5:focus {
+  top: 0.625rem;
+}
+
+.focus\\\\:top-3\\\\.5:focus {
+  top: 0.875rem;
+}
+
+.focus\\\\:-top-0:focus {
+  top: 0px;
+}
+
+.focus\\\\:-top-1:focus {
+  top: -0.25rem;
+}
+
+.focus\\\\:-top-2:focus {
+  top: -0.5rem;
+}
+
+.focus\\\\:-top-3:focus {
+  top: -0.75rem;
+}
+
+.focus\\\\:-top-4:focus {
+  top: -1rem;
+}
+
+.focus\\\\:-top-5:focus {
+  top: -1.25rem;
+}
+
+.focus\\\\:-top-6:focus {
+  top: -1.5rem;
+}
+
+.focus\\\\:-top-7:focus {
+  top: -1.75rem;
+}
+
+.focus\\\\:-top-8:focus {
+  top: -2rem;
+}
+
+.focus\\\\:-top-9:focus {
+  top: -2.25rem;
+}
+
+.focus\\\\:-top-10:focus {
+  top: -2.5rem;
+}
+
+.focus\\\\:-top-11:focus {
+  top: -2.75rem;
+}
+
+.focus\\\\:-top-12:focus {
+  top: -3rem;
+}
+
+.focus\\\\:-top-14:focus {
+  top: -3.5rem;
+}
+
+.focus\\\\:-top-16:focus {
+  top: -4rem;
+}
+
+.focus\\\\:-top-20:focus {
+  top: -5rem;
+}
+
+.focus\\\\:-top-24:focus {
+  top: -6rem;
+}
+
+.focus\\\\:-top-28:focus {
+  top: -7rem;
+}
+
+.focus\\\\:-top-32:focus {
+  top: -8rem;
+}
+
+.focus\\\\:-top-36:focus {
+  top: -9rem;
+}
+
+.focus\\\\:-top-40:focus {
+  top: -10rem;
+}
+
+.focus\\\\:-top-44:focus {
+  top: -11rem;
+}
+
+.focus\\\\:-top-48:focus {
+  top: -12rem;
+}
+
+.focus\\\\:-top-52:focus {
+  top: -13rem;
+}
+
+.focus\\\\:-top-56:focus {
+  top: -14rem;
+}
+
+.focus\\\\:-top-60:focus {
+  top: -15rem;
+}
+
+.focus\\\\:-top-64:focus {
+  top: -16rem;
+}
+
+.focus\\\\:-top-72:focus {
+  top: -18rem;
+}
+
+.focus\\\\:-top-80:focus {
+  top: -20rem;
+}
+
+.focus\\\\:-top-96:focus {
+  top: -24rem;
+}
+
+.focus\\\\:-top-px:focus {
+  top: -1px;
+}
+
+.focus\\\\:-top-0\\\\.5:focus {
+  top: -0.125rem;
+}
+
+.focus\\\\:-top-1\\\\.5:focus {
+  top: -0.375rem;
+}
+
+.focus\\\\:-top-2\\\\.5:focus {
+  top: -0.625rem;
+}
+
+.focus\\\\:-top-3\\\\.5:focus {
+  top: -0.875rem;
+}
+
+.focus\\\\:top-1\\\\/2:focus {
+  top: 50%;
+}
+
+.focus\\\\:top-1\\\\/3:focus {
+  top: 33.333333%;
+}
+
+.focus\\\\:top-2\\\\/3:focus {
+  top: 66.666667%;
+}
+
+.focus\\\\:top-1\\\\/4:focus {
+  top: 25%;
+}
+
+.focus\\\\:top-2\\\\/4:focus {
+  top: 50%;
+}
+
+.focus\\\\:top-3\\\\/4:focus {
+  top: 75%;
+}
+
+.focus\\\\:top-full:focus {
+  top: 100%;
+}
+
+.focus\\\\:-top-1\\\\/2:focus {
+  top: -50%;
+}
+
+.focus\\\\:-top-1\\\\/3:focus {
+  top: -33.333333%;
+}
+
+.focus\\\\:-top-2\\\\/3:focus {
+  top: -66.666667%;
+}
+
+.focus\\\\:-top-1\\\\/4:focus {
+  top: -25%;
+}
+
+.focus\\\\:-top-2\\\\/4:focus {
+  top: -50%;
+}
+
+.focus\\\\:-top-3\\\\/4:focus {
+  top: -75%;
+}
+
+.focus\\\\:-top-full:focus {
+  top: -100%;
+}
+
+.focus\\\\:right-0:focus {
+  right: 0px;
+}
+
+.focus\\\\:right-1:focus {
+  right: 0.25rem;
+}
+
+.focus\\\\:right-2:focus {
+  right: 0.5rem;
+}
+
+.focus\\\\:right-3:focus {
+  right: 0.75rem;
+}
+
+.focus\\\\:right-4:focus {
+  right: 1rem;
+}
+
+.focus\\\\:right-5:focus {
+  right: 1.25rem;
+}
+
+.focus\\\\:right-6:focus {
+  right: 1.5rem;
+}
+
+.focus\\\\:right-7:focus {
+  right: 1.75rem;
+}
+
+.focus\\\\:right-8:focus {
+  right: 2rem;
+}
+
+.focus\\\\:right-9:focus {
+  right: 2.25rem;
+}
+
+.focus\\\\:right-10:focus {
+  right: 2.5rem;
+}
+
+.focus\\\\:right-11:focus {
+  right: 2.75rem;
+}
+
+.focus\\\\:right-12:focus {
+  right: 3rem;
+}
+
+.focus\\\\:right-14:focus {
+  right: 3.5rem;
+}
+
+.focus\\\\:right-16:focus {
+  right: 4rem;
+}
+
+.focus\\\\:right-20:focus {
+  right: 5rem;
+}
+
+.focus\\\\:right-24:focus {
+  right: 6rem;
+}
+
+.focus\\\\:right-28:focus {
+  right: 7rem;
+}
+
+.focus\\\\:right-32:focus {
+  right: 8rem;
+}
+
+.focus\\\\:right-36:focus {
+  right: 9rem;
+}
+
+.focus\\\\:right-40:focus {
+  right: 10rem;
+}
+
+.focus\\\\:right-44:focus {
+  right: 11rem;
+}
+
+.focus\\\\:right-48:focus {
+  right: 12rem;
+}
+
+.focus\\\\:right-52:focus {
+  right: 13rem;
+}
+
+.focus\\\\:right-56:focus {
+  right: 14rem;
+}
+
+.focus\\\\:right-60:focus {
+  right: 15rem;
+}
+
+.focus\\\\:right-64:focus {
+  right: 16rem;
+}
+
+.focus\\\\:right-72:focus {
+  right: 18rem;
+}
+
+.focus\\\\:right-80:focus {
+  right: 20rem;
+}
+
+.focus\\\\:right-96:focus {
+  right: 24rem;
+}
+
+.focus\\\\:right-auto:focus {
+  right: auto;
+}
+
+.focus\\\\:right-px:focus {
+  right: 1px;
+}
+
+.focus\\\\:right-0\\\\.5:focus {
+  right: 0.125rem;
+}
+
+.focus\\\\:right-1\\\\.5:focus {
+  right: 0.375rem;
+}
+
+.focus\\\\:right-2\\\\.5:focus {
+  right: 0.625rem;
+}
+
+.focus\\\\:right-3\\\\.5:focus {
+  right: 0.875rem;
+}
+
+.focus\\\\:-right-0:focus {
+  right: 0px;
+}
+
+.focus\\\\:-right-1:focus {
+  right: -0.25rem;
+}
+
+.focus\\\\:-right-2:focus {
+  right: -0.5rem;
+}
+
+.focus\\\\:-right-3:focus {
+  right: -0.75rem;
+}
+
+.focus\\\\:-right-4:focus {
+  right: -1rem;
+}
+
+.focus\\\\:-right-5:focus {
+  right: -1.25rem;
+}
+
+.focus\\\\:-right-6:focus {
+  right: -1.5rem;
+}
+
+.focus\\\\:-right-7:focus {
+  right: -1.75rem;
+}
+
+.focus\\\\:-right-8:focus {
+  right: -2rem;
+}
+
+.focus\\\\:-right-9:focus {
+  right: -2.25rem;
+}
+
+.focus\\\\:-right-10:focus {
+  right: -2.5rem;
+}
+
+.focus\\\\:-right-11:focus {
+  right: -2.75rem;
+}
+
+.focus\\\\:-right-12:focus {
+  right: -3rem;
+}
+
+.focus\\\\:-right-14:focus {
+  right: -3.5rem;
+}
+
+.focus\\\\:-right-16:focus {
+  right: -4rem;
+}
+
+.focus\\\\:-right-20:focus {
+  right: -5rem;
+}
+
+.focus\\\\:-right-24:focus {
+  right: -6rem;
+}
+
+.focus\\\\:-right-28:focus {
+  right: -7rem;
+}
+
+.focus\\\\:-right-32:focus {
+  right: -8rem;
+}
+
+.focus\\\\:-right-36:focus {
+  right: -9rem;
+}
+
+.focus\\\\:-right-40:focus {
+  right: -10rem;
+}
+
+.focus\\\\:-right-44:focus {
+  right: -11rem;
+}
+
+.focus\\\\:-right-48:focus {
+  right: -12rem;
+}
+
+.focus\\\\:-right-52:focus {
+  right: -13rem;
+}
+
+.focus\\\\:-right-56:focus {
+  right: -14rem;
+}
+
+.focus\\\\:-right-60:focus {
+  right: -15rem;
+}
+
+.focus\\\\:-right-64:focus {
+  right: -16rem;
+}
+
+.focus\\\\:-right-72:focus {
+  right: -18rem;
+}
+
+.focus\\\\:-right-80:focus {
+  right: -20rem;
+}
+
+.focus\\\\:-right-96:focus {
+  right: -24rem;
+}
+
+.focus\\\\:-right-px:focus {
+  right: -1px;
+}
+
+.focus\\\\:-right-0\\\\.5:focus {
+  right: -0.125rem;
+}
+
+.focus\\\\:-right-1\\\\.5:focus {
+  right: -0.375rem;
+}
+
+.focus\\\\:-right-2\\\\.5:focus {
+  right: -0.625rem;
+}
+
+.focus\\\\:-right-3\\\\.5:focus {
+  right: -0.875rem;
+}
+
+.focus\\\\:right-1\\\\/2:focus {
+  right: 50%;
+}
+
+.focus\\\\:right-1\\\\/3:focus {
+  right: 33.333333%;
+}
+
+.focus\\\\:right-2\\\\/3:focus {
+  right: 66.666667%;
+}
+
+.focus\\\\:right-1\\\\/4:focus {
+  right: 25%;
+}
+
+.focus\\\\:right-2\\\\/4:focus {
+  right: 50%;
+}
+
+.focus\\\\:right-3\\\\/4:focus {
+  right: 75%;
+}
+
+.focus\\\\:right-full:focus {
+  right: 100%;
+}
+
+.focus\\\\:-right-1\\\\/2:focus {
+  right: -50%;
+}
+
+.focus\\\\:-right-1\\\\/3:focus {
+  right: -33.333333%;
+}
+
+.focus\\\\:-right-2\\\\/3:focus {
+  right: -66.666667%;
+}
+
+.focus\\\\:-right-1\\\\/4:focus {
+  right: -25%;
+}
+
+.focus\\\\:-right-2\\\\/4:focus {
+  right: -50%;
+}
+
+.focus\\\\:-right-3\\\\/4:focus {
+  right: -75%;
+}
+
+.focus\\\\:-right-full:focus {
+  right: -100%;
+}
+
+.focus\\\\:bottom-0:focus {
+  bottom: 0px;
+}
+
+.focus\\\\:bottom-1:focus {
+  bottom: 0.25rem;
+}
+
+.focus\\\\:bottom-2:focus {
+  bottom: 0.5rem;
+}
+
+.focus\\\\:bottom-3:focus {
+  bottom: 0.75rem;
+}
+
+.focus\\\\:bottom-4:focus {
+  bottom: 1rem;
+}
+
+.focus\\\\:bottom-5:focus {
+  bottom: 1.25rem;
+}
+
+.focus\\\\:bottom-6:focus {
+  bottom: 1.5rem;
+}
+
+.focus\\\\:bottom-7:focus {
+  bottom: 1.75rem;
+}
+
+.focus\\\\:bottom-8:focus {
+  bottom: 2rem;
+}
+
+.focus\\\\:bottom-9:focus {
+  bottom: 2.25rem;
+}
+
+.focus\\\\:bottom-10:focus {
+  bottom: 2.5rem;
+}
+
+.focus\\\\:bottom-11:focus {
+  bottom: 2.75rem;
+}
+
+.focus\\\\:bottom-12:focus {
+  bottom: 3rem;
+}
+
+.focus\\\\:bottom-14:focus {
+  bottom: 3.5rem;
+}
+
+.focus\\\\:bottom-16:focus {
+  bottom: 4rem;
+}
+
+.focus\\\\:bottom-20:focus {
+  bottom: 5rem;
+}
+
+.focus\\\\:bottom-24:focus {
+  bottom: 6rem;
+}
+
+.focus\\\\:bottom-28:focus {
+  bottom: 7rem;
+}
+
+.focus\\\\:bottom-32:focus {
+  bottom: 8rem;
+}
+
+.focus\\\\:bottom-36:focus {
+  bottom: 9rem;
+}
+
+.focus\\\\:bottom-40:focus {
+  bottom: 10rem;
+}
+
+.focus\\\\:bottom-44:focus {
+  bottom: 11rem;
+}
+
+.focus\\\\:bottom-48:focus {
+  bottom: 12rem;
+}
+
+.focus\\\\:bottom-52:focus {
+  bottom: 13rem;
+}
+
+.focus\\\\:bottom-56:focus {
+  bottom: 14rem;
+}
+
+.focus\\\\:bottom-60:focus {
+  bottom: 15rem;
+}
+
+.focus\\\\:bottom-64:focus {
+  bottom: 16rem;
+}
+
+.focus\\\\:bottom-72:focus {
+  bottom: 18rem;
+}
+
+.focus\\\\:bottom-80:focus {
+  bottom: 20rem;
+}
+
+.focus\\\\:bottom-96:focus {
+  bottom: 24rem;
+}
+
+.focus\\\\:bottom-auto:focus {
+  bottom: auto;
+}
+
+.focus\\\\:bottom-px:focus {
+  bottom: 1px;
+}
+
+.focus\\\\:bottom-0\\\\.5:focus {
+  bottom: 0.125rem;
+}
+
+.focus\\\\:bottom-1\\\\.5:focus {
+  bottom: 0.375rem;
+}
+
+.focus\\\\:bottom-2\\\\.5:focus {
+  bottom: 0.625rem;
+}
+
+.focus\\\\:bottom-3\\\\.5:focus {
+  bottom: 0.875rem;
+}
+
+.focus\\\\:-bottom-0:focus {
+  bottom: 0px;
+}
+
+.focus\\\\:-bottom-1:focus {
+  bottom: -0.25rem;
+}
+
+.focus\\\\:-bottom-2:focus {
+  bottom: -0.5rem;
+}
+
+.focus\\\\:-bottom-3:focus {
+  bottom: -0.75rem;
+}
+
+.focus\\\\:-bottom-4:focus {
+  bottom: -1rem;
+}
+
+.focus\\\\:-bottom-5:focus {
+  bottom: -1.25rem;
+}
+
+.focus\\\\:-bottom-6:focus {
+  bottom: -1.5rem;
+}
+
+.focus\\\\:-bottom-7:focus {
+  bottom: -1.75rem;
+}
+
+.focus\\\\:-bottom-8:focus {
+  bottom: -2rem;
+}
+
+.focus\\\\:-bottom-9:focus {
+  bottom: -2.25rem;
+}
+
+.focus\\\\:-bottom-10:focus {
+  bottom: -2.5rem;
+}
+
+.focus\\\\:-bottom-11:focus {
+  bottom: -2.75rem;
+}
+
+.focus\\\\:-bottom-12:focus {
+  bottom: -3rem;
+}
+
+.focus\\\\:-bottom-14:focus {
+  bottom: -3.5rem;
+}
+
+.focus\\\\:-bottom-16:focus {
+  bottom: -4rem;
+}
+
+.focus\\\\:-bottom-20:focus {
+  bottom: -5rem;
+}
+
+.focus\\\\:-bottom-24:focus {
+  bottom: -6rem;
+}
+
+.focus\\\\:-bottom-28:focus {
+  bottom: -7rem;
+}
+
+.focus\\\\:-bottom-32:focus {
+  bottom: -8rem;
+}
+
+.focus\\\\:-bottom-36:focus {
+  bottom: -9rem;
+}
+
+.focus\\\\:-bottom-40:focus {
+  bottom: -10rem;
+}
+
+.focus\\\\:-bottom-44:focus {
+  bottom: -11rem;
+}
+
+.focus\\\\:-bottom-48:focus {
+  bottom: -12rem;
+}
+
+.focus\\\\:-bottom-52:focus {
+  bottom: -13rem;
+}
+
+.focus\\\\:-bottom-56:focus {
+  bottom: -14rem;
+}
+
+.focus\\\\:-bottom-60:focus {
+  bottom: -15rem;
+}
+
+.focus\\\\:-bottom-64:focus {
+  bottom: -16rem;
+}
+
+.focus\\\\:-bottom-72:focus {
+  bottom: -18rem;
+}
+
+.focus\\\\:-bottom-80:focus {
+  bottom: -20rem;
+}
+
+.focus\\\\:-bottom-96:focus {
+  bottom: -24rem;
+}
+
+.focus\\\\:-bottom-px:focus {
+  bottom: -1px;
+}
+
+.focus\\\\:-bottom-0\\\\.5:focus {
+  bottom: -0.125rem;
+}
+
+.focus\\\\:-bottom-1\\\\.5:focus {
+  bottom: -0.375rem;
+}
+
+.focus\\\\:-bottom-2\\\\.5:focus {
+  bottom: -0.625rem;
+}
+
+.focus\\\\:-bottom-3\\\\.5:focus {
+  bottom: -0.875rem;
+}
+
+.focus\\\\:bottom-1\\\\/2:focus {
+  bottom: 50%;
+}
+
+.focus\\\\:bottom-1\\\\/3:focus {
+  bottom: 33.333333%;
+}
+
+.focus\\\\:bottom-2\\\\/3:focus {
+  bottom: 66.666667%;
+}
+
+.focus\\\\:bottom-1\\\\/4:focus {
+  bottom: 25%;
+}
+
+.focus\\\\:bottom-2\\\\/4:focus {
+  bottom: 50%;
+}
+
+.focus\\\\:bottom-3\\\\/4:focus {
+  bottom: 75%;
+}
+
+.focus\\\\:bottom-full:focus {
+  bottom: 100%;
+}
+
+.focus\\\\:-bottom-1\\\\/2:focus {
+  bottom: -50%;
+}
+
+.focus\\\\:-bottom-1\\\\/3:focus {
+  bottom: -33.333333%;
+}
+
+.focus\\\\:-bottom-2\\\\/3:focus {
+  bottom: -66.666667%;
+}
+
+.focus\\\\:-bottom-1\\\\/4:focus {
+  bottom: -25%;
+}
+
+.focus\\\\:-bottom-2\\\\/4:focus {
+  bottom: -50%;
+}
+
+.focus\\\\:-bottom-3\\\\/4:focus {
+  bottom: -75%;
+}
+
+.focus\\\\:-bottom-full:focus {
+  bottom: -100%;
+}
+
+.focus\\\\:left-0:focus {
+  left: 0px;
+}
+
+.focus\\\\:left-1:focus {
+  left: 0.25rem;
+}
+
+.focus\\\\:left-2:focus {
+  left: 0.5rem;
+}
+
+.focus\\\\:left-3:focus {
+  left: 0.75rem;
+}
+
+.focus\\\\:left-4:focus {
+  left: 1rem;
+}
+
+.focus\\\\:left-5:focus {
+  left: 1.25rem;
+}
+
+.focus\\\\:left-6:focus {
+  left: 1.5rem;
+}
+
+.focus\\\\:left-7:focus {
+  left: 1.75rem;
+}
+
+.focus\\\\:left-8:focus {
+  left: 2rem;
+}
+
+.focus\\\\:left-9:focus {
+  left: 2.25rem;
+}
+
+.focus\\\\:left-10:focus {
+  left: 2.5rem;
+}
+
+.focus\\\\:left-11:focus {
+  left: 2.75rem;
+}
+
+.focus\\\\:left-12:focus {
+  left: 3rem;
+}
+
+.focus\\\\:left-14:focus {
+  left: 3.5rem;
+}
+
+.focus\\\\:left-16:focus {
+  left: 4rem;
+}
+
+.focus\\\\:left-20:focus {
+  left: 5rem;
+}
+
+.focus\\\\:left-24:focus {
+  left: 6rem;
+}
+
+.focus\\\\:left-28:focus {
+  left: 7rem;
+}
+
+.focus\\\\:left-32:focus {
+  left: 8rem;
+}
+
+.focus\\\\:left-36:focus {
+  left: 9rem;
+}
+
+.focus\\\\:left-40:focus {
+  left: 10rem;
+}
+
+.focus\\\\:left-44:focus {
+  left: 11rem;
+}
+
+.focus\\\\:left-48:focus {
+  left: 12rem;
+}
+
+.focus\\\\:left-52:focus {
+  left: 13rem;
+}
+
+.focus\\\\:left-56:focus {
+  left: 14rem;
+}
+
+.focus\\\\:left-60:focus {
+  left: 15rem;
+}
+
+.focus\\\\:left-64:focus {
+  left: 16rem;
+}
+
+.focus\\\\:left-72:focus {
+  left: 18rem;
+}
+
+.focus\\\\:left-80:focus {
+  left: 20rem;
+}
+
+.focus\\\\:left-96:focus {
+  left: 24rem;
+}
+
+.focus\\\\:left-auto:focus {
+  left: auto;
+}
+
+.focus\\\\:left-px:focus {
+  left: 1px;
+}
+
+.focus\\\\:left-0\\\\.5:focus {
+  left: 0.125rem;
+}
+
+.focus\\\\:left-1\\\\.5:focus {
+  left: 0.375rem;
+}
+
+.focus\\\\:left-2\\\\.5:focus {
+  left: 0.625rem;
+}
+
+.focus\\\\:left-3\\\\.5:focus {
+  left: 0.875rem;
+}
+
+.focus\\\\:-left-0:focus {
+  left: 0px;
+}
+
+.focus\\\\:-left-1:focus {
+  left: -0.25rem;
+}
+
+.focus\\\\:-left-2:focus {
+  left: -0.5rem;
+}
+
+.focus\\\\:-left-3:focus {
+  left: -0.75rem;
+}
+
+.focus\\\\:-left-4:focus {
+  left: -1rem;
+}
+
+.focus\\\\:-left-5:focus {
+  left: -1.25rem;
+}
+
+.focus\\\\:-left-6:focus {
+  left: -1.5rem;
+}
+
+.focus\\\\:-left-7:focus {
+  left: -1.75rem;
+}
+
+.focus\\\\:-left-8:focus {
+  left: -2rem;
+}
+
+.focus\\\\:-left-9:focus {
+  left: -2.25rem;
+}
+
+.focus\\\\:-left-10:focus {
+  left: -2.5rem;
+}
+
+.focus\\\\:-left-11:focus {
+  left: -2.75rem;
+}
+
+.focus\\\\:-left-12:focus {
+  left: -3rem;
+}
+
+.focus\\\\:-left-14:focus {
+  left: -3.5rem;
+}
+
+.focus\\\\:-left-16:focus {
+  left: -4rem;
+}
+
+.focus\\\\:-left-20:focus {
+  left: -5rem;
+}
+
+.focus\\\\:-left-24:focus {
+  left: -6rem;
+}
+
+.focus\\\\:-left-28:focus {
+  left: -7rem;
+}
+
+.focus\\\\:-left-32:focus {
+  left: -8rem;
+}
+
+.focus\\\\:-left-36:focus {
+  left: -9rem;
+}
+
+.focus\\\\:-left-40:focus {
+  left: -10rem;
+}
+
+.focus\\\\:-left-44:focus {
+  left: -11rem;
+}
+
+.focus\\\\:-left-48:focus {
+  left: -12rem;
+}
+
+.focus\\\\:-left-52:focus {
+  left: -13rem;
+}
+
+.focus\\\\:-left-56:focus {
+  left: -14rem;
+}
+
+.focus\\\\:-left-60:focus {
+  left: -15rem;
+}
+
+.focus\\\\:-left-64:focus {
+  left: -16rem;
+}
+
+.focus\\\\:-left-72:focus {
+  left: -18rem;
+}
+
+.focus\\\\:-left-80:focus {
+  left: -20rem;
+}
+
+.focus\\\\:-left-96:focus {
+  left: -24rem;
+}
+
+.focus\\\\:-left-px:focus {
+  left: -1px;
+}
+
+.focus\\\\:-left-0\\\\.5:focus {
+  left: -0.125rem;
+}
+
+.focus\\\\:-left-1\\\\.5:focus {
+  left: -0.375rem;
+}
+
+.focus\\\\:-left-2\\\\.5:focus {
+  left: -0.625rem;
+}
+
+.focus\\\\:-left-3\\\\.5:focus {
+  left: -0.875rem;
+}
+
+.focus\\\\:left-1\\\\/2:focus {
+  left: 50%;
+}
+
+.focus\\\\:left-1\\\\/3:focus {
+  left: 33.333333%;
+}
+
+.focus\\\\:left-2\\\\/3:focus {
+  left: 66.666667%;
+}
+
+.focus\\\\:left-1\\\\/4:focus {
+  left: 25%;
+}
+
+.focus\\\\:left-2\\\\/4:focus {
+  left: 50%;
+}
+
+.focus\\\\:left-3\\\\/4:focus {
+  left: 75%;
+}
+
+.focus\\\\:left-full:focus {
+  left: 100%;
+}
+
+.focus\\\\:-left-1\\\\/2:focus {
+  left: -50%;
+}
+
+.focus\\\\:-left-1\\\\/3:focus {
+  left: -33.333333%;
+}
+
+.focus\\\\:-left-2\\\\/3:focus {
+  left: -66.666667%;
+}
+
+.focus\\\\:-left-1\\\\/4:focus {
+  left: -25%;
+}
+
+.focus\\\\:-left-2\\\\/4:focus {
+  left: -50%;
+}
+
+.focus\\\\:-left-3\\\\/4:focus {
+  left: -75%;
+}
+
+.focus\\\\:-left-full:focus {
+  left: -100%;
+}
+
+.isolate {
+  isolation: isolate;
+}
+
+.isolation-auto {
+  isolation: auto;
+}
+
+.z-1 {
+  z-index: 1;
+}
+
+.z-2 {
+  z-index: 2;
+}
+
+.z-3 {
+  z-index: 3;
+}
+
+.z-4 {
+  z-index: 4;
+}
+
+.z-5 {
+  z-index: 5;
+}
+
+.z-6 {
+  z-index: 6;
+}
+
+.z-7 {
+  z-index: 7;
+}
+
+.z-8 {
+  z-index: 8;
+}
+
+.z-9 {
+  z-index: 9;
+}
+
+.z-10 {
+  z-index: 10;
+}
+
+.-z-1 {
+  z-index: -1;
+}
+
+.z-flash-messages {
+  z-index: var(--z-index-flash-messages);
+}
+
+.z-overlay {
+  z-index: var(--z-index-overlay);
+}
+
+.z-tooltip {
+  z-index: var(--z-index-tooltip);
+}
+
+.z-popover-sticky {
+  z-index: var(--z-index-popover-sticky);
+}
+
+.z-popover {
+  z-index: var(--z-index-popover);
+}
+
+.z-skip-to-content {
+  z-index: var(--z-index-skip-to-content);
+}
+
+.z-tablist {
+  z-index: var(--z-index-tablist);
+}
+
+.z-tabpanel {
+  z-index: var(--z-index-tabpanel);
+}
+
+.z-tabpanel-scrim {
+  z-index: var(--z-index-tabpanel-scrim);
+}
+
+.z-template-head {
+  z-index: var(--z-index-template-head);
+}
+
+.z-template-main-head-sticky {
+  z-index: var(--z-index-template-main-head-sticky);
+}
+
+.z-template-main-head {
+  z-index: var(--z-index-template-main-head);
+}
+
+.z-template-main {
+  z-index: var(--z-index-template-main);
+}
+
+.z-search-results-navigation {
+  z-index: var(--z-index-navigation-search);
+}
+
+.hover\\\\:z-1:hover {
+  z-index: 1;
+}
+
+.hover\\\\:z-2:hover {
+  z-index: 2;
+}
+
+.hover\\\\:z-3:hover {
+  z-index: 3;
+}
+
+.hover\\\\:z-4:hover {
+  z-index: 4;
+}
+
+.hover\\\\:z-5:hover {
+  z-index: 5;
+}
+
+.hover\\\\:z-6:hover {
+  z-index: 6;
+}
+
+.hover\\\\:z-7:hover {
+  z-index: 7;
+}
+
+.hover\\\\:z-8:hover {
+  z-index: 8;
+}
+
+.hover\\\\:z-9:hover {
+  z-index: 9;
+}
+
+.hover\\\\:z-10:hover {
+  z-index: 10;
+}
+
+.hover\\\\:-z-1:hover {
+  z-index: -1;
+}
+
+.hover\\\\:z-flash-messages:hover {
+  z-index: var(--z-index-flash-messages);
+}
+
+.hover\\\\:z-overlay:hover {
+  z-index: var(--z-index-overlay);
+}
+
+.hover\\\\:z-tooltip:hover {
+  z-index: var(--z-index-tooltip);
+}
+
+.hover\\\\:z-popover-sticky:hover {
+  z-index: var(--z-index-popover-sticky);
+}
+
+.hover\\\\:z-popover:hover {
+  z-index: var(--z-index-popover);
+}
+
+.hover\\\\:z-skip-to-content:hover {
+  z-index: var(--z-index-skip-to-content);
+}
+
+.hover\\\\:z-tablist:hover {
+  z-index: var(--z-index-tablist);
+}
+
+.hover\\\\:z-tabpanel:hover {
+  z-index: var(--z-index-tabpanel);
+}
+
+.hover\\\\:z-tabpanel-scrim:hover {
+  z-index: var(--z-index-tabpanel-scrim);
+}
+
+.hover\\\\:z-template-head:hover {
+  z-index: var(--z-index-template-head);
+}
+
+.hover\\\\:z-template-main-head-sticky:hover {
+  z-index: var(--z-index-template-main-head-sticky);
+}
+
+.hover\\\\:z-template-main-head:hover {
+  z-index: var(--z-index-template-main-head);
+}
+
+.hover\\\\:z-template-main:hover {
+  z-index: var(--z-index-template-main);
+}
+
+.hover\\\\:z-search-results-navigation:hover {
+  z-index: var(--z-index-navigation-search);
+}
+
+.active\\\\:z-1:active {
+  z-index: 1;
+}
+
+.active\\\\:z-2:active {
+  z-index: 2;
+}
+
+.active\\\\:z-3:active {
+  z-index: 3;
+}
+
+.active\\\\:z-4:active {
+  z-index: 4;
+}
+
+.active\\\\:z-5:active {
+  z-index: 5;
+}
+
+.active\\\\:z-6:active {
+  z-index: 6;
+}
+
+.active\\\\:z-7:active {
+  z-index: 7;
+}
+
+.active\\\\:z-8:active {
+  z-index: 8;
+}
+
+.active\\\\:z-9:active {
+  z-index: 9;
+}
+
+.active\\\\:z-10:active {
+  z-index: 10;
+}
+
+.active\\\\:-z-1:active {
+  z-index: -1;
+}
+
+.active\\\\:z-flash-messages:active {
+  z-index: var(--z-index-flash-messages);
+}
+
+.active\\\\:z-overlay:active {
+  z-index: var(--z-index-overlay);
+}
+
+.active\\\\:z-tooltip:active {
+  z-index: var(--z-index-tooltip);
+}
+
+.active\\\\:z-popover-sticky:active {
+  z-index: var(--z-index-popover-sticky);
+}
+
+.active\\\\:z-popover:active {
+  z-index: var(--z-index-popover);
+}
+
+.active\\\\:z-skip-to-content:active {
+  z-index: var(--z-index-skip-to-content);
+}
+
+.active\\\\:z-tablist:active {
+  z-index: var(--z-index-tablist);
+}
+
+.active\\\\:z-tabpanel:active {
+  z-index: var(--z-index-tabpanel);
+}
+
+.active\\\\:z-tabpanel-scrim:active {
+  z-index: var(--z-index-tabpanel-scrim);
+}
+
+.active\\\\:z-template-head:active {
+  z-index: var(--z-index-template-head);
+}
+
+.active\\\\:z-template-main-head-sticky:active {
+  z-index: var(--z-index-template-main-head-sticky);
+}
+
+.active\\\\:z-template-main-head:active {
+  z-index: var(--z-index-template-main-head);
+}
+
+.active\\\\:z-template-main:active {
+  z-index: var(--z-index-template-main);
+}
+
+.active\\\\:z-search-results-navigation:active {
+  z-index: var(--z-index-navigation-search);
+}
+
+.group:hover .group-hover\\\\:z-1 {
+  z-index: 1;
+}
+
+.group:hover .group-hover\\\\:z-2 {
+  z-index: 2;
+}
+
+.group:hover .group-hover\\\\:z-3 {
+  z-index: 3;
+}
+
+.group:hover .group-hover\\\\:z-4 {
+  z-index: 4;
+}
+
+.group:hover .group-hover\\\\:z-5 {
+  z-index: 5;
+}
+
+.group:hover .group-hover\\\\:z-6 {
+  z-index: 6;
+}
+
+.group:hover .group-hover\\\\:z-7 {
+  z-index: 7;
+}
+
+.group:hover .group-hover\\\\:z-8 {
+  z-index: 8;
+}
+
+.group:hover .group-hover\\\\:z-9 {
+  z-index: 9;
+}
+
+.group:hover .group-hover\\\\:z-10 {
+  z-index: 10;
+}
+
+.group:hover .group-hover\\\\:-z-1 {
+  z-index: -1;
+}
+
+.group:hover .group-hover\\\\:z-flash-messages {
+  z-index: var(--z-index-flash-messages);
+}
+
+.group:hover .group-hover\\\\:z-overlay {
+  z-index: var(--z-index-overlay);
+}
+
+.group:hover .group-hover\\\\:z-tooltip {
+  z-index: var(--z-index-tooltip);
+}
+
+.group:hover .group-hover\\\\:z-popover-sticky {
+  z-index: var(--z-index-popover-sticky);
+}
+
+.group:hover .group-hover\\\\:z-popover {
+  z-index: var(--z-index-popover);
+}
+
+.group:hover .group-hover\\\\:z-skip-to-content {
+  z-index: var(--z-index-skip-to-content);
+}
+
+.group:hover .group-hover\\\\:z-tablist {
+  z-index: var(--z-index-tablist);
+}
+
+.group:hover .group-hover\\\\:z-tabpanel {
+  z-index: var(--z-index-tabpanel);
+}
+
+.group:hover .group-hover\\\\:z-tabpanel-scrim {
+  z-index: var(--z-index-tabpanel-scrim);
+}
+
+.group:hover .group-hover\\\\:z-template-head {
+  z-index: var(--z-index-template-head);
+}
+
+.group:hover .group-hover\\\\:z-template-main-head-sticky {
+  z-index: var(--z-index-template-main-head-sticky);
+}
+
+.group:hover .group-hover\\\\:z-template-main-head {
+  z-index: var(--z-index-template-main-head);
+}
+
+.group:hover .group-hover\\\\:z-template-main {
+  z-index: var(--z-index-template-main);
+}
+
+.group:hover .group-hover\\\\:z-search-results-navigation {
+  z-index: var(--z-index-navigation-search);
+}
+
+.order-1 {
+  order: 1;
+}
+
+.order-2 {
+  order: 2;
+}
+
+.order-3 {
+  order: 3;
+}
+
+.order-4 {
+  order: 4;
+}
+
+.order-5 {
+  order: 5;
+}
+
+.order-6 {
+  order: 6;
+}
+
+.order-7 {
+  order: 7;
+}
+
+.order-8 {
+  order: 8;
+}
+
+.order-9 {
+  order: 9;
+}
+
+.order-10 {
+  order: 10;
+}
+
+.order-11 {
+  order: 11;
+}
+
+.order-12 {
+  order: 12;
+}
+
+.order-first {
+  order: -9999;
+}
+
+.order-last {
+  order: 9999;
+}
+
+.order-none {
+  order: 0;
+}
+
+.col-auto {
+  grid-column: auto;
+}
+
+.col-span-1 {
+  grid-column: span 1 / span 1;
+}
+
+.col-span-2 {
+  grid-column: span 2 / span 2;
+}
+
+.col-span-3 {
+  grid-column: span 3 / span 3;
+}
+
+.col-span-4 {
+  grid-column: span 4 / span 4;
+}
+
+.col-span-5 {
+  grid-column: span 5 / span 5;
+}
+
+.col-span-6 {
+  grid-column: span 6 / span 6;
+}
+
+.col-span-7 {
+  grid-column: span 7 / span 7;
+}
+
+.col-span-8 {
+  grid-column: span 8 / span 8;
+}
+
+.col-span-9 {
+  grid-column: span 9 / span 9;
+}
+
+.col-span-10 {
+  grid-column: span 10 / span 10;
+}
+
+.col-span-11 {
+  grid-column: span 11 / span 11;
+}
+
+.col-span-12 {
+  grid-column: span 12 / span 12;
+}
+
+.col-span-full {
+  grid-column: 1 / -1;
+}
+
+.col-start-1 {
+  grid-column-start: 1;
+}
+
+.col-start-2 {
+  grid-column-start: 2;
+}
+
+.col-start-3 {
+  grid-column-start: 3;
+}
+
+.col-start-4 {
+  grid-column-start: 4;
+}
+
+.col-start-5 {
+  grid-column-start: 5;
+}
+
+.col-start-6 {
+  grid-column-start: 6;
+}
+
+.col-start-7 {
+  grid-column-start: 7;
+}
+
+.col-start-8 {
+  grid-column-start: 8;
+}
+
+.col-start-9 {
+  grid-column-start: 9;
+}
+
+.col-start-10 {
+  grid-column-start: 10;
+}
+
+.col-start-11 {
+  grid-column-start: 11;
+}
+
+.col-start-12 {
+  grid-column-start: 12;
+}
+
+.col-start-13 {
+  grid-column-start: 13;
+}
+
+.col-start-auto {
+  grid-column-start: auto;
+}
+
+.col-end-1 {
+  grid-column-end: 1;
+}
+
+.col-end-2 {
+  grid-column-end: 2;
+}
+
+.col-end-3 {
+  grid-column-end: 3;
+}
+
+.col-end-4 {
+  grid-column-end: 4;
+}
+
+.col-end-5 {
+  grid-column-end: 5;
+}
+
+.col-end-6 {
+  grid-column-end: 6;
+}
+
+.col-end-7 {
+  grid-column-end: 7;
+}
+
+.col-end-8 {
+  grid-column-end: 8;
+}
+
+.col-end-9 {
+  grid-column-end: 9;
+}
+
+.col-end-10 {
+  grid-column-end: 10;
+}
+
+.col-end-11 {
+  grid-column-end: 11;
+}
+
+.col-end-12 {
+  grid-column-end: 12;
+}
+
+.col-end-13 {
+  grid-column-end: 13;
+}
+
+.col-end-auto {
+  grid-column-end: auto;
+}
+
+.row-auto {
+  grid-row: auto;
+}
+
+.row-span-1 {
+  grid-row: span 1 / span 1;
+}
+
+.row-span-2 {
+  grid-row: span 2 / span 2;
+}
+
+.row-span-3 {
+  grid-row: span 3 / span 3;
+}
+
+.row-span-4 {
+  grid-row: span 4 / span 4;
+}
+
+.row-span-5 {
+  grid-row: span 5 / span 5;
+}
+
+.row-span-6 {
+  grid-row: span 6 / span 6;
+}
+
+.row-span-full {
+  grid-row: 1 / -1;
+}
+
+.row-start-1 {
+  grid-row-start: 1;
+}
+
+.row-start-2 {
+  grid-row-start: 2;
+}
+
+.row-start-3 {
+  grid-row-start: 3;
+}
+
+.row-start-4 {
+  grid-row-start: 4;
+}
+
+.row-start-5 {
+  grid-row-start: 5;
+}
+
+.row-start-6 {
+  grid-row-start: 6;
+}
+
+.row-start-7 {
+  grid-row-start: 7;
+}
+
+.row-start-auto {
+  grid-row-start: auto;
+}
+
+.row-end-1 {
+  grid-row-end: 1;
+}
+
+.row-end-2 {
+  grid-row-end: 2;
+}
+
+.row-end-3 {
+  grid-row-end: 3;
+}
+
+.row-end-4 {
+  grid-row-end: 4;
+}
+
+.row-end-5 {
+  grid-row-end: 5;
+}
+
+.row-end-6 {
+  grid-row-end: 6;
+}
+
+.row-end-7 {
+  grid-row-end: 7;
+}
+
+.row-end-auto {
+  grid-row-end: auto;
+}
+
+.float-right {
+  float: right;
+}
+
+.float-left {
+  float: left;
+}
+
+.float-none {
+  float: none;
+}
+
+.clear-left {
+  clear: left;
+}
+
+.clear-right {
+  clear: right;
+}
+
+.clear-both {
+  clear: both;
+}
+
+.clear-none {
+  clear: none;
+}
+
+.m-0 {
+  margin: 0px;
+}
+
+.m-1 {
+  margin: 0.25rem;
+}
+
+.m-2 {
+  margin: 0.5rem;
+}
+
+.m-3 {
+  margin: 0.75rem;
+}
+
+.m-4 {
+  margin: 1rem;
+}
+
+.m-5 {
+  margin: 1.25rem;
+}
+
+.m-6 {
+  margin: 1.5rem;
+}
+
+.m-7 {
+  margin: 1.75rem;
+}
+
+.m-8 {
+  margin: 2rem;
+}
+
+.m-9 {
+  margin: 2.25rem;
+}
+
+.m-10 {
+  margin: 2.5rem;
+}
+
+.m-11 {
+  margin: 2.75rem;
+}
+
+.m-12 {
+  margin: 3rem;
+}
+
+.m-14 {
+  margin: 3.5rem;
+}
+
+.m-16 {
+  margin: 4rem;
+}
+
+.m-20 {
+  margin: 5rem;
+}
+
+.m-24 {
+  margin: 6rem;
+}
+
+.m-28 {
+  margin: 7rem;
+}
+
+.m-32 {
+  margin: 8rem;
+}
+
+.m-36 {
+  margin: 9rem;
+}
+
+.m-40 {
+  margin: 10rem;
+}
+
+.m-44 {
+  margin: 11rem;
+}
+
+.m-48 {
+  margin: 12rem;
+}
+
+.m-52 {
+  margin: 13rem;
+}
+
+.m-56 {
+  margin: 14rem;
+}
+
+.m-60 {
+  margin: 15rem;
+}
+
+.m-64 {
+  margin: 16rem;
+}
+
+.m-72 {
+  margin: 18rem;
+}
+
+.m-80 {
+  margin: 20rem;
+}
+
+.m-96 {
+  margin: 24rem;
+}
+
+.m-auto {
+  margin: auto;
+}
+
+.m-px {
+  margin: 1px;
+}
+
+.m-0\\\\.5 {
+  margin: 0.125rem;
+}
+
+.m-1\\\\.5 {
+  margin: 0.375rem;
+}
+
+.m-2\\\\.5 {
+  margin: 0.625rem;
+}
+
+.m-3\\\\.5 {
+  margin: 0.875rem;
+}
+
+.-m-0 {
+  margin: 0px;
+}
+
+.-m-1 {
+  margin: -0.25rem;
+}
+
+.-m-2 {
+  margin: -0.5rem;
+}
+
+.-m-3 {
+  margin: -0.75rem;
+}
+
+.-m-4 {
+  margin: -1rem;
+}
+
+.-m-5 {
+  margin: -1.25rem;
+}
+
+.-m-6 {
+  margin: -1.5rem;
+}
+
+.-m-7 {
+  margin: -1.75rem;
+}
+
+.-m-8 {
+  margin: -2rem;
+}
+
+.-m-9 {
+  margin: -2.25rem;
+}
+
+.-m-10 {
+  margin: -2.5rem;
+}
+
+.-m-11 {
+  margin: -2.75rem;
+}
+
+.-m-12 {
+  margin: -3rem;
+}
+
+.-m-14 {
+  margin: -3.5rem;
+}
+
+.-m-16 {
+  margin: -4rem;
+}
+
+.-m-20 {
+  margin: -5rem;
+}
+
+.-m-24 {
+  margin: -6rem;
+}
+
+.-m-28 {
+  margin: -7rem;
+}
+
+.-m-32 {
+  margin: -8rem;
+}
+
+.-m-36 {
+  margin: -9rem;
+}
+
+.-m-40 {
+  margin: -10rem;
+}
+
+.-m-44 {
+  margin: -11rem;
+}
+
+.-m-48 {
+  margin: -12rem;
+}
+
+.-m-52 {
+  margin: -13rem;
+}
+
+.-m-56 {
+  margin: -14rem;
+}
+
+.-m-60 {
+  margin: -15rem;
+}
+
+.-m-64 {
+  margin: -16rem;
+}
+
+.-m-72 {
+  margin: -18rem;
+}
+
+.-m-80 {
+  margin: -20rem;
+}
+
+.-m-96 {
+  margin: -24rem;
+}
+
+.-m-px {
+  margin: -1px;
+}
+
+.-m-0\\\\.5 {
+  margin: -0.125rem;
+}
+
+.-m-1\\\\.5 {
+  margin: -0.375rem;
+}
+
+.-m-2\\\\.5 {
+  margin: -0.625rem;
+}
+
+.-m-3\\\\.5 {
+  margin: -0.875rem;
+}
+
+.first\\\\:m-0:first-child {
+  margin: 0px;
+}
+
+.first\\\\:m-1:first-child {
+  margin: 0.25rem;
+}
+
+.first\\\\:m-2:first-child {
+  margin: 0.5rem;
+}
+
+.first\\\\:m-3:first-child {
+  margin: 0.75rem;
+}
+
+.first\\\\:m-4:first-child {
+  margin: 1rem;
+}
+
+.first\\\\:m-5:first-child {
+  margin: 1.25rem;
+}
+
+.first\\\\:m-6:first-child {
+  margin: 1.5rem;
+}
+
+.first\\\\:m-7:first-child {
+  margin: 1.75rem;
+}
+
+.first\\\\:m-8:first-child {
+  margin: 2rem;
+}
+
+.first\\\\:m-9:first-child {
+  margin: 2.25rem;
+}
+
+.first\\\\:m-10:first-child {
+  margin: 2.5rem;
+}
+
+.first\\\\:m-11:first-child {
+  margin: 2.75rem;
+}
+
+.first\\\\:m-12:first-child {
+  margin: 3rem;
+}
+
+.first\\\\:m-14:first-child {
+  margin: 3.5rem;
+}
+
+.first\\\\:m-16:first-child {
+  margin: 4rem;
+}
+
+.first\\\\:m-20:first-child {
+  margin: 5rem;
+}
+
+.first\\\\:m-24:first-child {
+  margin: 6rem;
+}
+
+.first\\\\:m-28:first-child {
+  margin: 7rem;
+}
+
+.first\\\\:m-32:first-child {
+  margin: 8rem;
+}
+
+.first\\\\:m-36:first-child {
+  margin: 9rem;
+}
+
+.first\\\\:m-40:first-child {
+  margin: 10rem;
+}
+
+.first\\\\:m-44:first-child {
+  margin: 11rem;
+}
+
+.first\\\\:m-48:first-child {
+  margin: 12rem;
+}
+
+.first\\\\:m-52:first-child {
+  margin: 13rem;
+}
+
+.first\\\\:m-56:first-child {
+  margin: 14rem;
+}
+
+.first\\\\:m-60:first-child {
+  margin: 15rem;
+}
+
+.first\\\\:m-64:first-child {
+  margin: 16rem;
+}
+
+.first\\\\:m-72:first-child {
+  margin: 18rem;
+}
+
+.first\\\\:m-80:first-child {
+  margin: 20rem;
+}
+
+.first\\\\:m-96:first-child {
+  margin: 24rem;
+}
+
+.first\\\\:m-auto:first-child {
+  margin: auto;
+}
+
+.first\\\\:m-px:first-child {
+  margin: 1px;
+}
+
+.first\\\\:m-0\\\\.5:first-child {
+  margin: 0.125rem;
+}
+
+.first\\\\:m-1\\\\.5:first-child {
+  margin: 0.375rem;
+}
+
+.first\\\\:m-2\\\\.5:first-child {
+  margin: 0.625rem;
+}
+
+.first\\\\:m-3\\\\.5:first-child {
+  margin: 0.875rem;
+}
+
+.first\\\\:-m-0:first-child {
+  margin: 0px;
+}
+
+.first\\\\:-m-1:first-child {
+  margin: -0.25rem;
+}
+
+.first\\\\:-m-2:first-child {
+  margin: -0.5rem;
+}
+
+.first\\\\:-m-3:first-child {
+  margin: -0.75rem;
+}
+
+.first\\\\:-m-4:first-child {
+  margin: -1rem;
+}
+
+.first\\\\:-m-5:first-child {
+  margin: -1.25rem;
+}
+
+.first\\\\:-m-6:first-child {
+  margin: -1.5rem;
+}
+
+.first\\\\:-m-7:first-child {
+  margin: -1.75rem;
+}
+
+.first\\\\:-m-8:first-child {
+  margin: -2rem;
+}
+
+.first\\\\:-m-9:first-child {
+  margin: -2.25rem;
+}
+
+.first\\\\:-m-10:first-child {
+  margin: -2.5rem;
+}
+
+.first\\\\:-m-11:first-child {
+  margin: -2.75rem;
+}
+
+.first\\\\:-m-12:first-child {
+  margin: -3rem;
+}
+
+.first\\\\:-m-14:first-child {
+  margin: -3.5rem;
+}
+
+.first\\\\:-m-16:first-child {
+  margin: -4rem;
+}
+
+.first\\\\:-m-20:first-child {
+  margin: -5rem;
+}
+
+.first\\\\:-m-24:first-child {
+  margin: -6rem;
+}
+
+.first\\\\:-m-28:first-child {
+  margin: -7rem;
+}
+
+.first\\\\:-m-32:first-child {
+  margin: -8rem;
+}
+
+.first\\\\:-m-36:first-child {
+  margin: -9rem;
+}
+
+.first\\\\:-m-40:first-child {
+  margin: -10rem;
+}
+
+.first\\\\:-m-44:first-child {
+  margin: -11rem;
+}
+
+.first\\\\:-m-48:first-child {
+  margin: -12rem;
+}
+
+.first\\\\:-m-52:first-child {
+  margin: -13rem;
+}
+
+.first\\\\:-m-56:first-child {
+  margin: -14rem;
+}
+
+.first\\\\:-m-60:first-child {
+  margin: -15rem;
+}
+
+.first\\\\:-m-64:first-child {
+  margin: -16rem;
+}
+
+.first\\\\:-m-72:first-child {
+  margin: -18rem;
+}
+
+.first\\\\:-m-80:first-child {
+  margin: -20rem;
+}
+
+.first\\\\:-m-96:first-child {
+  margin: -24rem;
+}
+
+.first\\\\:-m-px:first-child {
+  margin: -1px;
+}
+
+.first\\\\:-m-0\\\\.5:first-child {
+  margin: -0.125rem;
+}
+
+.first\\\\:-m-1\\\\.5:first-child {
+  margin: -0.375rem;
+}
+
+.first\\\\:-m-2\\\\.5:first-child {
+  margin: -0.625rem;
+}
+
+.first\\\\:-m-3\\\\.5:first-child {
+  margin: -0.875rem;
+}
+
+.last\\\\:m-0:last-child {
+  margin: 0px;
+}
+
+.last\\\\:m-1:last-child {
+  margin: 0.25rem;
+}
+
+.last\\\\:m-2:last-child {
+  margin: 0.5rem;
+}
+
+.last\\\\:m-3:last-child {
+  margin: 0.75rem;
+}
+
+.last\\\\:m-4:last-child {
+  margin: 1rem;
+}
+
+.last\\\\:m-5:last-child {
+  margin: 1.25rem;
+}
+
+.last\\\\:m-6:last-child {
+  margin: 1.5rem;
+}
+
+.last\\\\:m-7:last-child {
+  margin: 1.75rem;
+}
+
+.last\\\\:m-8:last-child {
+  margin: 2rem;
+}
+
+.last\\\\:m-9:last-child {
+  margin: 2.25rem;
+}
+
+.last\\\\:m-10:last-child {
+  margin: 2.5rem;
+}
+
+.last\\\\:m-11:last-child {
+  margin: 2.75rem;
+}
+
+.last\\\\:m-12:last-child {
+  margin: 3rem;
+}
+
+.last\\\\:m-14:last-child {
+  margin: 3.5rem;
+}
+
+.last\\\\:m-16:last-child {
+  margin: 4rem;
+}
+
+.last\\\\:m-20:last-child {
+  margin: 5rem;
+}
+
+.last\\\\:m-24:last-child {
+  margin: 6rem;
+}
+
+.last\\\\:m-28:last-child {
+  margin: 7rem;
+}
+
+.last\\\\:m-32:last-child {
+  margin: 8rem;
+}
+
+.last\\\\:m-36:last-child {
+  margin: 9rem;
+}
+
+.last\\\\:m-40:last-child {
+  margin: 10rem;
+}
+
+.last\\\\:m-44:last-child {
+  margin: 11rem;
+}
+
+.last\\\\:m-48:last-child {
+  margin: 12rem;
+}
+
+.last\\\\:m-52:last-child {
+  margin: 13rem;
+}
+
+.last\\\\:m-56:last-child {
+  margin: 14rem;
+}
+
+.last\\\\:m-60:last-child {
+  margin: 15rem;
+}
+
+.last\\\\:m-64:last-child {
+  margin: 16rem;
+}
+
+.last\\\\:m-72:last-child {
+  margin: 18rem;
+}
+
+.last\\\\:m-80:last-child {
+  margin: 20rem;
+}
+
+.last\\\\:m-96:last-child {
+  margin: 24rem;
+}
+
+.last\\\\:m-auto:last-child {
+  margin: auto;
+}
+
+.last\\\\:m-px:last-child {
+  margin: 1px;
+}
+
+.last\\\\:m-0\\\\.5:last-child {
+  margin: 0.125rem;
+}
+
+.last\\\\:m-1\\\\.5:last-child {
+  margin: 0.375rem;
+}
+
+.last\\\\:m-2\\\\.5:last-child {
+  margin: 0.625rem;
+}
+
+.last\\\\:m-3\\\\.5:last-child {
+  margin: 0.875rem;
+}
+
+.last\\\\:-m-0:last-child {
+  margin: 0px;
+}
+
+.last\\\\:-m-1:last-child {
+  margin: -0.25rem;
+}
+
+.last\\\\:-m-2:last-child {
+  margin: -0.5rem;
+}
+
+.last\\\\:-m-3:last-child {
+  margin: -0.75rem;
+}
+
+.last\\\\:-m-4:last-child {
+  margin: -1rem;
+}
+
+.last\\\\:-m-5:last-child {
+  margin: -1.25rem;
+}
+
+.last\\\\:-m-6:last-child {
+  margin: -1.5rem;
+}
+
+.last\\\\:-m-7:last-child {
+  margin: -1.75rem;
+}
+
+.last\\\\:-m-8:last-child {
+  margin: -2rem;
+}
+
+.last\\\\:-m-9:last-child {
+  margin: -2.25rem;
+}
+
+.last\\\\:-m-10:last-child {
+  margin: -2.5rem;
+}
+
+.last\\\\:-m-11:last-child {
+  margin: -2.75rem;
+}
+
+.last\\\\:-m-12:last-child {
+  margin: -3rem;
+}
+
+.last\\\\:-m-14:last-child {
+  margin: -3.5rem;
+}
+
+.last\\\\:-m-16:last-child {
+  margin: -4rem;
+}
+
+.last\\\\:-m-20:last-child {
+  margin: -5rem;
+}
+
+.last\\\\:-m-24:last-child {
+  margin: -6rem;
+}
+
+.last\\\\:-m-28:last-child {
+  margin: -7rem;
+}
+
+.last\\\\:-m-32:last-child {
+  margin: -8rem;
+}
+
+.last\\\\:-m-36:last-child {
+  margin: -9rem;
+}
+
+.last\\\\:-m-40:last-child {
+  margin: -10rem;
+}
+
+.last\\\\:-m-44:last-child {
+  margin: -11rem;
+}
+
+.last\\\\:-m-48:last-child {
+  margin: -12rem;
+}
+
+.last\\\\:-m-52:last-child {
+  margin: -13rem;
+}
+
+.last\\\\:-m-56:last-child {
+  margin: -14rem;
+}
+
+.last\\\\:-m-60:last-child {
+  margin: -15rem;
+}
+
+.last\\\\:-m-64:last-child {
+  margin: -16rem;
+}
+
+.last\\\\:-m-72:last-child {
+  margin: -18rem;
+}
+
+.last\\\\:-m-80:last-child {
+  margin: -20rem;
+}
+
+.last\\\\:-m-96:last-child {
+  margin: -24rem;
+}
+
+.last\\\\:-m-px:last-child {
+  margin: -1px;
+}
+
+.last\\\\:-m-0\\\\.5:last-child {
+  margin: -0.125rem;
+}
+
+.last\\\\:-m-1\\\\.5:last-child {
+  margin: -0.375rem;
+}
+
+.last\\\\:-m-2\\\\.5:last-child {
+  margin: -0.625rem;
+}
+
+.last\\\\:-m-3\\\\.5:last-child {
+  margin: -0.875rem;
+}
+
+.mx-0 {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.mx-1 {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.mx-2 {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.mx-3 {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
+}
+
+.mx-4 {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.mx-5 {
+  margin-left: 1.25rem;
+  margin-right: 1.25rem;
+}
+
+.mx-6 {
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+}
+
+.mx-7 {
+  margin-left: 1.75rem;
+  margin-right: 1.75rem;
+}
+
+.mx-8 {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.mx-9 {
+  margin-left: 2.25rem;
+  margin-right: 2.25rem;
+}
+
+.mx-10 {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
+}
+
+.mx-11 {
+  margin-left: 2.75rem;
+  margin-right: 2.75rem;
+}
+
+.mx-12 {
+  margin-left: 3rem;
+  margin-right: 3rem;
+}
+
+.mx-14 {
+  margin-left: 3.5rem;
+  margin-right: 3.5rem;
+}
+
+.mx-16 {
+  margin-left: 4rem;
+  margin-right: 4rem;
+}
+
+.mx-20 {
+  margin-left: 5rem;
+  margin-right: 5rem;
+}
+
+.mx-24 {
+  margin-left: 6rem;
+  margin-right: 6rem;
+}
+
+.mx-28 {
+  margin-left: 7rem;
+  margin-right: 7rem;
+}
+
+.mx-32 {
+  margin-left: 8rem;
+  margin-right: 8rem;
+}
+
+.mx-36 {
+  margin-left: 9rem;
+  margin-right: 9rem;
+}
+
+.mx-40 {
+  margin-left: 10rem;
+  margin-right: 10rem;
+}
+
+.mx-44 {
+  margin-left: 11rem;
+  margin-right: 11rem;
+}
+
+.mx-48 {
+  margin-left: 12rem;
+  margin-right: 12rem;
+}
+
+.mx-52 {
+  margin-left: 13rem;
+  margin-right: 13rem;
+}
+
+.mx-56 {
+  margin-left: 14rem;
+  margin-right: 14rem;
+}
+
+.mx-60 {
+  margin-left: 15rem;
+  margin-right: 15rem;
+}
+
+.mx-64 {
+  margin-left: 16rem;
+  margin-right: 16rem;
+}
+
+.mx-72 {
+  margin-left: 18rem;
+  margin-right: 18rem;
+}
+
+.mx-80 {
+  margin-left: 20rem;
+  margin-right: 20rem;
+}
+
+.mx-96 {
+  margin-left: 24rem;
+  margin-right: 24rem;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.mx-px {
+  margin-left: 1px;
+  margin-right: 1px;
+}
+
+.mx-0\\\\.5 {
+  margin-left: 0.125rem;
+  margin-right: 0.125rem;
+}
+
+.mx-1\\\\.5 {
+  margin-left: 0.375rem;
+  margin-right: 0.375rem;
+}
+
+.mx-2\\\\.5 {
+  margin-left: 0.625rem;
+  margin-right: 0.625rem;
+}
+
+.mx-3\\\\.5 {
+  margin-left: 0.875rem;
+  margin-right: 0.875rem;
+}
+
+.-mx-0 {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.-mx-1 {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+.-mx-2 {
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+}
+
+.-mx-3 {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
+
+.-mx-4 {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+.-mx-5 {
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+}
+
+.-mx-6 {
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+}
+
+.-mx-7 {
+  margin-left: -1.75rem;
+  margin-right: -1.75rem;
+}
+
+.-mx-8 {
+  margin-left: -2rem;
+  margin-right: -2rem;
+}
+
+.-mx-9 {
+  margin-left: -2.25rem;
+  margin-right: -2.25rem;
+}
+
+.-mx-10 {
+  margin-left: -2.5rem;
+  margin-right: -2.5rem;
+}
+
+.-mx-11 {
+  margin-left: -2.75rem;
+  margin-right: -2.75rem;
+}
+
+.-mx-12 {
+  margin-left: -3rem;
+  margin-right: -3rem;
+}
+
+.-mx-14 {
+  margin-left: -3.5rem;
+  margin-right: -3.5rem;
+}
+
+.-mx-16 {
+  margin-left: -4rem;
+  margin-right: -4rem;
+}
+
+.-mx-20 {
+  margin-left: -5rem;
+  margin-right: -5rem;
+}
+
+.-mx-24 {
+  margin-left: -6rem;
+  margin-right: -6rem;
+}
+
+.-mx-28 {
+  margin-left: -7rem;
+  margin-right: -7rem;
+}
+
+.-mx-32 {
+  margin-left: -8rem;
+  margin-right: -8rem;
+}
+
+.-mx-36 {
+  margin-left: -9rem;
+  margin-right: -9rem;
+}
+
+.-mx-40 {
+  margin-left: -10rem;
+  margin-right: -10rem;
+}
+
+.-mx-44 {
+  margin-left: -11rem;
+  margin-right: -11rem;
+}
+
+.-mx-48 {
+  margin-left: -12rem;
+  margin-right: -12rem;
+}
+
+.-mx-52 {
+  margin-left: -13rem;
+  margin-right: -13rem;
+}
+
+.-mx-56 {
+  margin-left: -14rem;
+  margin-right: -14rem;
+}
+
+.-mx-60 {
+  margin-left: -15rem;
+  margin-right: -15rem;
+}
+
+.-mx-64 {
+  margin-left: -16rem;
+  margin-right: -16rem;
+}
+
+.-mx-72 {
+  margin-left: -18rem;
+  margin-right: -18rem;
+}
+
+.-mx-80 {
+  margin-left: -20rem;
+  margin-right: -20rem;
+}
+
+.-mx-96 {
+  margin-left: -24rem;
+  margin-right: -24rem;
+}
+
+.-mx-px {
+  margin-left: -1px;
+  margin-right: -1px;
+}
+
+.-mx-0\\\\.5 {
+  margin-left: -0.125rem;
+  margin-right: -0.125rem;
+}
+
+.-mx-1\\\\.5 {
+  margin-left: -0.375rem;
+  margin-right: -0.375rem;
+}
+
+.-mx-2\\\\.5 {
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+}
+
+.-mx-3\\\\.5 {
+  margin-left: -0.875rem;
+  margin-right: -0.875rem;
+}
+
+.my-0 {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.my-1 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.my-3 {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.my-5 {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.my-6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.my-7 {
+  margin-top: 1.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.my-8 {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.my-9 {
+  margin-top: 2.25rem;
+  margin-bottom: 2.25rem;
+}
+
+.my-10 {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.my-11 {
+  margin-top: 2.75rem;
+  margin-bottom: 2.75rem;
+}
+
+.my-12 {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
+
+.my-14 {
+  margin-top: 3.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.my-16 {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+
+.my-20 {
+  margin-top: 5rem;
+  margin-bottom: 5rem;
+}
+
+.my-24 {
+  margin-top: 6rem;
+  margin-bottom: 6rem;
+}
+
+.my-28 {
+  margin-top: 7rem;
+  margin-bottom: 7rem;
+}
+
+.my-32 {
+  margin-top: 8rem;
+  margin-bottom: 8rem;
+}
+
+.my-36 {
+  margin-top: 9rem;
+  margin-bottom: 9rem;
+}
+
+.my-40 {
+  margin-top: 10rem;
+  margin-bottom: 10rem;
+}
+
+.my-44 {
+  margin-top: 11rem;
+  margin-bottom: 11rem;
+}
+
+.my-48 {
+  margin-top: 12rem;
+  margin-bottom: 12rem;
+}
+
+.my-52 {
+  margin-top: 13rem;
+  margin-bottom: 13rem;
+}
+
+.my-56 {
+  margin-top: 14rem;
+  margin-bottom: 14rem;
+}
+
+.my-60 {
+  margin-top: 15rem;
+  margin-bottom: 15rem;
+}
+
+.my-64 {
+  margin-top: 16rem;
+  margin-bottom: 16rem;
+}
+
+.my-72 {
+  margin-top: 18rem;
+  margin-bottom: 18rem;
+}
+
+.my-80 {
+  margin-top: 20rem;
+  margin-bottom: 20rem;
+}
+
+.my-96 {
+  margin-top: 24rem;
+  margin-bottom: 24rem;
+}
+
+.my-auto {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.my-px {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+
+.my-0\\\\.5 {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+}
+
+.my-1\\\\.5 {
+  margin-top: 0.375rem;
+  margin-bottom: 0.375rem;
+}
+
+.my-2\\\\.5 {
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+}
+
+.my-3\\\\.5 {
+  margin-top: 0.875rem;
+  margin-bottom: 0.875rem;
+}
+
+.-my-0 {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.-my-1 {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+}
+
+.-my-2 {
+  margin-top: -0.5rem;
+  margin-bottom: -0.5rem;
+}
+
+.-my-3 {
+  margin-top: -0.75rem;
+  margin-bottom: -0.75rem;
+}
+
+.-my-4 {
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+}
+
+.-my-5 {
+  margin-top: -1.25rem;
+  margin-bottom: -1.25rem;
+}
+
+.-my-6 {
+  margin-top: -1.5rem;
+  margin-bottom: -1.5rem;
+}
+
+.-my-7 {
+  margin-top: -1.75rem;
+  margin-bottom: -1.75rem;
+}
+
+.-my-8 {
+  margin-top: -2rem;
+  margin-bottom: -2rem;
+}
+
+.-my-9 {
+  margin-top: -2.25rem;
+  margin-bottom: -2.25rem;
+}
+
+.-my-10 {
+  margin-top: -2.5rem;
+  margin-bottom: -2.5rem;
+}
+
+.-my-11 {
+  margin-top: -2.75rem;
+  margin-bottom: -2.75rem;
+}
+
+.-my-12 {
+  margin-top: -3rem;
+  margin-bottom: -3rem;
+}
+
+.-my-14 {
+  margin-top: -3.5rem;
+  margin-bottom: -3.5rem;
+}
+
+.-my-16 {
+  margin-top: -4rem;
+  margin-bottom: -4rem;
+}
+
+.-my-20 {
+  margin-top: -5rem;
+  margin-bottom: -5rem;
+}
+
+.-my-24 {
+  margin-top: -6rem;
+  margin-bottom: -6rem;
+}
+
+.-my-28 {
+  margin-top: -7rem;
+  margin-bottom: -7rem;
+}
+
+.-my-32 {
+  margin-top: -8rem;
+  margin-bottom: -8rem;
+}
+
+.-my-36 {
+  margin-top: -9rem;
+  margin-bottom: -9rem;
+}
+
+.-my-40 {
+  margin-top: -10rem;
+  margin-bottom: -10rem;
+}
+
+.-my-44 {
+  margin-top: -11rem;
+  margin-bottom: -11rem;
+}
+
+.-my-48 {
+  margin-top: -12rem;
+  margin-bottom: -12rem;
+}
+
+.-my-52 {
+  margin-top: -13rem;
+  margin-bottom: -13rem;
+}
+
+.-my-56 {
+  margin-top: -14rem;
+  margin-bottom: -14rem;
+}
+
+.-my-60 {
+  margin-top: -15rem;
+  margin-bottom: -15rem;
+}
+
+.-my-64 {
+  margin-top: -16rem;
+  margin-bottom: -16rem;
+}
+
+.-my-72 {
+  margin-top: -18rem;
+  margin-bottom: -18rem;
+}
+
+.-my-80 {
+  margin-top: -20rem;
+  margin-bottom: -20rem;
+}
+
+.-my-96 {
+  margin-top: -24rem;
+  margin-bottom: -24rem;
+}
+
+.-my-px {
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+
+.-my-0\\\\.5 {
+  margin-top: -0.125rem;
+  margin-bottom: -0.125rem;
+}
+
+.-my-1\\\\.5 {
+  margin-top: -0.375rem;
+  margin-bottom: -0.375rem;
+}
+
+.-my-2\\\\.5 {
+  margin-top: -0.625rem;
+  margin-bottom: -0.625rem;
+}
+
+.-my-3\\\\.5 {
+  margin-top: -0.875rem;
+  margin-bottom: -0.875rem;
+}
+
+.first\\\\:mx-0:first-child {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.first\\\\:mx-1:first-child {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.first\\\\:mx-2:first-child {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.first\\\\:mx-3:first-child {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
+}
+
+.first\\\\:mx-4:first-child {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.first\\\\:mx-5:first-child {
+  margin-left: 1.25rem;
+  margin-right: 1.25rem;
+}
+
+.first\\\\:mx-6:first-child {
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+}
+
+.first\\\\:mx-7:first-child {
+  margin-left: 1.75rem;
+  margin-right: 1.75rem;
+}
+
+.first\\\\:mx-8:first-child {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.first\\\\:mx-9:first-child {
+  margin-left: 2.25rem;
+  margin-right: 2.25rem;
+}
+
+.first\\\\:mx-10:first-child {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
+}
+
+.first\\\\:mx-11:first-child {
+  margin-left: 2.75rem;
+  margin-right: 2.75rem;
+}
+
+.first\\\\:mx-12:first-child {
+  margin-left: 3rem;
+  margin-right: 3rem;
+}
+
+.first\\\\:mx-14:first-child {
+  margin-left: 3.5rem;
+  margin-right: 3.5rem;
+}
+
+.first\\\\:mx-16:first-child {
+  margin-left: 4rem;
+  margin-right: 4rem;
+}
+
+.first\\\\:mx-20:first-child {
+  margin-left: 5rem;
+  margin-right: 5rem;
+}
+
+.first\\\\:mx-24:first-child {
+  margin-left: 6rem;
+  margin-right: 6rem;
+}
+
+.first\\\\:mx-28:first-child {
+  margin-left: 7rem;
+  margin-right: 7rem;
+}
+
+.first\\\\:mx-32:first-child {
+  margin-left: 8rem;
+  margin-right: 8rem;
+}
+
+.first\\\\:mx-36:first-child {
+  margin-left: 9rem;
+  margin-right: 9rem;
+}
+
+.first\\\\:mx-40:first-child {
+  margin-left: 10rem;
+  margin-right: 10rem;
+}
+
+.first\\\\:mx-44:first-child {
+  margin-left: 11rem;
+  margin-right: 11rem;
+}
+
+.first\\\\:mx-48:first-child {
+  margin-left: 12rem;
+  margin-right: 12rem;
+}
+
+.first\\\\:mx-52:first-child {
+  margin-left: 13rem;
+  margin-right: 13rem;
+}
+
+.first\\\\:mx-56:first-child {
+  margin-left: 14rem;
+  margin-right: 14rem;
+}
+
+.first\\\\:mx-60:first-child {
+  margin-left: 15rem;
+  margin-right: 15rem;
+}
+
+.first\\\\:mx-64:first-child {
+  margin-left: 16rem;
+  margin-right: 16rem;
+}
+
+.first\\\\:mx-72:first-child {
+  margin-left: 18rem;
+  margin-right: 18rem;
+}
+
+.first\\\\:mx-80:first-child {
+  margin-left: 20rem;
+  margin-right: 20rem;
+}
+
+.first\\\\:mx-96:first-child {
+  margin-left: 24rem;
+  margin-right: 24rem;
+}
+
+.first\\\\:mx-auto:first-child {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.first\\\\:mx-px:first-child {
+  margin-left: 1px;
+  margin-right: 1px;
+}
+
+.first\\\\:mx-0\\\\.5:first-child {
+  margin-left: 0.125rem;
+  margin-right: 0.125rem;
+}
+
+.first\\\\:mx-1\\\\.5:first-child {
+  margin-left: 0.375rem;
+  margin-right: 0.375rem;
+}
+
+.first\\\\:mx-2\\\\.5:first-child {
+  margin-left: 0.625rem;
+  margin-right: 0.625rem;
+}
+
+.first\\\\:mx-3\\\\.5:first-child {
+  margin-left: 0.875rem;
+  margin-right: 0.875rem;
+}
+
+.first\\\\:-mx-0:first-child {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.first\\\\:-mx-1:first-child {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+.first\\\\:-mx-2:first-child {
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+}
+
+.first\\\\:-mx-3:first-child {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
+
+.first\\\\:-mx-4:first-child {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+.first\\\\:-mx-5:first-child {
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+}
+
+.first\\\\:-mx-6:first-child {
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+}
+
+.first\\\\:-mx-7:first-child {
+  margin-left: -1.75rem;
+  margin-right: -1.75rem;
+}
+
+.first\\\\:-mx-8:first-child {
+  margin-left: -2rem;
+  margin-right: -2rem;
+}
+
+.first\\\\:-mx-9:first-child {
+  margin-left: -2.25rem;
+  margin-right: -2.25rem;
+}
+
+.first\\\\:-mx-10:first-child {
+  margin-left: -2.5rem;
+  margin-right: -2.5rem;
+}
+
+.first\\\\:-mx-11:first-child {
+  margin-left: -2.75rem;
+  margin-right: -2.75rem;
+}
+
+.first\\\\:-mx-12:first-child {
+  margin-left: -3rem;
+  margin-right: -3rem;
+}
+
+.first\\\\:-mx-14:first-child {
+  margin-left: -3.5rem;
+  margin-right: -3.5rem;
+}
+
+.first\\\\:-mx-16:first-child {
+  margin-left: -4rem;
+  margin-right: -4rem;
+}
+
+.first\\\\:-mx-20:first-child {
+  margin-left: -5rem;
+  margin-right: -5rem;
+}
+
+.first\\\\:-mx-24:first-child {
+  margin-left: -6rem;
+  margin-right: -6rem;
+}
+
+.first\\\\:-mx-28:first-child {
+  margin-left: -7rem;
+  margin-right: -7rem;
+}
+
+.first\\\\:-mx-32:first-child {
+  margin-left: -8rem;
+  margin-right: -8rem;
+}
+
+.first\\\\:-mx-36:first-child {
+  margin-left: -9rem;
+  margin-right: -9rem;
+}
+
+.first\\\\:-mx-40:first-child {
+  margin-left: -10rem;
+  margin-right: -10rem;
+}
+
+.first\\\\:-mx-44:first-child {
+  margin-left: -11rem;
+  margin-right: -11rem;
+}
+
+.first\\\\:-mx-48:first-child {
+  margin-left: -12rem;
+  margin-right: -12rem;
+}
+
+.first\\\\:-mx-52:first-child {
+  margin-left: -13rem;
+  margin-right: -13rem;
+}
+
+.first\\\\:-mx-56:first-child {
+  margin-left: -14rem;
+  margin-right: -14rem;
+}
+
+.first\\\\:-mx-60:first-child {
+  margin-left: -15rem;
+  margin-right: -15rem;
+}
+
+.first\\\\:-mx-64:first-child {
+  margin-left: -16rem;
+  margin-right: -16rem;
+}
+
+.first\\\\:-mx-72:first-child {
+  margin-left: -18rem;
+  margin-right: -18rem;
+}
+
+.first\\\\:-mx-80:first-child {
+  margin-left: -20rem;
+  margin-right: -20rem;
+}
+
+.first\\\\:-mx-96:first-child {
+  margin-left: -24rem;
+  margin-right: -24rem;
+}
+
+.first\\\\:-mx-px:first-child {
+  margin-left: -1px;
+  margin-right: -1px;
+}
+
+.first\\\\:-mx-0\\\\.5:first-child {
+  margin-left: -0.125rem;
+  margin-right: -0.125rem;
+}
+
+.first\\\\:-mx-1\\\\.5:first-child {
+  margin-left: -0.375rem;
+  margin-right: -0.375rem;
+}
+
+.first\\\\:-mx-2\\\\.5:first-child {
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+}
+
+.first\\\\:-mx-3\\\\.5:first-child {
+  margin-left: -0.875rem;
+  margin-right: -0.875rem;
+}
+
+.first\\\\:my-0:first-child {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.first\\\\:my-1:first-child {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.first\\\\:my-2:first-child {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.first\\\\:my-3:first-child {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.first\\\\:my-4:first-child {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.first\\\\:my-5:first-child {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.first\\\\:my-6:first-child {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.first\\\\:my-7:first-child {
+  margin-top: 1.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.first\\\\:my-8:first-child {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.first\\\\:my-9:first-child {
+  margin-top: 2.25rem;
+  margin-bottom: 2.25rem;
+}
+
+.first\\\\:my-10:first-child {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.first\\\\:my-11:first-child {
+  margin-top: 2.75rem;
+  margin-bottom: 2.75rem;
+}
+
+.first\\\\:my-12:first-child {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
+
+.first\\\\:my-14:first-child {
+  margin-top: 3.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.first\\\\:my-16:first-child {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+
+.first\\\\:my-20:first-child {
+  margin-top: 5rem;
+  margin-bottom: 5rem;
+}
+
+.first\\\\:my-24:first-child {
+  margin-top: 6rem;
+  margin-bottom: 6rem;
+}
+
+.first\\\\:my-28:first-child {
+  margin-top: 7rem;
+  margin-bottom: 7rem;
+}
+
+.first\\\\:my-32:first-child {
+  margin-top: 8rem;
+  margin-bottom: 8rem;
+}
+
+.first\\\\:my-36:first-child {
+  margin-top: 9rem;
+  margin-bottom: 9rem;
+}
+
+.first\\\\:my-40:first-child {
+  margin-top: 10rem;
+  margin-bottom: 10rem;
+}
+
+.first\\\\:my-44:first-child {
+  margin-top: 11rem;
+  margin-bottom: 11rem;
+}
+
+.first\\\\:my-48:first-child {
+  margin-top: 12rem;
+  margin-bottom: 12rem;
+}
+
+.first\\\\:my-52:first-child {
+  margin-top: 13rem;
+  margin-bottom: 13rem;
+}
+
+.first\\\\:my-56:first-child {
+  margin-top: 14rem;
+  margin-bottom: 14rem;
+}
+
+.first\\\\:my-60:first-child {
+  margin-top: 15rem;
+  margin-bottom: 15rem;
+}
+
+.first\\\\:my-64:first-child {
+  margin-top: 16rem;
+  margin-bottom: 16rem;
+}
+
+.first\\\\:my-72:first-child {
+  margin-top: 18rem;
+  margin-bottom: 18rem;
+}
+
+.first\\\\:my-80:first-child {
+  margin-top: 20rem;
+  margin-bottom: 20rem;
+}
+
+.first\\\\:my-96:first-child {
+  margin-top: 24rem;
+  margin-bottom: 24rem;
+}
+
+.first\\\\:my-auto:first-child {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.first\\\\:my-px:first-child {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+
+.first\\\\:my-0\\\\.5:first-child {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+}
+
+.first\\\\:my-1\\\\.5:first-child {
+  margin-top: 0.375rem;
+  margin-bottom: 0.375rem;
+}
+
+.first\\\\:my-2\\\\.5:first-child {
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+}
+
+.first\\\\:my-3\\\\.5:first-child {
+  margin-top: 0.875rem;
+  margin-bottom: 0.875rem;
+}
+
+.first\\\\:-my-0:first-child {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.first\\\\:-my-1:first-child {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+}
+
+.first\\\\:-my-2:first-child {
+  margin-top: -0.5rem;
+  margin-bottom: -0.5rem;
+}
+
+.first\\\\:-my-3:first-child {
+  margin-top: -0.75rem;
+  margin-bottom: -0.75rem;
+}
+
+.first\\\\:-my-4:first-child {
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+}
+
+.first\\\\:-my-5:first-child {
+  margin-top: -1.25rem;
+  margin-bottom: -1.25rem;
+}
+
+.first\\\\:-my-6:first-child {
+  margin-top: -1.5rem;
+  margin-bottom: -1.5rem;
+}
+
+.first\\\\:-my-7:first-child {
+  margin-top: -1.75rem;
+  margin-bottom: -1.75rem;
+}
+
+.first\\\\:-my-8:first-child {
+  margin-top: -2rem;
+  margin-bottom: -2rem;
+}
+
+.first\\\\:-my-9:first-child {
+  margin-top: -2.25rem;
+  margin-bottom: -2.25rem;
+}
+
+.first\\\\:-my-10:first-child {
+  margin-top: -2.5rem;
+  margin-bottom: -2.5rem;
+}
+
+.first\\\\:-my-11:first-child {
+  margin-top: -2.75rem;
+  margin-bottom: -2.75rem;
+}
+
+.first\\\\:-my-12:first-child {
+  margin-top: -3rem;
+  margin-bottom: -3rem;
+}
+
+.first\\\\:-my-14:first-child {
+  margin-top: -3.5rem;
+  margin-bottom: -3.5rem;
+}
+
+.first\\\\:-my-16:first-child {
+  margin-top: -4rem;
+  margin-bottom: -4rem;
+}
+
+.first\\\\:-my-20:first-child {
+  margin-top: -5rem;
+  margin-bottom: -5rem;
+}
+
+.first\\\\:-my-24:first-child {
+  margin-top: -6rem;
+  margin-bottom: -6rem;
+}
+
+.first\\\\:-my-28:first-child {
+  margin-top: -7rem;
+  margin-bottom: -7rem;
+}
+
+.first\\\\:-my-32:first-child {
+  margin-top: -8rem;
+  margin-bottom: -8rem;
+}
+
+.first\\\\:-my-36:first-child {
+  margin-top: -9rem;
+  margin-bottom: -9rem;
+}
+
+.first\\\\:-my-40:first-child {
+  margin-top: -10rem;
+  margin-bottom: -10rem;
+}
+
+.first\\\\:-my-44:first-child {
+  margin-top: -11rem;
+  margin-bottom: -11rem;
+}
+
+.first\\\\:-my-48:first-child {
+  margin-top: -12rem;
+  margin-bottom: -12rem;
+}
+
+.first\\\\:-my-52:first-child {
+  margin-top: -13rem;
+  margin-bottom: -13rem;
+}
+
+.first\\\\:-my-56:first-child {
+  margin-top: -14rem;
+  margin-bottom: -14rem;
+}
+
+.first\\\\:-my-60:first-child {
+  margin-top: -15rem;
+  margin-bottom: -15rem;
+}
+
+.first\\\\:-my-64:first-child {
+  margin-top: -16rem;
+  margin-bottom: -16rem;
+}
+
+.first\\\\:-my-72:first-child {
+  margin-top: -18rem;
+  margin-bottom: -18rem;
+}
+
+.first\\\\:-my-80:first-child {
+  margin-top: -20rem;
+  margin-bottom: -20rem;
+}
+
+.first\\\\:-my-96:first-child {
+  margin-top: -24rem;
+  margin-bottom: -24rem;
+}
+
+.first\\\\:-my-px:first-child {
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+
+.first\\\\:-my-0\\\\.5:first-child {
+  margin-top: -0.125rem;
+  margin-bottom: -0.125rem;
+}
+
+.first\\\\:-my-1\\\\.5:first-child {
+  margin-top: -0.375rem;
+  margin-bottom: -0.375rem;
+}
+
+.first\\\\:-my-2\\\\.5:first-child {
+  margin-top: -0.625rem;
+  margin-bottom: -0.625rem;
+}
+
+.first\\\\:-my-3\\\\.5:first-child {
+  margin-top: -0.875rem;
+  margin-bottom: -0.875rem;
+}
+
+.last\\\\:mx-0:last-child {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.last\\\\:mx-1:last-child {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.last\\\\:mx-2:last-child {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.last\\\\:mx-3:last-child {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
+}
+
+.last\\\\:mx-4:last-child {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.last\\\\:mx-5:last-child {
+  margin-left: 1.25rem;
+  margin-right: 1.25rem;
+}
+
+.last\\\\:mx-6:last-child {
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+}
+
+.last\\\\:mx-7:last-child {
+  margin-left: 1.75rem;
+  margin-right: 1.75rem;
+}
+
+.last\\\\:mx-8:last-child {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.last\\\\:mx-9:last-child {
+  margin-left: 2.25rem;
+  margin-right: 2.25rem;
+}
+
+.last\\\\:mx-10:last-child {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
+}
+
+.last\\\\:mx-11:last-child {
+  margin-left: 2.75rem;
+  margin-right: 2.75rem;
+}
+
+.last\\\\:mx-12:last-child {
+  margin-left: 3rem;
+  margin-right: 3rem;
+}
+
+.last\\\\:mx-14:last-child {
+  margin-left: 3.5rem;
+  margin-right: 3.5rem;
+}
+
+.last\\\\:mx-16:last-child {
+  margin-left: 4rem;
+  margin-right: 4rem;
+}
+
+.last\\\\:mx-20:last-child {
+  margin-left: 5rem;
+  margin-right: 5rem;
+}
+
+.last\\\\:mx-24:last-child {
+  margin-left: 6rem;
+  margin-right: 6rem;
+}
+
+.last\\\\:mx-28:last-child {
+  margin-left: 7rem;
+  margin-right: 7rem;
+}
+
+.last\\\\:mx-32:last-child {
+  margin-left: 8rem;
+  margin-right: 8rem;
+}
+
+.last\\\\:mx-36:last-child {
+  margin-left: 9rem;
+  margin-right: 9rem;
+}
+
+.last\\\\:mx-40:last-child {
+  margin-left: 10rem;
+  margin-right: 10rem;
+}
+
+.last\\\\:mx-44:last-child {
+  margin-left: 11rem;
+  margin-right: 11rem;
+}
+
+.last\\\\:mx-48:last-child {
+  margin-left: 12rem;
+  margin-right: 12rem;
+}
+
+.last\\\\:mx-52:last-child {
+  margin-left: 13rem;
+  margin-right: 13rem;
+}
+
+.last\\\\:mx-56:last-child {
+  margin-left: 14rem;
+  margin-right: 14rem;
+}
+
+.last\\\\:mx-60:last-child {
+  margin-left: 15rem;
+  margin-right: 15rem;
+}
+
+.last\\\\:mx-64:last-child {
+  margin-left: 16rem;
+  margin-right: 16rem;
+}
+
+.last\\\\:mx-72:last-child {
+  margin-left: 18rem;
+  margin-right: 18rem;
+}
+
+.last\\\\:mx-80:last-child {
+  margin-left: 20rem;
+  margin-right: 20rem;
+}
+
+.last\\\\:mx-96:last-child {
+  margin-left: 24rem;
+  margin-right: 24rem;
+}
+
+.last\\\\:mx-auto:last-child {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.last\\\\:mx-px:last-child {
+  margin-left: 1px;
+  margin-right: 1px;
+}
+
+.last\\\\:mx-0\\\\.5:last-child {
+  margin-left: 0.125rem;
+  margin-right: 0.125rem;
+}
+
+.last\\\\:mx-1\\\\.5:last-child {
+  margin-left: 0.375rem;
+  margin-right: 0.375rem;
+}
+
+.last\\\\:mx-2\\\\.5:last-child {
+  margin-left: 0.625rem;
+  margin-right: 0.625rem;
+}
+
+.last\\\\:mx-3\\\\.5:last-child {
+  margin-left: 0.875rem;
+  margin-right: 0.875rem;
+}
+
+.last\\\\:-mx-0:last-child {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.last\\\\:-mx-1:last-child {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+.last\\\\:-mx-2:last-child {
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+}
+
+.last\\\\:-mx-3:last-child {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
+
+.last\\\\:-mx-4:last-child {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+.last\\\\:-mx-5:last-child {
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+}
+
+.last\\\\:-mx-6:last-child {
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+}
+
+.last\\\\:-mx-7:last-child {
+  margin-left: -1.75rem;
+  margin-right: -1.75rem;
+}
+
+.last\\\\:-mx-8:last-child {
+  margin-left: -2rem;
+  margin-right: -2rem;
+}
+
+.last\\\\:-mx-9:last-child {
+  margin-left: -2.25rem;
+  margin-right: -2.25rem;
+}
+
+.last\\\\:-mx-10:last-child {
+  margin-left: -2.5rem;
+  margin-right: -2.5rem;
+}
+
+.last\\\\:-mx-11:last-child {
+  margin-left: -2.75rem;
+  margin-right: -2.75rem;
+}
+
+.last\\\\:-mx-12:last-child {
+  margin-left: -3rem;
+  margin-right: -3rem;
+}
+
+.last\\\\:-mx-14:last-child {
+  margin-left: -3.5rem;
+  margin-right: -3.5rem;
+}
+
+.last\\\\:-mx-16:last-child {
+  margin-left: -4rem;
+  margin-right: -4rem;
+}
+
+.last\\\\:-mx-20:last-child {
+  margin-left: -5rem;
+  margin-right: -5rem;
+}
+
+.last\\\\:-mx-24:last-child {
+  margin-left: -6rem;
+  margin-right: -6rem;
+}
+
+.last\\\\:-mx-28:last-child {
+  margin-left: -7rem;
+  margin-right: -7rem;
+}
+
+.last\\\\:-mx-32:last-child {
+  margin-left: -8rem;
+  margin-right: -8rem;
+}
+
+.last\\\\:-mx-36:last-child {
+  margin-left: -9rem;
+  margin-right: -9rem;
+}
+
+.last\\\\:-mx-40:last-child {
+  margin-left: -10rem;
+  margin-right: -10rem;
+}
+
+.last\\\\:-mx-44:last-child {
+  margin-left: -11rem;
+  margin-right: -11rem;
+}
+
+.last\\\\:-mx-48:last-child {
+  margin-left: -12rem;
+  margin-right: -12rem;
+}
+
+.last\\\\:-mx-52:last-child {
+  margin-left: -13rem;
+  margin-right: -13rem;
+}
+
+.last\\\\:-mx-56:last-child {
+  margin-left: -14rem;
+  margin-right: -14rem;
+}
+
+.last\\\\:-mx-60:last-child {
+  margin-left: -15rem;
+  margin-right: -15rem;
+}
+
+.last\\\\:-mx-64:last-child {
+  margin-left: -16rem;
+  margin-right: -16rem;
+}
+
+.last\\\\:-mx-72:last-child {
+  margin-left: -18rem;
+  margin-right: -18rem;
+}
+
+.last\\\\:-mx-80:last-child {
+  margin-left: -20rem;
+  margin-right: -20rem;
+}
+
+.last\\\\:-mx-96:last-child {
+  margin-left: -24rem;
+  margin-right: -24rem;
+}
+
+.last\\\\:-mx-px:last-child {
+  margin-left: -1px;
+  margin-right: -1px;
+}
+
+.last\\\\:-mx-0\\\\.5:last-child {
+  margin-left: -0.125rem;
+  margin-right: -0.125rem;
+}
+
+.last\\\\:-mx-1\\\\.5:last-child {
+  margin-left: -0.375rem;
+  margin-right: -0.375rem;
+}
+
+.last\\\\:-mx-2\\\\.5:last-child {
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+}
+
+.last\\\\:-mx-3\\\\.5:last-child {
+  margin-left: -0.875rem;
+  margin-right: -0.875rem;
+}
+
+.last\\\\:my-0:last-child {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.last\\\\:my-1:last-child {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.last\\\\:my-2:last-child {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.last\\\\:my-3:last-child {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.last\\\\:my-4:last-child {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.last\\\\:my-5:last-child {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.last\\\\:my-6:last-child {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.last\\\\:my-7:last-child {
+  margin-top: 1.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.last\\\\:my-8:last-child {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.last\\\\:my-9:last-child {
+  margin-top: 2.25rem;
+  margin-bottom: 2.25rem;
+}
+
+.last\\\\:my-10:last-child {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.last\\\\:my-11:last-child {
+  margin-top: 2.75rem;
+  margin-bottom: 2.75rem;
+}
+
+.last\\\\:my-12:last-child {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
+
+.last\\\\:my-14:last-child {
+  margin-top: 3.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.last\\\\:my-16:last-child {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+
+.last\\\\:my-20:last-child {
+  margin-top: 5rem;
+  margin-bottom: 5rem;
+}
+
+.last\\\\:my-24:last-child {
+  margin-top: 6rem;
+  margin-bottom: 6rem;
+}
+
+.last\\\\:my-28:last-child {
+  margin-top: 7rem;
+  margin-bottom: 7rem;
+}
+
+.last\\\\:my-32:last-child {
+  margin-top: 8rem;
+  margin-bottom: 8rem;
+}
+
+.last\\\\:my-36:last-child {
+  margin-top: 9rem;
+  margin-bottom: 9rem;
+}
+
+.last\\\\:my-40:last-child {
+  margin-top: 10rem;
+  margin-bottom: 10rem;
+}
+
+.last\\\\:my-44:last-child {
+  margin-top: 11rem;
+  margin-bottom: 11rem;
+}
+
+.last\\\\:my-48:last-child {
+  margin-top: 12rem;
+  margin-bottom: 12rem;
+}
+
+.last\\\\:my-52:last-child {
+  margin-top: 13rem;
+  margin-bottom: 13rem;
+}
+
+.last\\\\:my-56:last-child {
+  margin-top: 14rem;
+  margin-bottom: 14rem;
+}
+
+.last\\\\:my-60:last-child {
+  margin-top: 15rem;
+  margin-bottom: 15rem;
+}
+
+.last\\\\:my-64:last-child {
+  margin-top: 16rem;
+  margin-bottom: 16rem;
+}
+
+.last\\\\:my-72:last-child {
+  margin-top: 18rem;
+  margin-bottom: 18rem;
+}
+
+.last\\\\:my-80:last-child {
+  margin-top: 20rem;
+  margin-bottom: 20rem;
+}
+
+.last\\\\:my-96:last-child {
+  margin-top: 24rem;
+  margin-bottom: 24rem;
+}
+
+.last\\\\:my-auto:last-child {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.last\\\\:my-px:last-child {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+
+.last\\\\:my-0\\\\.5:last-child {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+}
+
+.last\\\\:my-1\\\\.5:last-child {
+  margin-top: 0.375rem;
+  margin-bottom: 0.375rem;
+}
+
+.last\\\\:my-2\\\\.5:last-child {
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+}
+
+.last\\\\:my-3\\\\.5:last-child {
+  margin-top: 0.875rem;
+  margin-bottom: 0.875rem;
+}
+
+.last\\\\:-my-0:last-child {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.last\\\\:-my-1:last-child {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+}
+
+.last\\\\:-my-2:last-child {
+  margin-top: -0.5rem;
+  margin-bottom: -0.5rem;
+}
+
+.last\\\\:-my-3:last-child {
+  margin-top: -0.75rem;
+  margin-bottom: -0.75rem;
+}
+
+.last\\\\:-my-4:last-child {
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+}
+
+.last\\\\:-my-5:last-child {
+  margin-top: -1.25rem;
+  margin-bottom: -1.25rem;
+}
+
+.last\\\\:-my-6:last-child {
+  margin-top: -1.5rem;
+  margin-bottom: -1.5rem;
+}
+
+.last\\\\:-my-7:last-child {
+  margin-top: -1.75rem;
+  margin-bottom: -1.75rem;
+}
+
+.last\\\\:-my-8:last-child {
+  margin-top: -2rem;
+  margin-bottom: -2rem;
+}
+
+.last\\\\:-my-9:last-child {
+  margin-top: -2.25rem;
+  margin-bottom: -2.25rem;
+}
+
+.last\\\\:-my-10:last-child {
+  margin-top: -2.5rem;
+  margin-bottom: -2.5rem;
+}
+
+.last\\\\:-my-11:last-child {
+  margin-top: -2.75rem;
+  margin-bottom: -2.75rem;
+}
+
+.last\\\\:-my-12:last-child {
+  margin-top: -3rem;
+  margin-bottom: -3rem;
+}
+
+.last\\\\:-my-14:last-child {
+  margin-top: -3.5rem;
+  margin-bottom: -3.5rem;
+}
+
+.last\\\\:-my-16:last-child {
+  margin-top: -4rem;
+  margin-bottom: -4rem;
+}
+
+.last\\\\:-my-20:last-child {
+  margin-top: -5rem;
+  margin-bottom: -5rem;
+}
+
+.last\\\\:-my-24:last-child {
+  margin-top: -6rem;
+  margin-bottom: -6rem;
+}
+
+.last\\\\:-my-28:last-child {
+  margin-top: -7rem;
+  margin-bottom: -7rem;
+}
+
+.last\\\\:-my-32:last-child {
+  margin-top: -8rem;
+  margin-bottom: -8rem;
+}
+
+.last\\\\:-my-36:last-child {
+  margin-top: -9rem;
+  margin-bottom: -9rem;
+}
+
+.last\\\\:-my-40:last-child {
+  margin-top: -10rem;
+  margin-bottom: -10rem;
+}
+
+.last\\\\:-my-44:last-child {
+  margin-top: -11rem;
+  margin-bottom: -11rem;
+}
+
+.last\\\\:-my-48:last-child {
+  margin-top: -12rem;
+  margin-bottom: -12rem;
+}
+
+.last\\\\:-my-52:last-child {
+  margin-top: -13rem;
+  margin-bottom: -13rem;
+}
+
+.last\\\\:-my-56:last-child {
+  margin-top: -14rem;
+  margin-bottom: -14rem;
+}
+
+.last\\\\:-my-60:last-child {
+  margin-top: -15rem;
+  margin-bottom: -15rem;
+}
+
+.last\\\\:-my-64:last-child {
+  margin-top: -16rem;
+  margin-bottom: -16rem;
+}
+
+.last\\\\:-my-72:last-child {
+  margin-top: -18rem;
+  margin-bottom: -18rem;
+}
+
+.last\\\\:-my-80:last-child {
+  margin-top: -20rem;
+  margin-bottom: -20rem;
+}
+
+.last\\\\:-my-96:last-child {
+  margin-top: -24rem;
+  margin-bottom: -24rem;
+}
+
+.last\\\\:-my-px:last-child {
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+
+.last\\\\:-my-0\\\\.5:last-child {
+  margin-top: -0.125rem;
+  margin-bottom: -0.125rem;
+}
+
+.last\\\\:-my-1\\\\.5:last-child {
+  margin-top: -0.375rem;
+  margin-bottom: -0.375rem;
+}
+
+.last\\\\:-my-2\\\\.5:last-child {
+  margin-top: -0.625rem;
+  margin-bottom: -0.625rem;
+}
+
+.last\\\\:-my-3\\\\.5:last-child {
+  margin-top: -0.875rem;
+  margin-bottom: -0.875rem;
+}
+
+.mt-0 {
+  margin-top: 0px;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
+}
+
+.mt-5 {
+  margin-top: 1.25rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mt-7 {
+  margin-top: 1.75rem;
+}
+
+.mt-8 {
+  margin-top: 2rem;
+}
+
+.mt-9 {
+  margin-top: 2.25rem;
+}
+
+.mt-10 {
+  margin-top: 2.5rem;
+}
+
+.mt-11 {
+  margin-top: 2.75rem;
+}
+
+.mt-12 {
+  margin-top: 3rem;
+}
+
+.mt-14 {
+  margin-top: 3.5rem;
+}
+
+.mt-16 {
+  margin-top: 4rem;
+}
+
+.mt-20 {
+  margin-top: 5rem;
+}
+
+.mt-24 {
+  margin-top: 6rem;
+}
+
+.mt-28 {
+  margin-top: 7rem;
+}
+
+.mt-32 {
+  margin-top: 8rem;
+}
+
+.mt-36 {
+  margin-top: 9rem;
+}
+
+.mt-40 {
+  margin-top: 10rem;
+}
+
+.mt-44 {
+  margin-top: 11rem;
+}
+
+.mt-48 {
+  margin-top: 12rem;
+}
+
+.mt-52 {
+  margin-top: 13rem;
+}
+
+.mt-56 {
+  margin-top: 14rem;
+}
+
+.mt-60 {
+  margin-top: 15rem;
+}
+
+.mt-64 {
+  margin-top: 16rem;
+}
+
+.mt-72 {
+  margin-top: 18rem;
+}
+
+.mt-80 {
+  margin-top: 20rem;
+}
+
+.mt-96 {
+  margin-top: 24rem;
+}
+
+.mt-auto {
+  margin-top: auto;
+}
+
+.mt-px {
+  margin-top: 1px;
+}
+
+.mt-0\\\\.5 {
+  margin-top: 0.125rem;
+}
+
+.mt-1\\\\.5 {
+  margin-top: 0.375rem;
+}
+
+.mt-2\\\\.5 {
+  margin-top: 0.625rem;
+}
+
+.mt-3\\\\.5 {
+  margin-top: 0.875rem;
+}
+
+.-mt-0 {
+  margin-top: 0px;
+}
+
+.-mt-1 {
+  margin-top: -0.25rem;
+}
+
+.-mt-2 {
+  margin-top: -0.5rem;
+}
+
+.-mt-3 {
+  margin-top: -0.75rem;
+}
+
+.-mt-4 {
+  margin-top: -1rem;
+}
+
+.-mt-5 {
+  margin-top: -1.25rem;
+}
+
+.-mt-6 {
+  margin-top: -1.5rem;
+}
+
+.-mt-7 {
+  margin-top: -1.75rem;
+}
+
+.-mt-8 {
+  margin-top: -2rem;
+}
+
+.-mt-9 {
+  margin-top: -2.25rem;
+}
+
+.-mt-10 {
+  margin-top: -2.5rem;
+}
+
+.-mt-11 {
+  margin-top: -2.75rem;
+}
+
+.-mt-12 {
+  margin-top: -3rem;
+}
+
+.-mt-14 {
+  margin-top: -3.5rem;
+}
+
+.-mt-16 {
+  margin-top: -4rem;
+}
+
+.-mt-20 {
+  margin-top: -5rem;
+}
+
+.-mt-24 {
+  margin-top: -6rem;
+}
+
+.-mt-28 {
+  margin-top: -7rem;
+}
+
+.-mt-32 {
+  margin-top: -8rem;
+}
+
+.-mt-36 {
+  margin-top: -9rem;
+}
+
+.-mt-40 {
+  margin-top: -10rem;
+}
+
+.-mt-44 {
+  margin-top: -11rem;
+}
+
+.-mt-48 {
+  margin-top: -12rem;
+}
+
+.-mt-52 {
+  margin-top: -13rem;
+}
+
+.-mt-56 {
+  margin-top: -14rem;
+}
+
+.-mt-60 {
+  margin-top: -15rem;
+}
+
+.-mt-64 {
+  margin-top: -16rem;
+}
+
+.-mt-72 {
+  margin-top: -18rem;
+}
+
+.-mt-80 {
+  margin-top: -20rem;
+}
+
+.-mt-96 {
+  margin-top: -24rem;
+}
+
+.-mt-px {
+  margin-top: -1px;
+}
+
+.-mt-0\\\\.5 {
+  margin-top: -0.125rem;
+}
+
+.-mt-1\\\\.5 {
+  margin-top: -0.375rem;
+}
+
+.-mt-2\\\\.5 {
+  margin-top: -0.625rem;
+}
+
+.-mt-3\\\\.5 {
+  margin-top: -0.875rem;
+}
+
+.mr-0 {
+  margin-right: 0px;
+}
+
+.mr-1 {
+  margin-right: 0.25rem;
+}
+
+.mr-2 {
+  margin-right: 0.5rem;
+}
+
+.mr-3 {
+  margin-right: 0.75rem;
+}
+
+.mr-4 {
+  margin-right: 1rem;
+}
+
+.mr-5 {
+  margin-right: 1.25rem;
+}
+
+.mr-6 {
+  margin-right: 1.5rem;
+}
+
+.mr-7 {
+  margin-right: 1.75rem;
+}
+
+.mr-8 {
+  margin-right: 2rem;
+}
+
+.mr-9 {
+  margin-right: 2.25rem;
+}
+
+.mr-10 {
+  margin-right: 2.5rem;
+}
+
+.mr-11 {
+  margin-right: 2.75rem;
+}
+
+.mr-12 {
+  margin-right: 3rem;
+}
+
+.mr-14 {
+  margin-right: 3.5rem;
+}
+
+.mr-16 {
+  margin-right: 4rem;
+}
+
+.mr-20 {
+  margin-right: 5rem;
+}
+
+.mr-24 {
+  margin-right: 6rem;
+}
+
+.mr-28 {
+  margin-right: 7rem;
+}
+
+.mr-32 {
+  margin-right: 8rem;
+}
+
+.mr-36 {
+  margin-right: 9rem;
+}
+
+.mr-40 {
+  margin-right: 10rem;
+}
+
+.mr-44 {
+  margin-right: 11rem;
+}
+
+.mr-48 {
+  margin-right: 12rem;
+}
+
+.mr-52 {
+  margin-right: 13rem;
+}
+
+.mr-56 {
+  margin-right: 14rem;
+}
+
+.mr-60 {
+  margin-right: 15rem;
+}
+
+.mr-64 {
+  margin-right: 16rem;
+}
+
+.mr-72 {
+  margin-right: 18rem;
+}
+
+.mr-80 {
+  margin-right: 20rem;
+}
+
+.mr-96 {
+  margin-right: 24rem;
+}
+
+.mr-auto {
+  margin-right: auto;
+}
+
+.mr-px {
+  margin-right: 1px;
+}
+
+.mr-0\\\\.5 {
+  margin-right: 0.125rem;
+}
+
+.mr-1\\\\.5 {
+  margin-right: 0.375rem;
+}
+
+.mr-2\\\\.5 {
+  margin-right: 0.625rem;
+}
+
+.mr-3\\\\.5 {
+  margin-right: 0.875rem;
+}
+
+.-mr-0 {
+  margin-right: 0px;
+}
+
+.-mr-1 {
+  margin-right: -0.25rem;
+}
+
+.-mr-2 {
+  margin-right: -0.5rem;
+}
+
+.-mr-3 {
+  margin-right: -0.75rem;
+}
+
+.-mr-4 {
+  margin-right: -1rem;
+}
+
+.-mr-5 {
+  margin-right: -1.25rem;
+}
+
+.-mr-6 {
+  margin-right: -1.5rem;
+}
+
+.-mr-7 {
+  margin-right: -1.75rem;
+}
+
+.-mr-8 {
+  margin-right: -2rem;
+}
+
+.-mr-9 {
+  margin-right: -2.25rem;
+}
+
+.-mr-10 {
+  margin-right: -2.5rem;
+}
+
+.-mr-11 {
+  margin-right: -2.75rem;
+}
+
+.-mr-12 {
+  margin-right: -3rem;
+}
+
+.-mr-14 {
+  margin-right: -3.5rem;
+}
+
+.-mr-16 {
+  margin-right: -4rem;
+}
+
+.-mr-20 {
+  margin-right: -5rem;
+}
+
+.-mr-24 {
+  margin-right: -6rem;
+}
+
+.-mr-28 {
+  margin-right: -7rem;
+}
+
+.-mr-32 {
+  margin-right: -8rem;
+}
+
+.-mr-36 {
+  margin-right: -9rem;
+}
+
+.-mr-40 {
+  margin-right: -10rem;
+}
+
+.-mr-44 {
+  margin-right: -11rem;
+}
+
+.-mr-48 {
+  margin-right: -12rem;
+}
+
+.-mr-52 {
+  margin-right: -13rem;
+}
+
+.-mr-56 {
+  margin-right: -14rem;
+}
+
+.-mr-60 {
+  margin-right: -15rem;
+}
+
+.-mr-64 {
+  margin-right: -16rem;
+}
+
+.-mr-72 {
+  margin-right: -18rem;
+}
+
+.-mr-80 {
+  margin-right: -20rem;
+}
+
+.-mr-96 {
+  margin-right: -24rem;
+}
+
+.-mr-px {
+  margin-right: -1px;
+}
+
+.-mr-0\\\\.5 {
+  margin-right: -0.125rem;
+}
+
+.-mr-1\\\\.5 {
+  margin-right: -0.375rem;
+}
+
+.-mr-2\\\\.5 {
+  margin-right: -0.625rem;
+}
+
+.-mr-3\\\\.5 {
+  margin-right: -0.875rem;
+}
+
+.mb-0 {
+  margin-bottom: 0px;
+}
+
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mb-5 {
+  margin-bottom: 1.25rem;
+}
+
+.mb-6 {
+  margin-bottom: 1.5rem;
+}
+
+.mb-7 {
+  margin-bottom: 1.75rem;
+}
+
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
+.mb-9 {
+  margin-bottom: 2.25rem;
+}
+
+.mb-10 {
+  margin-bottom: 2.5rem;
+}
+
+.mb-11 {
+  margin-bottom: 2.75rem;
+}
+
+.mb-12 {
+  margin-bottom: 3rem;
+}
+
+.mb-14 {
+  margin-bottom: 3.5rem;
+}
+
+.mb-16 {
+  margin-bottom: 4rem;
+}
+
+.mb-20 {
+  margin-bottom: 5rem;
+}
+
+.mb-24 {
+  margin-bottom: 6rem;
+}
+
+.mb-28 {
+  margin-bottom: 7rem;
+}
+
+.mb-32 {
+  margin-bottom: 8rem;
+}
+
+.mb-36 {
+  margin-bottom: 9rem;
+}
+
+.mb-40 {
+  margin-bottom: 10rem;
+}
+
+.mb-44 {
+  margin-bottom: 11rem;
+}
+
+.mb-48 {
+  margin-bottom: 12rem;
+}
+
+.mb-52 {
+  margin-bottom: 13rem;
+}
+
+.mb-56 {
+  margin-bottom: 14rem;
+}
+
+.mb-60 {
+  margin-bottom: 15rem;
+}
+
+.mb-64 {
+  margin-bottom: 16rem;
+}
+
+.mb-72 {
+  margin-bottom: 18rem;
+}
+
+.mb-80 {
+  margin-bottom: 20rem;
+}
+
+.mb-96 {
+  margin-bottom: 24rem;
+}
+
+.mb-auto {
+  margin-bottom: auto;
+}
+
+.mb-px {
+  margin-bottom: 1px;
+}
+
+.mb-0\\\\.5 {
+  margin-bottom: 0.125rem;
+}
+
+.mb-1\\\\.5 {
+  margin-bottom: 0.375rem;
+}
+
+.mb-2\\\\.5 {
+  margin-bottom: 0.625rem;
+}
+
+.mb-3\\\\.5 {
+  margin-bottom: 0.875rem;
+}
+
+.-mb-0 {
+  margin-bottom: 0px;
+}
+
+.-mb-1 {
+  margin-bottom: -0.25rem;
+}
+
+.-mb-2 {
+  margin-bottom: -0.5rem;
+}
+
+.-mb-3 {
+  margin-bottom: -0.75rem;
+}
+
+.-mb-4 {
+  margin-bottom: -1rem;
+}
+
+.-mb-5 {
+  margin-bottom: -1.25rem;
+}
+
+.-mb-6 {
+  margin-bottom: -1.5rem;
+}
+
+.-mb-7 {
+  margin-bottom: -1.75rem;
+}
+
+.-mb-8 {
+  margin-bottom: -2rem;
+}
+
+.-mb-9 {
+  margin-bottom: -2.25rem;
+}
+
+.-mb-10 {
+  margin-bottom: -2.5rem;
+}
+
+.-mb-11 {
+  margin-bottom: -2.75rem;
+}
+
+.-mb-12 {
+  margin-bottom: -3rem;
+}
+
+.-mb-14 {
+  margin-bottom: -3.5rem;
+}
+
+.-mb-16 {
+  margin-bottom: -4rem;
+}
+
+.-mb-20 {
+  margin-bottom: -5rem;
+}
+
+.-mb-24 {
+  margin-bottom: -6rem;
+}
+
+.-mb-28 {
+  margin-bottom: -7rem;
+}
+
+.-mb-32 {
+  margin-bottom: -8rem;
+}
+
+.-mb-36 {
+  margin-bottom: -9rem;
+}
+
+.-mb-40 {
+  margin-bottom: -10rem;
+}
+
+.-mb-44 {
+  margin-bottom: -11rem;
+}
+
+.-mb-48 {
+  margin-bottom: -12rem;
+}
+
+.-mb-52 {
+  margin-bottom: -13rem;
+}
+
+.-mb-56 {
+  margin-bottom: -14rem;
+}
+
+.-mb-60 {
+  margin-bottom: -15rem;
+}
+
+.-mb-64 {
+  margin-bottom: -16rem;
+}
+
+.-mb-72 {
+  margin-bottom: -18rem;
+}
+
+.-mb-80 {
+  margin-bottom: -20rem;
+}
+
+.-mb-96 {
+  margin-bottom: -24rem;
+}
+
+.-mb-px {
+  margin-bottom: -1px;
+}
+
+.-mb-0\\\\.5 {
+  margin-bottom: -0.125rem;
+}
+
+.-mb-1\\\\.5 {
+  margin-bottom: -0.375rem;
+}
+
+.-mb-2\\\\.5 {
+  margin-bottom: -0.625rem;
+}
+
+.-mb-3\\\\.5 {
+  margin-bottom: -0.875rem;
+}
+
+.ml-0 {
+  margin-left: 0px;
+}
+
+.ml-1 {
+  margin-left: 0.25rem;
+}
+
+.ml-2 {
+  margin-left: 0.5rem;
+}
+
+.ml-3 {
+  margin-left: 0.75rem;
+}
+
+.ml-4 {
+  margin-left: 1rem;
+}
+
+.ml-5 {
+  margin-left: 1.25rem;
+}
+
+.ml-6 {
+  margin-left: 1.5rem;
+}
+
+.ml-7 {
+  margin-left: 1.75rem;
+}
+
+.ml-8 {
+  margin-left: 2rem;
+}
+
+.ml-9 {
+  margin-left: 2.25rem;
+}
+
+.ml-10 {
+  margin-left: 2.5rem;
+}
+
+.ml-11 {
+  margin-left: 2.75rem;
+}
+
+.ml-12 {
+  margin-left: 3rem;
+}
+
+.ml-14 {
+  margin-left: 3.5rem;
+}
+
+.ml-16 {
+  margin-left: 4rem;
+}
+
+.ml-20 {
+  margin-left: 5rem;
+}
+
+.ml-24 {
+  margin-left: 6rem;
+}
+
+.ml-28 {
+  margin-left: 7rem;
+}
+
+.ml-32 {
+  margin-left: 8rem;
+}
+
+.ml-36 {
+  margin-left: 9rem;
+}
+
+.ml-40 {
+  margin-left: 10rem;
+}
+
+.ml-44 {
+  margin-left: 11rem;
+}
+
+.ml-48 {
+  margin-left: 12rem;
+}
+
+.ml-52 {
+  margin-left: 13rem;
+}
+
+.ml-56 {
+  margin-left: 14rem;
+}
+
+.ml-60 {
+  margin-left: 15rem;
+}
+
+.ml-64 {
+  margin-left: 16rem;
+}
+
+.ml-72 {
+  margin-left: 18rem;
+}
+
+.ml-80 {
+  margin-left: 20rem;
+}
+
+.ml-96 {
+  margin-left: 24rem;
+}
+
+.ml-auto {
+  margin-left: auto;
+}
+
+.ml-px {
+  margin-left: 1px;
+}
+
+.ml-0\\\\.5 {
+  margin-left: 0.125rem;
+}
+
+.ml-1\\\\.5 {
+  margin-left: 0.375rem;
+}
+
+.ml-2\\\\.5 {
+  margin-left: 0.625rem;
+}
+
+.ml-3\\\\.5 {
+  margin-left: 0.875rem;
+}
+
+.-ml-0 {
+  margin-left: 0px;
+}
+
+.-ml-1 {
+  margin-left: -0.25rem;
+}
+
+.-ml-2 {
+  margin-left: -0.5rem;
+}
+
+.-ml-3 {
+  margin-left: -0.75rem;
+}
+
+.-ml-4 {
+  margin-left: -1rem;
+}
+
+.-ml-5 {
+  margin-left: -1.25rem;
+}
+
+.-ml-6 {
+  margin-left: -1.5rem;
+}
+
+.-ml-7 {
+  margin-left: -1.75rem;
+}
+
+.-ml-8 {
+  margin-left: -2rem;
+}
+
+.-ml-9 {
+  margin-left: -2.25rem;
+}
+
+.-ml-10 {
+  margin-left: -2.5rem;
+}
+
+.-ml-11 {
+  margin-left: -2.75rem;
+}
+
+.-ml-12 {
+  margin-left: -3rem;
+}
+
+.-ml-14 {
+  margin-left: -3.5rem;
+}
+
+.-ml-16 {
+  margin-left: -4rem;
+}
+
+.-ml-20 {
+  margin-left: -5rem;
+}
+
+.-ml-24 {
+  margin-left: -6rem;
+}
+
+.-ml-28 {
+  margin-left: -7rem;
+}
+
+.-ml-32 {
+  margin-left: -8rem;
+}
+
+.-ml-36 {
+  margin-left: -9rem;
+}
+
+.-ml-40 {
+  margin-left: -10rem;
+}
+
+.-ml-44 {
+  margin-left: -11rem;
+}
+
+.-ml-48 {
+  margin-left: -12rem;
+}
+
+.-ml-52 {
+  margin-left: -13rem;
+}
+
+.-ml-56 {
+  margin-left: -14rem;
+}
+
+.-ml-60 {
+  margin-left: -15rem;
+}
+
+.-ml-64 {
+  margin-left: -16rem;
+}
+
+.-ml-72 {
+  margin-left: -18rem;
+}
+
+.-ml-80 {
+  margin-left: -20rem;
+}
+
+.-ml-96 {
+  margin-left: -24rem;
+}
+
+.-ml-px {
+  margin-left: -1px;
+}
+
+.-ml-0\\\\.5 {
+  margin-left: -0.125rem;
+}
+
+.-ml-1\\\\.5 {
+  margin-left: -0.375rem;
+}
+
+.-ml-2\\\\.5 {
+  margin-left: -0.625rem;
+}
+
+.-ml-3\\\\.5 {
+  margin-left: -0.875rem;
+}
+
+.first\\\\:mt-0:first-child {
+  margin-top: 0px;
+}
+
+.first\\\\:mt-1:first-child {
+  margin-top: 0.25rem;
+}
+
+.first\\\\:mt-2:first-child {
+  margin-top: 0.5rem;
+}
+
+.first\\\\:mt-3:first-child {
+  margin-top: 0.75rem;
+}
+
+.first\\\\:mt-4:first-child {
+  margin-top: 1rem;
+}
+
+.first\\\\:mt-5:first-child {
+  margin-top: 1.25rem;
+}
+
+.first\\\\:mt-6:first-child {
+  margin-top: 1.5rem;
+}
+
+.first\\\\:mt-7:first-child {
+  margin-top: 1.75rem;
+}
+
+.first\\\\:mt-8:first-child {
+  margin-top: 2rem;
+}
+
+.first\\\\:mt-9:first-child {
+  margin-top: 2.25rem;
+}
+
+.first\\\\:mt-10:first-child {
+  margin-top: 2.5rem;
+}
+
+.first\\\\:mt-11:first-child {
+  margin-top: 2.75rem;
+}
+
+.first\\\\:mt-12:first-child {
+  margin-top: 3rem;
+}
+
+.first\\\\:mt-14:first-child {
+  margin-top: 3.5rem;
+}
+
+.first\\\\:mt-16:first-child {
+  margin-top: 4rem;
+}
+
+.first\\\\:mt-20:first-child {
+  margin-top: 5rem;
+}
+
+.first\\\\:mt-24:first-child {
+  margin-top: 6rem;
+}
+
+.first\\\\:mt-28:first-child {
+  margin-top: 7rem;
+}
+
+.first\\\\:mt-32:first-child {
+  margin-top: 8rem;
+}
+
+.first\\\\:mt-36:first-child {
+  margin-top: 9rem;
+}
+
+.first\\\\:mt-40:first-child {
+  margin-top: 10rem;
+}
+
+.first\\\\:mt-44:first-child {
+  margin-top: 11rem;
+}
+
+.first\\\\:mt-48:first-child {
+  margin-top: 12rem;
+}
+
+.first\\\\:mt-52:first-child {
+  margin-top: 13rem;
+}
+
+.first\\\\:mt-56:first-child {
+  margin-top: 14rem;
+}
+
+.first\\\\:mt-60:first-child {
+  margin-top: 15rem;
+}
+
+.first\\\\:mt-64:first-child {
+  margin-top: 16rem;
+}
+
+.first\\\\:mt-72:first-child {
+  margin-top: 18rem;
+}
+
+.first\\\\:mt-80:first-child {
+  margin-top: 20rem;
+}
+
+.first\\\\:mt-96:first-child {
+  margin-top: 24rem;
+}
+
+.first\\\\:mt-auto:first-child {
+  margin-top: auto;
+}
+
+.first\\\\:mt-px:first-child {
+  margin-top: 1px;
+}
+
+.first\\\\:mt-0\\\\.5:first-child {
+  margin-top: 0.125rem;
+}
+
+.first\\\\:mt-1\\\\.5:first-child {
+  margin-top: 0.375rem;
+}
+
+.first\\\\:mt-2\\\\.5:first-child {
+  margin-top: 0.625rem;
+}
+
+.first\\\\:mt-3\\\\.5:first-child {
+  margin-top: 0.875rem;
+}
+
+.first\\\\:-mt-0:first-child {
+  margin-top: 0px;
+}
+
+.first\\\\:-mt-1:first-child {
+  margin-top: -0.25rem;
+}
+
+.first\\\\:-mt-2:first-child {
+  margin-top: -0.5rem;
+}
+
+.first\\\\:-mt-3:first-child {
+  margin-top: -0.75rem;
+}
+
+.first\\\\:-mt-4:first-child {
+  margin-top: -1rem;
+}
+
+.first\\\\:-mt-5:first-child {
+  margin-top: -1.25rem;
+}
+
+.first\\\\:-mt-6:first-child {
+  margin-top: -1.5rem;
+}
+
+.first\\\\:-mt-7:first-child {
+  margin-top: -1.75rem;
+}
+
+.first\\\\:-mt-8:first-child {
+  margin-top: -2rem;
+}
+
+.first\\\\:-mt-9:first-child {
+  margin-top: -2.25rem;
+}
+
+.first\\\\:-mt-10:first-child {
+  margin-top: -2.5rem;
+}
+
+.first\\\\:-mt-11:first-child {
+  margin-top: -2.75rem;
+}
+
+.first\\\\:-mt-12:first-child {
+  margin-top: -3rem;
+}
+
+.first\\\\:-mt-14:first-child {
+  margin-top: -3.5rem;
+}
+
+.first\\\\:-mt-16:first-child {
+  margin-top: -4rem;
+}
+
+.first\\\\:-mt-20:first-child {
+  margin-top: -5rem;
+}
+
+.first\\\\:-mt-24:first-child {
+  margin-top: -6rem;
+}
+
+.first\\\\:-mt-28:first-child {
+  margin-top: -7rem;
+}
+
+.first\\\\:-mt-32:first-child {
+  margin-top: -8rem;
+}
+
+.first\\\\:-mt-36:first-child {
+  margin-top: -9rem;
+}
+
+.first\\\\:-mt-40:first-child {
+  margin-top: -10rem;
+}
+
+.first\\\\:-mt-44:first-child {
+  margin-top: -11rem;
+}
+
+.first\\\\:-mt-48:first-child {
+  margin-top: -12rem;
+}
+
+.first\\\\:-mt-52:first-child {
+  margin-top: -13rem;
+}
+
+.first\\\\:-mt-56:first-child {
+  margin-top: -14rem;
+}
+
+.first\\\\:-mt-60:first-child {
+  margin-top: -15rem;
+}
+
+.first\\\\:-mt-64:first-child {
+  margin-top: -16rem;
+}
+
+.first\\\\:-mt-72:first-child {
+  margin-top: -18rem;
+}
+
+.first\\\\:-mt-80:first-child {
+  margin-top: -20rem;
+}
+
+.first\\\\:-mt-96:first-child {
+  margin-top: -24rem;
+}
+
+.first\\\\:-mt-px:first-child {
+  margin-top: -1px;
+}
+
+.first\\\\:-mt-0\\\\.5:first-child {
+  margin-top: -0.125rem;
+}
+
+.first\\\\:-mt-1\\\\.5:first-child {
+  margin-top: -0.375rem;
+}
+
+.first\\\\:-mt-2\\\\.5:first-child {
+  margin-top: -0.625rem;
+}
+
+.first\\\\:-mt-3\\\\.5:first-child {
+  margin-top: -0.875rem;
+}
+
+.first\\\\:mr-0:first-child {
+  margin-right: 0px;
+}
+
+.first\\\\:mr-1:first-child {
+  margin-right: 0.25rem;
+}
+
+.first\\\\:mr-2:first-child {
+  margin-right: 0.5rem;
+}
+
+.first\\\\:mr-3:first-child {
+  margin-right: 0.75rem;
+}
+
+.first\\\\:mr-4:first-child {
+  margin-right: 1rem;
+}
+
+.first\\\\:mr-5:first-child {
+  margin-right: 1.25rem;
+}
+
+.first\\\\:mr-6:first-child {
+  margin-right: 1.5rem;
+}
+
+.first\\\\:mr-7:first-child {
+  margin-right: 1.75rem;
+}
+
+.first\\\\:mr-8:first-child {
+  margin-right: 2rem;
+}
+
+.first\\\\:mr-9:first-child {
+  margin-right: 2.25rem;
+}
+
+.first\\\\:mr-10:first-child {
+  margin-right: 2.5rem;
+}
+
+.first\\\\:mr-11:first-child {
+  margin-right: 2.75rem;
+}
+
+.first\\\\:mr-12:first-child {
+  margin-right: 3rem;
+}
+
+.first\\\\:mr-14:first-child {
+  margin-right: 3.5rem;
+}
+
+.first\\\\:mr-16:first-child {
+  margin-right: 4rem;
+}
+
+.first\\\\:mr-20:first-child {
+  margin-right: 5rem;
+}
+
+.first\\\\:mr-24:first-child {
+  margin-right: 6rem;
+}
+
+.first\\\\:mr-28:first-child {
+  margin-right: 7rem;
+}
+
+.first\\\\:mr-32:first-child {
+  margin-right: 8rem;
+}
+
+.first\\\\:mr-36:first-child {
+  margin-right: 9rem;
+}
+
+.first\\\\:mr-40:first-child {
+  margin-right: 10rem;
+}
+
+.first\\\\:mr-44:first-child {
+  margin-right: 11rem;
+}
+
+.first\\\\:mr-48:first-child {
+  margin-right: 12rem;
+}
+
+.first\\\\:mr-52:first-child {
+  margin-right: 13rem;
+}
+
+.first\\\\:mr-56:first-child {
+  margin-right: 14rem;
+}
+
+.first\\\\:mr-60:first-child {
+  margin-right: 15rem;
+}
+
+.first\\\\:mr-64:first-child {
+  margin-right: 16rem;
+}
+
+.first\\\\:mr-72:first-child {
+  margin-right: 18rem;
+}
+
+.first\\\\:mr-80:first-child {
+  margin-right: 20rem;
+}
+
+.first\\\\:mr-96:first-child {
+  margin-right: 24rem;
+}
+
+.first\\\\:mr-auto:first-child {
+  margin-right: auto;
+}
+
+.first\\\\:mr-px:first-child {
+  margin-right: 1px;
+}
+
+.first\\\\:mr-0\\\\.5:first-child {
+  margin-right: 0.125rem;
+}
+
+.first\\\\:mr-1\\\\.5:first-child {
+  margin-right: 0.375rem;
+}
+
+.first\\\\:mr-2\\\\.5:first-child {
+  margin-right: 0.625rem;
+}
+
+.first\\\\:mr-3\\\\.5:first-child {
+  margin-right: 0.875rem;
+}
+
+.first\\\\:-mr-0:first-child {
+  margin-right: 0px;
+}
+
+.first\\\\:-mr-1:first-child {
+  margin-right: -0.25rem;
+}
+
+.first\\\\:-mr-2:first-child {
+  margin-right: -0.5rem;
+}
+
+.first\\\\:-mr-3:first-child {
+  margin-right: -0.75rem;
+}
+
+.first\\\\:-mr-4:first-child {
+  margin-right: -1rem;
+}
+
+.first\\\\:-mr-5:first-child {
+  margin-right: -1.25rem;
+}
+
+.first\\\\:-mr-6:first-child {
+  margin-right: -1.5rem;
+}
+
+.first\\\\:-mr-7:first-child {
+  margin-right: -1.75rem;
+}
+
+.first\\\\:-mr-8:first-child {
+  margin-right: -2rem;
+}
+
+.first\\\\:-mr-9:first-child {
+  margin-right: -2.25rem;
+}
+
+.first\\\\:-mr-10:first-child {
+  margin-right: -2.5rem;
+}
+
+.first\\\\:-mr-11:first-child {
+  margin-right: -2.75rem;
+}
+
+.first\\\\:-mr-12:first-child {
+  margin-right: -3rem;
+}
+
+.first\\\\:-mr-14:first-child {
+  margin-right: -3.5rem;
+}
+
+.first\\\\:-mr-16:first-child {
+  margin-right: -4rem;
+}
+
+.first\\\\:-mr-20:first-child {
+  margin-right: -5rem;
+}
+
+.first\\\\:-mr-24:first-child {
+  margin-right: -6rem;
+}
+
+.first\\\\:-mr-28:first-child {
+  margin-right: -7rem;
+}
+
+.first\\\\:-mr-32:first-child {
+  margin-right: -8rem;
+}
+
+.first\\\\:-mr-36:first-child {
+  margin-right: -9rem;
+}
+
+.first\\\\:-mr-40:first-child {
+  margin-right: -10rem;
+}
+
+.first\\\\:-mr-44:first-child {
+  margin-right: -11rem;
+}
+
+.first\\\\:-mr-48:first-child {
+  margin-right: -12rem;
+}
+
+.first\\\\:-mr-52:first-child {
+  margin-right: -13rem;
+}
+
+.first\\\\:-mr-56:first-child {
+  margin-right: -14rem;
+}
+
+.first\\\\:-mr-60:first-child {
+  margin-right: -15rem;
+}
+
+.first\\\\:-mr-64:first-child {
+  margin-right: -16rem;
+}
+
+.first\\\\:-mr-72:first-child {
+  margin-right: -18rem;
+}
+
+.first\\\\:-mr-80:first-child {
+  margin-right: -20rem;
+}
+
+.first\\\\:-mr-96:first-child {
+  margin-right: -24rem;
+}
+
+.first\\\\:-mr-px:first-child {
+  margin-right: -1px;
+}
+
+.first\\\\:-mr-0\\\\.5:first-child {
+  margin-right: -0.125rem;
+}
+
+.first\\\\:-mr-1\\\\.5:first-child {
+  margin-right: -0.375rem;
+}
+
+.first\\\\:-mr-2\\\\.5:first-child {
+  margin-right: -0.625rem;
+}
+
+.first\\\\:-mr-3\\\\.5:first-child {
+  margin-right: -0.875rem;
+}
+
+.first\\\\:mb-0:first-child {
+  margin-bottom: 0px;
+}
+
+.first\\\\:mb-1:first-child {
+  margin-bottom: 0.25rem;
+}
+
+.first\\\\:mb-2:first-child {
+  margin-bottom: 0.5rem;
+}
+
+.first\\\\:mb-3:first-child {
+  margin-bottom: 0.75rem;
+}
+
+.first\\\\:mb-4:first-child {
+  margin-bottom: 1rem;
+}
+
+.first\\\\:mb-5:first-child {
+  margin-bottom: 1.25rem;
+}
+
+.first\\\\:mb-6:first-child {
+  margin-bottom: 1.5rem;
+}
+
+.first\\\\:mb-7:first-child {
+  margin-bottom: 1.75rem;
+}
+
+.first\\\\:mb-8:first-child {
+  margin-bottom: 2rem;
+}
+
+.first\\\\:mb-9:first-child {
+  margin-bottom: 2.25rem;
+}
+
+.first\\\\:mb-10:first-child {
+  margin-bottom: 2.5rem;
+}
+
+.first\\\\:mb-11:first-child {
+  margin-bottom: 2.75rem;
+}
+
+.first\\\\:mb-12:first-child {
+  margin-bottom: 3rem;
+}
+
+.first\\\\:mb-14:first-child {
+  margin-bottom: 3.5rem;
+}
+
+.first\\\\:mb-16:first-child {
+  margin-bottom: 4rem;
+}
+
+.first\\\\:mb-20:first-child {
+  margin-bottom: 5rem;
+}
+
+.first\\\\:mb-24:first-child {
+  margin-bottom: 6rem;
+}
+
+.first\\\\:mb-28:first-child {
+  margin-bottom: 7rem;
+}
+
+.first\\\\:mb-32:first-child {
+  margin-bottom: 8rem;
+}
+
+.first\\\\:mb-36:first-child {
+  margin-bottom: 9rem;
+}
+
+.first\\\\:mb-40:first-child {
+  margin-bottom: 10rem;
+}
+
+.first\\\\:mb-44:first-child {
+  margin-bottom: 11rem;
+}
+
+.first\\\\:mb-48:first-child {
+  margin-bottom: 12rem;
+}
+
+.first\\\\:mb-52:first-child {
+  margin-bottom: 13rem;
+}
+
+.first\\\\:mb-56:first-child {
+  margin-bottom: 14rem;
+}
+
+.first\\\\:mb-60:first-child {
+  margin-bottom: 15rem;
+}
+
+.first\\\\:mb-64:first-child {
+  margin-bottom: 16rem;
+}
+
+.first\\\\:mb-72:first-child {
+  margin-bottom: 18rem;
+}
+
+.first\\\\:mb-80:first-child {
+  margin-bottom: 20rem;
+}
+
+.first\\\\:mb-96:first-child {
+  margin-bottom: 24rem;
+}
+
+.first\\\\:mb-auto:first-child {
+  margin-bottom: auto;
+}
+
+.first\\\\:mb-px:first-child {
+  margin-bottom: 1px;
+}
+
+.first\\\\:mb-0\\\\.5:first-child {
+  margin-bottom: 0.125rem;
+}
+
+.first\\\\:mb-1\\\\.5:first-child {
+  margin-bottom: 0.375rem;
+}
+
+.first\\\\:mb-2\\\\.5:first-child {
+  margin-bottom: 0.625rem;
+}
+
+.first\\\\:mb-3\\\\.5:first-child {
+  margin-bottom: 0.875rem;
+}
+
+.first\\\\:-mb-0:first-child {
+  margin-bottom: 0px;
+}
+
+.first\\\\:-mb-1:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.first\\\\:-mb-2:first-child {
+  margin-bottom: -0.5rem;
+}
+
+.first\\\\:-mb-3:first-child {
+  margin-bottom: -0.75rem;
+}
+
+.first\\\\:-mb-4:first-child {
+  margin-bottom: -1rem;
+}
+
+.first\\\\:-mb-5:first-child {
+  margin-bottom: -1.25rem;
+}
+
+.first\\\\:-mb-6:first-child {
+  margin-bottom: -1.5rem;
+}
+
+.first\\\\:-mb-7:first-child {
+  margin-bottom: -1.75rem;
+}
+
+.first\\\\:-mb-8:first-child {
+  margin-bottom: -2rem;
+}
+
+.first\\\\:-mb-9:first-child {
+  margin-bottom: -2.25rem;
+}
+
+.first\\\\:-mb-10:first-child {
+  margin-bottom: -2.5rem;
+}
+
+.first\\\\:-mb-11:first-child {
+  margin-bottom: -2.75rem;
+}
+
+.first\\\\:-mb-12:first-child {
+  margin-bottom: -3rem;
+}
+
+.first\\\\:-mb-14:first-child {
+  margin-bottom: -3.5rem;
+}
+
+.first\\\\:-mb-16:first-child {
+  margin-bottom: -4rem;
+}
+
+.first\\\\:-mb-20:first-child {
+  margin-bottom: -5rem;
+}
+
+.first\\\\:-mb-24:first-child {
+  margin-bottom: -6rem;
+}
+
+.first\\\\:-mb-28:first-child {
+  margin-bottom: -7rem;
+}
+
+.first\\\\:-mb-32:first-child {
+  margin-bottom: -8rem;
+}
+
+.first\\\\:-mb-36:first-child {
+  margin-bottom: -9rem;
+}
+
+.first\\\\:-mb-40:first-child {
+  margin-bottom: -10rem;
+}
+
+.first\\\\:-mb-44:first-child {
+  margin-bottom: -11rem;
+}
+
+.first\\\\:-mb-48:first-child {
+  margin-bottom: -12rem;
+}
+
+.first\\\\:-mb-52:first-child {
+  margin-bottom: -13rem;
+}
+
+.first\\\\:-mb-56:first-child {
+  margin-bottom: -14rem;
+}
+
+.first\\\\:-mb-60:first-child {
+  margin-bottom: -15rem;
+}
+
+.first\\\\:-mb-64:first-child {
+  margin-bottom: -16rem;
+}
+
+.first\\\\:-mb-72:first-child {
+  margin-bottom: -18rem;
+}
+
+.first\\\\:-mb-80:first-child {
+  margin-bottom: -20rem;
+}
+
+.first\\\\:-mb-96:first-child {
+  margin-bottom: -24rem;
+}
+
+.first\\\\:-mb-px:first-child {
+  margin-bottom: -1px;
+}
+
+.first\\\\:-mb-0\\\\.5:first-child {
+  margin-bottom: -0.125rem;
+}
+
+.first\\\\:-mb-1\\\\.5:first-child {
+  margin-bottom: -0.375rem;
+}
+
+.first\\\\:-mb-2\\\\.5:first-child {
+  margin-bottom: -0.625rem;
+}
+
+.first\\\\:-mb-3\\\\.5:first-child {
+  margin-bottom: -0.875rem;
+}
+
+.first\\\\:ml-0:first-child {
+  margin-left: 0px;
+}
+
+.first\\\\:ml-1:first-child {
+  margin-left: 0.25rem;
+}
+
+.first\\\\:ml-2:first-child {
+  margin-left: 0.5rem;
+}
+
+.first\\\\:ml-3:first-child {
+  margin-left: 0.75rem;
+}
+
+.first\\\\:ml-4:first-child {
+  margin-left: 1rem;
+}
+
+.first\\\\:ml-5:first-child {
+  margin-left: 1.25rem;
+}
+
+.first\\\\:ml-6:first-child {
+  margin-left: 1.5rem;
+}
+
+.first\\\\:ml-7:first-child {
+  margin-left: 1.75rem;
+}
+
+.first\\\\:ml-8:first-child {
+  margin-left: 2rem;
+}
+
+.first\\\\:ml-9:first-child {
+  margin-left: 2.25rem;
+}
+
+.first\\\\:ml-10:first-child {
+  margin-left: 2.5rem;
+}
+
+.first\\\\:ml-11:first-child {
+  margin-left: 2.75rem;
+}
+
+.first\\\\:ml-12:first-child {
+  margin-left: 3rem;
+}
+
+.first\\\\:ml-14:first-child {
+  margin-left: 3.5rem;
+}
+
+.first\\\\:ml-16:first-child {
+  margin-left: 4rem;
+}
+
+.first\\\\:ml-20:first-child {
+  margin-left: 5rem;
+}
+
+.first\\\\:ml-24:first-child {
+  margin-left: 6rem;
+}
+
+.first\\\\:ml-28:first-child {
+  margin-left: 7rem;
+}
+
+.first\\\\:ml-32:first-child {
+  margin-left: 8rem;
+}
+
+.first\\\\:ml-36:first-child {
+  margin-left: 9rem;
+}
+
+.first\\\\:ml-40:first-child {
+  margin-left: 10rem;
+}
+
+.first\\\\:ml-44:first-child {
+  margin-left: 11rem;
+}
+
+.first\\\\:ml-48:first-child {
+  margin-left: 12rem;
+}
+
+.first\\\\:ml-52:first-child {
+  margin-left: 13rem;
+}
+
+.first\\\\:ml-56:first-child {
+  margin-left: 14rem;
+}
+
+.first\\\\:ml-60:first-child {
+  margin-left: 15rem;
+}
+
+.first\\\\:ml-64:first-child {
+  margin-left: 16rem;
+}
+
+.first\\\\:ml-72:first-child {
+  margin-left: 18rem;
+}
+
+.first\\\\:ml-80:first-child {
+  margin-left: 20rem;
+}
+
+.first\\\\:ml-96:first-child {
+  margin-left: 24rem;
+}
+
+.first\\\\:ml-auto:first-child {
+  margin-left: auto;
+}
+
+.first\\\\:ml-px:first-child {
+  margin-left: 1px;
+}
+
+.first\\\\:ml-0\\\\.5:first-child {
+  margin-left: 0.125rem;
+}
+
+.first\\\\:ml-1\\\\.5:first-child {
+  margin-left: 0.375rem;
+}
+
+.first\\\\:ml-2\\\\.5:first-child {
+  margin-left: 0.625rem;
+}
+
+.first\\\\:ml-3\\\\.5:first-child {
+  margin-left: 0.875rem;
+}
+
+.first\\\\:-ml-0:first-child {
+  margin-left: 0px;
+}
+
+.first\\\\:-ml-1:first-child {
+  margin-left: -0.25rem;
+}
+
+.first\\\\:-ml-2:first-child {
+  margin-left: -0.5rem;
+}
+
+.first\\\\:-ml-3:first-child {
+  margin-left: -0.75rem;
+}
+
+.first\\\\:-ml-4:first-child {
+  margin-left: -1rem;
+}
+
+.first\\\\:-ml-5:first-child {
+  margin-left: -1.25rem;
+}
+
+.first\\\\:-ml-6:first-child {
+  margin-left: -1.5rem;
+}
+
+.first\\\\:-ml-7:first-child {
+  margin-left: -1.75rem;
+}
+
+.first\\\\:-ml-8:first-child {
+  margin-left: -2rem;
+}
+
+.first\\\\:-ml-9:first-child {
+  margin-left: -2.25rem;
+}
+
+.first\\\\:-ml-10:first-child {
+  margin-left: -2.5rem;
+}
+
+.first\\\\:-ml-11:first-child {
+  margin-left: -2.75rem;
+}
+
+.first\\\\:-ml-12:first-child {
+  margin-left: -3rem;
+}
+
+.first\\\\:-ml-14:first-child {
+  margin-left: -3.5rem;
+}
+
+.first\\\\:-ml-16:first-child {
+  margin-left: -4rem;
+}
+
+.first\\\\:-ml-20:first-child {
+  margin-left: -5rem;
+}
+
+.first\\\\:-ml-24:first-child {
+  margin-left: -6rem;
+}
+
+.first\\\\:-ml-28:first-child {
+  margin-left: -7rem;
+}
+
+.first\\\\:-ml-32:first-child {
+  margin-left: -8rem;
+}
+
+.first\\\\:-ml-36:first-child {
+  margin-left: -9rem;
+}
+
+.first\\\\:-ml-40:first-child {
+  margin-left: -10rem;
+}
+
+.first\\\\:-ml-44:first-child {
+  margin-left: -11rem;
+}
+
+.first\\\\:-ml-48:first-child {
+  margin-left: -12rem;
+}
+
+.first\\\\:-ml-52:first-child {
+  margin-left: -13rem;
+}
+
+.first\\\\:-ml-56:first-child {
+  margin-left: -14rem;
+}
+
+.first\\\\:-ml-60:first-child {
+  margin-left: -15rem;
+}
+
+.first\\\\:-ml-64:first-child {
+  margin-left: -16rem;
+}
+
+.first\\\\:-ml-72:first-child {
+  margin-left: -18rem;
+}
+
+.first\\\\:-ml-80:first-child {
+  margin-left: -20rem;
+}
+
+.first\\\\:-ml-96:first-child {
+  margin-left: -24rem;
+}
+
+.first\\\\:-ml-px:first-child {
+  margin-left: -1px;
+}
+
+.first\\\\:-ml-0\\\\.5:first-child {
+  margin-left: -0.125rem;
+}
+
+.first\\\\:-ml-1\\\\.5:first-child {
+  margin-left: -0.375rem;
+}
+
+.first\\\\:-ml-2\\\\.5:first-child {
+  margin-left: -0.625rem;
+}
+
+.first\\\\:-ml-3\\\\.5:first-child {
+  margin-left: -0.875rem;
+}
+
+.last\\\\:mt-0:last-child {
+  margin-top: 0px;
+}
+
+.last\\\\:mt-1:last-child {
+  margin-top: 0.25rem;
+}
+
+.last\\\\:mt-2:last-child {
+  margin-top: 0.5rem;
+}
+
+.last\\\\:mt-3:last-child {
+  margin-top: 0.75rem;
+}
+
+.last\\\\:mt-4:last-child {
+  margin-top: 1rem;
+}
+
+.last\\\\:mt-5:last-child {
+  margin-top: 1.25rem;
+}
+
+.last\\\\:mt-6:last-child {
+  margin-top: 1.5rem;
+}
+
+.last\\\\:mt-7:last-child {
+  margin-top: 1.75rem;
+}
+
+.last\\\\:mt-8:last-child {
+  margin-top: 2rem;
+}
+
+.last\\\\:mt-9:last-child {
+  margin-top: 2.25rem;
+}
+
+.last\\\\:mt-10:last-child {
+  margin-top: 2.5rem;
+}
+
+.last\\\\:mt-11:last-child {
+  margin-top: 2.75rem;
+}
+
+.last\\\\:mt-12:last-child {
+  margin-top: 3rem;
+}
+
+.last\\\\:mt-14:last-child {
+  margin-top: 3.5rem;
+}
+
+.last\\\\:mt-16:last-child {
+  margin-top: 4rem;
+}
+
+.last\\\\:mt-20:last-child {
+  margin-top: 5rem;
+}
+
+.last\\\\:mt-24:last-child {
+  margin-top: 6rem;
+}
+
+.last\\\\:mt-28:last-child {
+  margin-top: 7rem;
+}
+
+.last\\\\:mt-32:last-child {
+  margin-top: 8rem;
+}
+
+.last\\\\:mt-36:last-child {
+  margin-top: 9rem;
+}
+
+.last\\\\:mt-40:last-child {
+  margin-top: 10rem;
+}
+
+.last\\\\:mt-44:last-child {
+  margin-top: 11rem;
+}
+
+.last\\\\:mt-48:last-child {
+  margin-top: 12rem;
+}
+
+.last\\\\:mt-52:last-child {
+  margin-top: 13rem;
+}
+
+.last\\\\:mt-56:last-child {
+  margin-top: 14rem;
+}
+
+.last\\\\:mt-60:last-child {
+  margin-top: 15rem;
+}
+
+.last\\\\:mt-64:last-child {
+  margin-top: 16rem;
+}
+
+.last\\\\:mt-72:last-child {
+  margin-top: 18rem;
+}
+
+.last\\\\:mt-80:last-child {
+  margin-top: 20rem;
+}
+
+.last\\\\:mt-96:last-child {
+  margin-top: 24rem;
+}
+
+.last\\\\:mt-auto:last-child {
+  margin-top: auto;
+}
+
+.last\\\\:mt-px:last-child {
+  margin-top: 1px;
+}
+
+.last\\\\:mt-0\\\\.5:last-child {
+  margin-top: 0.125rem;
+}
+
+.last\\\\:mt-1\\\\.5:last-child {
+  margin-top: 0.375rem;
+}
+
+.last\\\\:mt-2\\\\.5:last-child {
+  margin-top: 0.625rem;
+}
+
+.last\\\\:mt-3\\\\.5:last-child {
+  margin-top: 0.875rem;
+}
+
+.last\\\\:-mt-0:last-child {
+  margin-top: 0px;
+}
+
+.last\\\\:-mt-1:last-child {
+  margin-top: -0.25rem;
+}
+
+.last\\\\:-mt-2:last-child {
+  margin-top: -0.5rem;
+}
+
+.last\\\\:-mt-3:last-child {
+  margin-top: -0.75rem;
+}
+
+.last\\\\:-mt-4:last-child {
+  margin-top: -1rem;
+}
+
+.last\\\\:-mt-5:last-child {
+  margin-top: -1.25rem;
+}
+
+.last\\\\:-mt-6:last-child {
+  margin-top: -1.5rem;
+}
+
+.last\\\\:-mt-7:last-child {
+  margin-top: -1.75rem;
+}
+
+.last\\\\:-mt-8:last-child {
+  margin-top: -2rem;
+}
+
+.last\\\\:-mt-9:last-child {
+  margin-top: -2.25rem;
+}
+
+.last\\\\:-mt-10:last-child {
+  margin-top: -2.5rem;
+}
+
+.last\\\\:-mt-11:last-child {
+  margin-top: -2.75rem;
+}
+
+.last\\\\:-mt-12:last-child {
+  margin-top: -3rem;
+}
+
+.last\\\\:-mt-14:last-child {
+  margin-top: -3.5rem;
+}
+
+.last\\\\:-mt-16:last-child {
+  margin-top: -4rem;
+}
+
+.last\\\\:-mt-20:last-child {
+  margin-top: -5rem;
+}
+
+.last\\\\:-mt-24:last-child {
+  margin-top: -6rem;
+}
+
+.last\\\\:-mt-28:last-child {
+  margin-top: -7rem;
+}
+
+.last\\\\:-mt-32:last-child {
+  margin-top: -8rem;
+}
+
+.last\\\\:-mt-36:last-child {
+  margin-top: -9rem;
+}
+
+.last\\\\:-mt-40:last-child {
+  margin-top: -10rem;
+}
+
+.last\\\\:-mt-44:last-child {
+  margin-top: -11rem;
+}
+
+.last\\\\:-mt-48:last-child {
+  margin-top: -12rem;
+}
+
+.last\\\\:-mt-52:last-child {
+  margin-top: -13rem;
+}
+
+.last\\\\:-mt-56:last-child {
+  margin-top: -14rem;
+}
+
+.last\\\\:-mt-60:last-child {
+  margin-top: -15rem;
+}
+
+.last\\\\:-mt-64:last-child {
+  margin-top: -16rem;
+}
+
+.last\\\\:-mt-72:last-child {
+  margin-top: -18rem;
+}
+
+.last\\\\:-mt-80:last-child {
+  margin-top: -20rem;
+}
+
+.last\\\\:-mt-96:last-child {
+  margin-top: -24rem;
+}
+
+.last\\\\:-mt-px:last-child {
+  margin-top: -1px;
+}
+
+.last\\\\:-mt-0\\\\.5:last-child {
+  margin-top: -0.125rem;
+}
+
+.last\\\\:-mt-1\\\\.5:last-child {
+  margin-top: -0.375rem;
+}
+
+.last\\\\:-mt-2\\\\.5:last-child {
+  margin-top: -0.625rem;
+}
+
+.last\\\\:-mt-3\\\\.5:last-child {
+  margin-top: -0.875rem;
+}
+
+.last\\\\:mr-0:last-child {
+  margin-right: 0px;
+}
+
+.last\\\\:mr-1:last-child {
+  margin-right: 0.25rem;
+}
+
+.last\\\\:mr-2:last-child {
+  margin-right: 0.5rem;
+}
+
+.last\\\\:mr-3:last-child {
+  margin-right: 0.75rem;
+}
+
+.last\\\\:mr-4:last-child {
+  margin-right: 1rem;
+}
+
+.last\\\\:mr-5:last-child {
+  margin-right: 1.25rem;
+}
+
+.last\\\\:mr-6:last-child {
+  margin-right: 1.5rem;
+}
+
+.last\\\\:mr-7:last-child {
+  margin-right: 1.75rem;
+}
+
+.last\\\\:mr-8:last-child {
+  margin-right: 2rem;
+}
+
+.last\\\\:mr-9:last-child {
+  margin-right: 2.25rem;
+}
+
+.last\\\\:mr-10:last-child {
+  margin-right: 2.5rem;
+}
+
+.last\\\\:mr-11:last-child {
+  margin-right: 2.75rem;
+}
+
+.last\\\\:mr-12:last-child {
+  margin-right: 3rem;
+}
+
+.last\\\\:mr-14:last-child {
+  margin-right: 3.5rem;
+}
+
+.last\\\\:mr-16:last-child {
+  margin-right: 4rem;
+}
+
+.last\\\\:mr-20:last-child {
+  margin-right: 5rem;
+}
+
+.last\\\\:mr-24:last-child {
+  margin-right: 6rem;
+}
+
+.last\\\\:mr-28:last-child {
+  margin-right: 7rem;
+}
+
+.last\\\\:mr-32:last-child {
+  margin-right: 8rem;
+}
+
+.last\\\\:mr-36:last-child {
+  margin-right: 9rem;
+}
+
+.last\\\\:mr-40:last-child {
+  margin-right: 10rem;
+}
+
+.last\\\\:mr-44:last-child {
+  margin-right: 11rem;
+}
+
+.last\\\\:mr-48:last-child {
+  margin-right: 12rem;
+}
+
+.last\\\\:mr-52:last-child {
+  margin-right: 13rem;
+}
+
+.last\\\\:mr-56:last-child {
+  margin-right: 14rem;
+}
+
+.last\\\\:mr-60:last-child {
+  margin-right: 15rem;
+}
+
+.last\\\\:mr-64:last-child {
+  margin-right: 16rem;
+}
+
+.last\\\\:mr-72:last-child {
+  margin-right: 18rem;
+}
+
+.last\\\\:mr-80:last-child {
+  margin-right: 20rem;
+}
+
+.last\\\\:mr-96:last-child {
+  margin-right: 24rem;
+}
+
+.last\\\\:mr-auto:last-child {
+  margin-right: auto;
+}
+
+.last\\\\:mr-px:last-child {
+  margin-right: 1px;
+}
+
+.last\\\\:mr-0\\\\.5:last-child {
+  margin-right: 0.125rem;
+}
+
+.last\\\\:mr-1\\\\.5:last-child {
+  margin-right: 0.375rem;
+}
+
+.last\\\\:mr-2\\\\.5:last-child {
+  margin-right: 0.625rem;
+}
+
+.last\\\\:mr-3\\\\.5:last-child {
+  margin-right: 0.875rem;
+}
+
+.last\\\\:-mr-0:last-child {
+  margin-right: 0px;
+}
+
+.last\\\\:-mr-1:last-child {
+  margin-right: -0.25rem;
+}
+
+.last\\\\:-mr-2:last-child {
+  margin-right: -0.5rem;
+}
+
+.last\\\\:-mr-3:last-child {
+  margin-right: -0.75rem;
+}
+
+.last\\\\:-mr-4:last-child {
+  margin-right: -1rem;
+}
+
+.last\\\\:-mr-5:last-child {
+  margin-right: -1.25rem;
+}
+
+.last\\\\:-mr-6:last-child {
+  margin-right: -1.5rem;
+}
+
+.last\\\\:-mr-7:last-child {
+  margin-right: -1.75rem;
+}
+
+.last\\\\:-mr-8:last-child {
+  margin-right: -2rem;
+}
+
+.last\\\\:-mr-9:last-child {
+  margin-right: -2.25rem;
+}
+
+.last\\\\:-mr-10:last-child {
+  margin-right: -2.5rem;
+}
+
+.last\\\\:-mr-11:last-child {
+  margin-right: -2.75rem;
+}
+
+.last\\\\:-mr-12:last-child {
+  margin-right: -3rem;
+}
+
+.last\\\\:-mr-14:last-child {
+  margin-right: -3.5rem;
+}
+
+.last\\\\:-mr-16:last-child {
+  margin-right: -4rem;
+}
+
+.last\\\\:-mr-20:last-child {
+  margin-right: -5rem;
+}
+
+.last\\\\:-mr-24:last-child {
+  margin-right: -6rem;
+}
+
+.last\\\\:-mr-28:last-child {
+  margin-right: -7rem;
+}
+
+.last\\\\:-mr-32:last-child {
+  margin-right: -8rem;
+}
+
+.last\\\\:-mr-36:last-child {
+  margin-right: -9rem;
+}
+
+.last\\\\:-mr-40:last-child {
+  margin-right: -10rem;
+}
+
+.last\\\\:-mr-44:last-child {
+  margin-right: -11rem;
+}
+
+.last\\\\:-mr-48:last-child {
+  margin-right: -12rem;
+}
+
+.last\\\\:-mr-52:last-child {
+  margin-right: -13rem;
+}
+
+.last\\\\:-mr-56:last-child {
+  margin-right: -14rem;
+}
+
+.last\\\\:-mr-60:last-child {
+  margin-right: -15rem;
+}
+
+.last\\\\:-mr-64:last-child {
+  margin-right: -16rem;
+}
+
+.last\\\\:-mr-72:last-child {
+  margin-right: -18rem;
+}
+
+.last\\\\:-mr-80:last-child {
+  margin-right: -20rem;
+}
+
+.last\\\\:-mr-96:last-child {
+  margin-right: -24rem;
+}
+
+.last\\\\:-mr-px:last-child {
+  margin-right: -1px;
+}
+
+.last\\\\:-mr-0\\\\.5:last-child {
+  margin-right: -0.125rem;
+}
+
+.last\\\\:-mr-1\\\\.5:last-child {
+  margin-right: -0.375rem;
+}
+
+.last\\\\:-mr-2\\\\.5:last-child {
+  margin-right: -0.625rem;
+}
+
+.last\\\\:-mr-3\\\\.5:last-child {
+  margin-right: -0.875rem;
+}
+
+.last\\\\:mb-0:last-child {
+  margin-bottom: 0px;
+}
+
+.last\\\\:mb-1:last-child {
+  margin-bottom: 0.25rem;
+}
+
+.last\\\\:mb-2:last-child {
+  margin-bottom: 0.5rem;
+}
+
+.last\\\\:mb-3:last-child {
+  margin-bottom: 0.75rem;
+}
+
+.last\\\\:mb-4:last-child {
+  margin-bottom: 1rem;
+}
+
+.last\\\\:mb-5:last-child {
+  margin-bottom: 1.25rem;
+}
+
+.last\\\\:mb-6:last-child {
+  margin-bottom: 1.5rem;
+}
+
+.last\\\\:mb-7:last-child {
+  margin-bottom: 1.75rem;
+}
+
+.last\\\\:mb-8:last-child {
+  margin-bottom: 2rem;
+}
+
+.last\\\\:mb-9:last-child {
+  margin-bottom: 2.25rem;
+}
+
+.last\\\\:mb-10:last-child {
+  margin-bottom: 2.5rem;
+}
+
+.last\\\\:mb-11:last-child {
+  margin-bottom: 2.75rem;
+}
+
+.last\\\\:mb-12:last-child {
+  margin-bottom: 3rem;
+}
+
+.last\\\\:mb-14:last-child {
+  margin-bottom: 3.5rem;
+}
+
+.last\\\\:mb-16:last-child {
+  margin-bottom: 4rem;
+}
+
+.last\\\\:mb-20:last-child {
+  margin-bottom: 5rem;
+}
+
+.last\\\\:mb-24:last-child {
+  margin-bottom: 6rem;
+}
+
+.last\\\\:mb-28:last-child {
+  margin-bottom: 7rem;
+}
+
+.last\\\\:mb-32:last-child {
+  margin-bottom: 8rem;
+}
+
+.last\\\\:mb-36:last-child {
+  margin-bottom: 9rem;
+}
+
+.last\\\\:mb-40:last-child {
+  margin-bottom: 10rem;
+}
+
+.last\\\\:mb-44:last-child {
+  margin-bottom: 11rem;
+}
+
+.last\\\\:mb-48:last-child {
+  margin-bottom: 12rem;
+}
+
+.last\\\\:mb-52:last-child {
+  margin-bottom: 13rem;
+}
+
+.last\\\\:mb-56:last-child {
+  margin-bottom: 14rem;
+}
+
+.last\\\\:mb-60:last-child {
+  margin-bottom: 15rem;
+}
+
+.last\\\\:mb-64:last-child {
+  margin-bottom: 16rem;
+}
+
+.last\\\\:mb-72:last-child {
+  margin-bottom: 18rem;
+}
+
+.last\\\\:mb-80:last-child {
+  margin-bottom: 20rem;
+}
+
+.last\\\\:mb-96:last-child {
+  margin-bottom: 24rem;
+}
+
+.last\\\\:mb-auto:last-child {
+  margin-bottom: auto;
+}
+
+.last\\\\:mb-px:last-child {
+  margin-bottom: 1px;
+}
+
+.last\\\\:mb-0\\\\.5:last-child {
+  margin-bottom: 0.125rem;
+}
+
+.last\\\\:mb-1\\\\.5:last-child {
+  margin-bottom: 0.375rem;
+}
+
+.last\\\\:mb-2\\\\.5:last-child {
+  margin-bottom: 0.625rem;
+}
+
+.last\\\\:mb-3\\\\.5:last-child {
+  margin-bottom: 0.875rem;
+}
+
+.last\\\\:-mb-0:last-child {
+  margin-bottom: 0px;
+}
+
+.last\\\\:-mb-1:last-child {
+  margin-bottom: -0.25rem;
+}
+
+.last\\\\:-mb-2:last-child {
+  margin-bottom: -0.5rem;
+}
+
+.last\\\\:-mb-3:last-child {
+  margin-bottom: -0.75rem;
+}
+
+.last\\\\:-mb-4:last-child {
+  margin-bottom: -1rem;
+}
+
+.last\\\\:-mb-5:last-child {
+  margin-bottom: -1.25rem;
+}
+
+.last\\\\:-mb-6:last-child {
+  margin-bottom: -1.5rem;
+}
+
+.last\\\\:-mb-7:last-child {
+  margin-bottom: -1.75rem;
+}
+
+.last\\\\:-mb-8:last-child {
+  margin-bottom: -2rem;
+}
+
+.last\\\\:-mb-9:last-child {
+  margin-bottom: -2.25rem;
+}
+
+.last\\\\:-mb-10:last-child {
+  margin-bottom: -2.5rem;
+}
+
+.last\\\\:-mb-11:last-child {
+  margin-bottom: -2.75rem;
+}
+
+.last\\\\:-mb-12:last-child {
+  margin-bottom: -3rem;
+}
+
+.last\\\\:-mb-14:last-child {
+  margin-bottom: -3.5rem;
+}
+
+.last\\\\:-mb-16:last-child {
+  margin-bottom: -4rem;
+}
+
+.last\\\\:-mb-20:last-child {
+  margin-bottom: -5rem;
+}
+
+.last\\\\:-mb-24:last-child {
+  margin-bottom: -6rem;
+}
+
+.last\\\\:-mb-28:last-child {
+  margin-bottom: -7rem;
+}
+
+.last\\\\:-mb-32:last-child {
+  margin-bottom: -8rem;
+}
+
+.last\\\\:-mb-36:last-child {
+  margin-bottom: -9rem;
+}
+
+.last\\\\:-mb-40:last-child {
+  margin-bottom: -10rem;
+}
+
+.last\\\\:-mb-44:last-child {
+  margin-bottom: -11rem;
+}
+
+.last\\\\:-mb-48:last-child {
+  margin-bottom: -12rem;
+}
+
+.last\\\\:-mb-52:last-child {
+  margin-bottom: -13rem;
+}
+
+.last\\\\:-mb-56:last-child {
+  margin-bottom: -14rem;
+}
+
+.last\\\\:-mb-60:last-child {
+  margin-bottom: -15rem;
+}
+
+.last\\\\:-mb-64:last-child {
+  margin-bottom: -16rem;
+}
+
+.last\\\\:-mb-72:last-child {
+  margin-bottom: -18rem;
+}
+
+.last\\\\:-mb-80:last-child {
+  margin-bottom: -20rem;
+}
+
+.last\\\\:-mb-96:last-child {
+  margin-bottom: -24rem;
+}
+
+.last\\\\:-mb-px:last-child {
+  margin-bottom: -1px;
+}
+
+.last\\\\:-mb-0\\\\.5:last-child {
+  margin-bottom: -0.125rem;
+}
+
+.last\\\\:-mb-1\\\\.5:last-child {
+  margin-bottom: -0.375rem;
+}
+
+.last\\\\:-mb-2\\\\.5:last-child {
+  margin-bottom: -0.625rem;
+}
+
+.last\\\\:-mb-3\\\\.5:last-child {
+  margin-bottom: -0.875rem;
+}
+
+.last\\\\:ml-0:last-child {
+  margin-left: 0px;
+}
+
+.last\\\\:ml-1:last-child {
+  margin-left: 0.25rem;
+}
+
+.last\\\\:ml-2:last-child {
+  margin-left: 0.5rem;
+}
+
+.last\\\\:ml-3:last-child {
+  margin-left: 0.75rem;
+}
+
+.last\\\\:ml-4:last-child {
+  margin-left: 1rem;
+}
+
+.last\\\\:ml-5:last-child {
+  margin-left: 1.25rem;
+}
+
+.last\\\\:ml-6:last-child {
+  margin-left: 1.5rem;
+}
+
+.last\\\\:ml-7:last-child {
+  margin-left: 1.75rem;
+}
+
+.last\\\\:ml-8:last-child {
+  margin-left: 2rem;
+}
+
+.last\\\\:ml-9:last-child {
+  margin-left: 2.25rem;
+}
+
+.last\\\\:ml-10:last-child {
+  margin-left: 2.5rem;
+}
+
+.last\\\\:ml-11:last-child {
+  margin-left: 2.75rem;
+}
+
+.last\\\\:ml-12:last-child {
+  margin-left: 3rem;
+}
+
+.last\\\\:ml-14:last-child {
+  margin-left: 3.5rem;
+}
+
+.last\\\\:ml-16:last-child {
+  margin-left: 4rem;
+}
+
+.last\\\\:ml-20:last-child {
+  margin-left: 5rem;
+}
+
+.last\\\\:ml-24:last-child {
+  margin-left: 6rem;
+}
+
+.last\\\\:ml-28:last-child {
+  margin-left: 7rem;
+}
+
+.last\\\\:ml-32:last-child {
+  margin-left: 8rem;
+}
+
+.last\\\\:ml-36:last-child {
+  margin-left: 9rem;
+}
+
+.last\\\\:ml-40:last-child {
+  margin-left: 10rem;
+}
+
+.last\\\\:ml-44:last-child {
+  margin-left: 11rem;
+}
+
+.last\\\\:ml-48:last-child {
+  margin-left: 12rem;
+}
+
+.last\\\\:ml-52:last-child {
+  margin-left: 13rem;
+}
+
+.last\\\\:ml-56:last-child {
+  margin-left: 14rem;
+}
+
+.last\\\\:ml-60:last-child {
+  margin-left: 15rem;
+}
+
+.last\\\\:ml-64:last-child {
+  margin-left: 16rem;
+}
+
+.last\\\\:ml-72:last-child {
+  margin-left: 18rem;
+}
+
+.last\\\\:ml-80:last-child {
+  margin-left: 20rem;
+}
+
+.last\\\\:ml-96:last-child {
+  margin-left: 24rem;
+}
+
+.last\\\\:ml-auto:last-child {
+  margin-left: auto;
+}
+
+.last\\\\:ml-px:last-child {
+  margin-left: 1px;
+}
+
+.last\\\\:ml-0\\\\.5:last-child {
+  margin-left: 0.125rem;
+}
+
+.last\\\\:ml-1\\\\.5:last-child {
+  margin-left: 0.375rem;
+}
+
+.last\\\\:ml-2\\\\.5:last-child {
+  margin-left: 0.625rem;
+}
+
+.last\\\\:ml-3\\\\.5:last-child {
+  margin-left: 0.875rem;
+}
+
+.last\\\\:-ml-0:last-child {
+  margin-left: 0px;
+}
+
+.last\\\\:-ml-1:last-child {
+  margin-left: -0.25rem;
+}
+
+.last\\\\:-ml-2:last-child {
+  margin-left: -0.5rem;
+}
+
+.last\\\\:-ml-3:last-child {
+  margin-left: -0.75rem;
+}
+
+.last\\\\:-ml-4:last-child {
+  margin-left: -1rem;
+}
+
+.last\\\\:-ml-5:last-child {
+  margin-left: -1.25rem;
+}
+
+.last\\\\:-ml-6:last-child {
+  margin-left: -1.5rem;
+}
+
+.last\\\\:-ml-7:last-child {
+  margin-left: -1.75rem;
+}
+
+.last\\\\:-ml-8:last-child {
+  margin-left: -2rem;
+}
+
+.last\\\\:-ml-9:last-child {
+  margin-left: -2.25rem;
+}
+
+.last\\\\:-ml-10:last-child {
+  margin-left: -2.5rem;
+}
+
+.last\\\\:-ml-11:last-child {
+  margin-left: -2.75rem;
+}
+
+.last\\\\:-ml-12:last-child {
+  margin-left: -3rem;
+}
+
+.last\\\\:-ml-14:last-child {
+  margin-left: -3.5rem;
+}
+
+.last\\\\:-ml-16:last-child {
+  margin-left: -4rem;
+}
+
+.last\\\\:-ml-20:last-child {
+  margin-left: -5rem;
+}
+
+.last\\\\:-ml-24:last-child {
+  margin-left: -6rem;
+}
+
+.last\\\\:-ml-28:last-child {
+  margin-left: -7rem;
+}
+
+.last\\\\:-ml-32:last-child {
+  margin-left: -8rem;
+}
+
+.last\\\\:-ml-36:last-child {
+  margin-left: -9rem;
+}
+
+.last\\\\:-ml-40:last-child {
+  margin-left: -10rem;
+}
+
+.last\\\\:-ml-44:last-child {
+  margin-left: -11rem;
+}
+
+.last\\\\:-ml-48:last-child {
+  margin-left: -12rem;
+}
+
+.last\\\\:-ml-52:last-child {
+  margin-left: -13rem;
+}
+
+.last\\\\:-ml-56:last-child {
+  margin-left: -14rem;
+}
+
+.last\\\\:-ml-60:last-child {
+  margin-left: -15rem;
+}
+
+.last\\\\:-ml-64:last-child {
+  margin-left: -16rem;
+}
+
+.last\\\\:-ml-72:last-child {
+  margin-left: -18rem;
+}
+
+.last\\\\:-ml-80:last-child {
+  margin-left: -20rem;
+}
+
+.last\\\\:-ml-96:last-child {
+  margin-left: -24rem;
+}
+
+.last\\\\:-ml-px:last-child {
+  margin-left: -1px;
+}
+
+.last\\\\:-ml-0\\\\.5:last-child {
+  margin-left: -0.125rem;
+}
+
+.last\\\\:-ml-1\\\\.5:last-child {
+  margin-left: -0.375rem;
+}
+
+.last\\\\:-ml-2\\\\.5:last-child {
+  margin-left: -0.625rem;
+}
+
+.last\\\\:-ml-3\\\\.5:last-child {
+  margin-left: -0.875rem;
+}
+
+.box-border {
+  box-sizing: border-box;
+}
+
+.box-content {
+  box-sizing: content-box;
+}
+
+.block {
+  display: block;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+.inline {
+  display: inline;
+}
+
+.flex {
+  display: flex;
+}
+
+.inline-flex {
+  display: inline-flex;
+}
+
+.table {
+  display: table;
+}
+
+.inline-table {
+  display: inline-table;
+}
+
+.table-caption {
+  display: table-caption;
+}
+
+.table-cell {
+  display: table-cell;
+}
+
+.table-column {
+  display: table-column;
+}
+
+.table-column-group {
+  display: table-column-group;
+}
+
+.table-footer-group {
+  display: table-footer-group;
+}
+
+.table-header-group {
+  display: table-header-group;
+}
+
+.table-row-group {
+  display: table-row-group;
+}
+
+.table-row {
+  display: table-row;
+}
+
+.flow-root {
+  display: flow-root;
+}
+
+.grid {
+  display: grid;
+}
+
+.inline-grid {
+  display: inline-grid;
+}
+
+.contents {
+  display: contents;
+}
+
+.list-item {
+  display: list-item;
+}
+
+.hidden {
+  display: none;
+}
+
+.group:hover .group-hover\\\\:block {
+  display: block;
+}
+
+.group:hover .group-hover\\\\:inline-block {
+  display: inline-block;
+}
+
+.group:hover .group-hover\\\\:inline {
+  display: inline;
+}
+
+.group:hover .group-hover\\\\:flex {
+  display: flex;
+}
+
+.group:hover .group-hover\\\\:inline-flex {
+  display: inline-flex;
+}
+
+.group:hover .group-hover\\\\:table {
+  display: table;
+}
+
+.group:hover .group-hover\\\\:inline-table {
+  display: inline-table;
+}
+
+.group:hover .group-hover\\\\:table-caption {
+  display: table-caption;
+}
+
+.group:hover .group-hover\\\\:table-cell {
+  display: table-cell;
+}
+
+.group:hover .group-hover\\\\:table-column {
+  display: table-column;
+}
+
+.group:hover .group-hover\\\\:table-column-group {
+  display: table-column-group;
+}
+
+.group:hover .group-hover\\\\:table-footer-group {
+  display: table-footer-group;
+}
+
+.group:hover .group-hover\\\\:table-header-group {
+  display: table-header-group;
+}
+
+.group:hover .group-hover\\\\:table-row-group {
+  display: table-row-group;
+}
+
+.group:hover .group-hover\\\\:table-row {
+  display: table-row;
+}
+
+.group:hover .group-hover\\\\:flow-root {
+  display: flow-root;
+}
+
+.group:hover .group-hover\\\\:grid {
+  display: grid;
+}
+
+.group:hover .group-hover\\\\:inline-grid {
+  display: inline-grid;
+}
+
+.group:hover .group-hover\\\\:contents {
+  display: contents;
+}
+
+.group:hover .group-hover\\\\:list-item {
+  display: list-item;
+}
+
+.group:hover .group-hover\\\\:hidden {
+  display: none;
+}
+
+.h-0 {
+  height: 0px;
+}
+
+.h-1 {
+  height: 0.25rem;
+}
+
+.h-2 {
+  height: 0.5rem;
+}
+
+.h-3 {
+  height: 0.75rem;
+}
+
+.h-4 {
+  height: 1rem;
+}
+
+.h-5 {
+  height: 1.25rem;
+}
+
+.h-6 {
+  height: 1.5rem;
+}
+
+.h-7 {
+  height: 1.75rem;
+}
+
+.h-8 {
+  height: 2rem;
+}
+
+.h-9 {
+  height: 2.25rem;
+}
+
+.h-10 {
+  height: 2.5rem;
+}
+
+.h-11 {
+  height: 2.75rem;
+}
+
+.h-12 {
+  height: 3rem;
+}
+
+.h-14 {
+  height: 3.5rem;
+}
+
+.h-16 {
+  height: 4rem;
+}
+
+.h-20 {
+  height: 5rem;
+}
+
+.h-24 {
+  height: 6rem;
+}
+
+.h-28 {
+  height: 7rem;
+}
+
+.h-32 {
+  height: 8rem;
+}
+
+.h-36 {
+  height: 9rem;
+}
+
+.h-40 {
+  height: 10rem;
+}
+
+.h-44 {
+  height: 11rem;
+}
+
+.h-48 {
+  height: 12rem;
+}
+
+.h-52 {
+  height: 13rem;
+}
+
+.h-56 {
+  height: 14rem;
+}
+
+.h-60 {
+  height: 15rem;
+}
+
+.h-64 {
+  height: 16rem;
+}
+
+.h-72 {
+  height: 18rem;
+}
+
+.h-80 {
+  height: 20rem;
+}
+
+.h-96 {
+  height: 24rem;
+}
+
+.h-auto {
+  height: auto;
+}
+
+.h-px {
+  height: 1px;
+}
+
+.h-0\\\\.5 {
+  height: 0.125rem;
+}
+
+.h-1\\\\.5 {
+  height: 0.375rem;
+}
+
+.h-2\\\\.5 {
+  height: 0.375rem;
+}
+
+.h-3\\\\.5 {
+  height: 0.875rem;
+}
+
+.h-1\\\\/2 {
+  height: 50%;
+}
+
+.h-1\\\\/3 {
+  height: 33.333333%;
+}
+
+.h-2\\\\/3 {
+  height: 66.666667%;
+}
+
+.h-1\\\\/4 {
+  height: 25%;
+}
+
+.h-2\\\\/4 {
+  height: 50%;
+}
+
+.h-3\\\\/4 {
+  height: 75%;
+}
+
+.h-1\\\\/5 {
+  height: 20%;
+}
+
+.h-2\\\\/5 {
+  height: 40%;
+}
+
+.h-3\\\\/5 {
+  height: 60%;
+}
+
+.h-4\\\\/5 {
+  height: 80%;
+}
+
+.h-1\\\\/6 {
+  height: 16.666667%;
+}
+
+.h-2\\\\/6 {
+  height: 33.333333%;
+}
+
+.h-3\\\\/6 {
+  height: 50%;
+}
+
+.h-4\\\\/6 {
+  height: 66.666667%;
+}
+
+.h-5\\\\/6 {
+  height: 83.333333%;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.h-screen {
+  height: 100vh;
+}
+
+.h-main-content-area {
+  height: calc(100vh - var(--template-head-height));
+}
+
+.max-h-0 {
+  max-height: 0px;
+}
+
+.max-h-1 {
+  max-height: 0.25rem;
+}
+
+.max-h-2 {
+  max-height: 0.5rem;
+}
+
+.max-h-3 {
+  max-height: 0.75rem;
+}
+
+.max-h-4 {
+  max-height: 1rem;
+}
+
+.max-h-5 {
+  max-height: 1.25rem;
+}
+
+.max-h-6 {
+  max-height: 1.5rem;
+}
+
+.max-h-7 {
+  max-height: 1.75rem;
+}
+
+.max-h-8 {
+  max-height: 2rem;
+}
+
+.max-h-9 {
+  max-height: 2.25rem;
+}
+
+.max-h-10 {
+  max-height: 2.5rem;
+}
+
+.max-h-11 {
+  max-height: 2.75rem;
+}
+
+.max-h-12 {
+  max-height: 3rem;
+}
+
+.max-h-14 {
+  max-height: 3.5rem;
+}
+
+.max-h-16 {
+  max-height: 4rem;
+}
+
+.max-h-20 {
+  max-height: 5rem;
+}
+
+.max-h-24 {
+  max-height: 6rem;
+}
+
+.max-h-28 {
+  max-height: 7rem;
+}
+
+.max-h-32 {
+  max-height: 8rem;
+}
+
+.max-h-36 {
+  max-height: 9rem;
+}
+
+.max-h-40 {
+  max-height: 10rem;
+}
+
+.max-h-44 {
+  max-height: 11rem;
+}
+
+.max-h-48 {
+  max-height: 12rem;
+}
+
+.max-h-52 {
+  max-height: 13rem;
+}
+
+.max-h-56 {
+  max-height: 14rem;
+}
+
+.max-h-60 {
+  max-height: 15rem;
+}
+
+.max-h-64 {
+  max-height: 16rem;
+}
+
+.max-h-72 {
+  max-height: 18rem;
+}
+
+.max-h-80 {
+  max-height: 20rem;
+}
+
+.max-h-96 {
+  max-height: 24rem;
+}
+
+.max-h-px {
+  max-height: 1px;
+}
+
+.max-h-0\\\\.5 {
+  max-height: 0.125rem;
+}
+
+.max-h-1\\\\.5 {
+  max-height: 0.375rem;
+}
+
+.max-h-2\\\\.5 {
+  max-height: 0.625rem;
+}
+
+.max-h-3\\\\.5 {
+  max-height: 0.875rem;
+}
+
+.max-h-full {
+  max-height: 100%;
+}
+
+.max-h-screen {
+  max-height: 100vh;
+}
+
+.max-h-listbox {
+  max-height: 12em;
+}
+
+.max-h-under-header {
+  max-height: calc(100vh - var(--template-head-height));
+}
+
+.min-h-0 {
+  min-height: 0px;
+}
+
+.min-h-3 {
+  min-height: 0.75rem;
+}
+
+.min-h-4 {
+  min-height: 1rem;
+}
+
+.min-h-6 {
+  min-height: 1.5rem;
+}
+
+.min-h-16 {
+  min-height: 4rem;
+}
+
+.min-h-full {
+  min-height: 100%;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.w-0 {
+  width: 0px;
+}
+
+.w-1 {
+  width: 0.25rem;
+}
+
+.w-2 {
+  width: 0.5rem;
+}
+
+.w-3 {
+  width: 0.75rem;
+}
+
+.w-4 {
+  width: 1rem;
+}
+
+.w-5 {
+  width: 1.25rem;
+}
+
+.w-6 {
+  width: 1.5rem;
+}
+
+.w-7 {
+  width: 1.75rem;
+}
+
+.w-8 {
+  width: 2rem;
+}
+
+.w-9 {
+  width: 2.25rem;
+}
+
+.w-10 {
+  width: 2.5rem;
+}
+
+.w-11 {
+  width: 2.75rem;
+}
+
+.w-12 {
+  width: 3rem;
+}
+
+.w-14 {
+  width: 3.5rem;
+}
+
+.w-15 {
+  width: 3.75rem;
+}
+
+.w-16 {
+  width: 4rem;
+}
+
+.w-20 {
+  width: 5rem;
+}
+
+.w-24 {
+  width: 6rem;
+}
+
+.w-28 {
+  width: 7rem;
+}
+
+.w-32 {
+  width: 8rem;
+}
+
+.w-36 {
+  width: 9rem;
+}
+
+.w-40 {
+  width: 10rem;
+}
+
+.w-44 {
+  width: 11rem;
+}
+
+.w-48 {
+  width: 12rem;
+}
+
+.w-52 {
+  width: 13rem;
+}
+
+.w-56 {
+  width: 14rem;
+}
+
+.w-60 {
+  width: 15rem;
+}
+
+.w-64 {
+  width: 16rem;
+}
+
+.w-72 {
+  width: 18rem;
+}
+
+.w-80 {
+  width: 20rem;
+}
+
+.w-96 {
+  width: 24rem;
+}
+
+.w-auto {
+  width: auto;
+}
+
+.w-px {
+  width: 1px;
+}
+
+.w-0\\\\.5 {
+  width: 0.125rem;
+}
+
+.w-1\\\\.5 {
+  width: 0.375rem;
+}
+
+.w-2\\\\.5 {
+  width: 0.375rem;
+}
+
+.w-3\\\\.5 {
+  width: 0.875rem;
+}
+
+.w-1\\\\/2 {
+  width: 50%;
+}
+
+.w-1\\\\/3 {
+  width: 33.333333%;
+}
+
+.w-2\\\\/3 {
+  width: 66.666667%;
+}
+
+.w-1\\\\/4 {
+  width: 25%;
+}
+
+.w-2\\\\/4 {
+  width: 50%;
+}
+
+.w-3\\\\/4 {
+  width: 75%;
+}
+
+.w-1\\\\/5 {
+  width: 20%;
+}
+
+.w-2\\\\/5 {
+  width: 40%;
+}
+
+.w-3\\\\/5 {
+  width: 60%;
+}
+
+.w-4\\\\/5 {
+  width: 80%;
+}
+
+.w-1\\\\/6 {
+  width: 16.666667%;
+}
+
+.w-2\\\\/6 {
+  width: 33.333333%;
+}
+
+.w-3\\\\/6 {
+  width: 50%;
+}
+
+.w-4\\\\/6 {
+  width: 66.666667%;
+}
+
+.w-5\\\\/6 {
+  width: 83.333333%;
+}
+
+.w-1\\\\/12 {
+  width: 8.333333%;
+}
+
+.w-2\\\\/12 {
+  width: 16.666667%;
+}
+
+.w-3\\\\/12 {
+  width: 25%;
+}
+
+.w-4\\\\/12 {
+  width: 33.333333%;
+}
+
+.w-5\\\\/12 {
+  width: 41.666667%;
+}
+
+.w-6\\\\/12 {
+  width: 50%;
+}
+
+.w-7\\\\/12 {
+  width: 58.333333%;
+}
+
+.w-8\\\\/12 {
+  width: 66.666667%;
+}
+
+.w-9\\\\/12 {
+  width: 75%;
+}
+
+.w-10\\\\/12 {
+  width: 83.333333%;
+}
+
+.w-11\\\\/12 {
+  width: 91.666667%;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.w-screen {
+  width: 100vw;
+}
+
+.w-min {
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+}
+
+.w-max {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.w-max-content {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.min-w-0 {
+  min-width: 0px;
+}
+
+.min-w-3 {
+  min-width: 0.75rem;
+}
+
+.min-w-4 {
+  min-width: 1rem;
+}
+
+.min-w-6 {
+  min-width: 1.5rem;
+}
+
+.min-w-16 {
+  min-width: 4rem;
+}
+
+.min-w-24 {
+  min-width: 6rem;
+}
+
+.min-w-48 {
+  min-width: 12rem;
+}
+
+.min-w-full {
+  min-width: 100%;
+}
+
+.min-w-min {
+  min-width: -webkit-min-content;
+  min-width: -moz-min-content;
+  min-width: min-content;
+}
+
+.min-w-max {
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+}
+
+.min-w-phoenix {
+  min-width: 1024px;
+}
+
+.min-w-popover {
+  min-width: 140px;
+}
+
+.min-w-toucan {
+  min-width: 1380px;
+}
+
+.max-w-0 {
+  max-width: 0rem;
+}
+
+.max-w-none {
+  max-width: none;
+}
+
+.max-w-xs {
+  max-width: 20rem;
+}
+
+.max-w-sm {
+  max-width: 24rem;
+}
+
+.max-w-md {
+  max-width: 28rem;
+}
+
+.max-w-lg {
+  max-width: 32rem;
+}
+
+.max-w-xl {
+  max-width: 36rem;
+}
+
+.max-w-2xl {
+  max-width: 42rem;
+}
+
+.max-w-3xl {
+  max-width: 48rem;
+}
+
+.max-w-4xl {
+  max-width: 56rem;
+}
+
+.max-w-5xl {
+  max-width: 64rem;
+}
+
+.max-w-6xl {
+  max-width: 72rem;
+}
+
+.max-w-7xl {
+  max-width: 80rem;
+}
+
+.max-w-full {
+  max-width: 100%;
+}
+
+.max-w-min {
+  max-width: -webkit-min-content;
+  max-width: -moz-min-content;
+  max-width: min-content;
+}
+
+.max-w-max {
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
+}
+
+.max-w-prose {
+  max-width: 65ch;
+}
+
+.max-w-screen-lg {
+  max-width: 1120px;
+}
+
+.max-w-screen-2xl {
+  max-width: 1536px;
+}
+
+.max-w-paragraph {
+  max-width: 34rem;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.flex-2 {
+  flex: 2 2 0%;
+}
+
+.flex-3 {
+  flex: 3 3 0%;
+}
+
+.flex-4 {
+  flex: 4 4 0%;
+}
+
+.flex-auto {
+  flex: 1 1 auto;
+}
+
+.flex-initial {
+  flex: 0 1 auto;
+}
+
+.flex-none {
+  flex: none;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
+.flex-shrink {
+  flex-shrink: 1;
+}
+
+.flex-grow-0 {
+  flex-grow: 0;
+}
+
+.flex-grow {
+  flex-grow: 1;
+}
+
+.table-auto {
+  table-layout: auto;
+}
+
+.table-fixed {
+  table-layout: fixed;
+}
+
+.border-collapse {
+  border-collapse: collapse;
+}
+
+.border-separate {
+  border-collapse: separate;
+}
+
+.origin-center {
+  transform-origin: center;
+}
+
+.origin-top {
+  transform-origin: top;
+}
+
+.origin-top-right {
+  transform-origin: top right;
+}
+
+.origin-right {
+  transform-origin: right;
+}
+
+.origin-bottom-right {
+  transform-origin: bottom right;
+}
+
+.origin-bottom {
+  transform-origin: bottom;
+}
+
+.origin-bottom-left {
+  transform-origin: bottom left;
+}
+
+.origin-left {
+  transform-origin: left;
+}
+
+.origin-top-left {
+  transform-origin: top left;
+}
+
+.transform {
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.transform-gpu {
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  transform: translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.transform-none {
+  transform: none;
+}
+
+.translate-x-0 {
+  --tw-translate-x: 0px;
+}
+
+.translate-x-1 {
+  --tw-translate-x: 0.25rem;
+}
+
+.translate-x-2 {
+  --tw-translate-x: 0.5rem;
+}
+
+.translate-x-3 {
+  --tw-translate-x: 0.75rem;
+}
+
+.translate-x-4 {
+  --tw-translate-x: 1rem;
+}
+
+.translate-x-5 {
+  --tw-translate-x: 1.25rem;
+}
+
+.translate-x-6 {
+  --tw-translate-x: 1.5rem;
+}
+
+.translate-x-7 {
+  --tw-translate-x: 1.75rem;
+}
+
+.translate-x-8 {
+  --tw-translate-x: 2rem;
+}
+
+.translate-x-9 {
+  --tw-translate-x: 2.25rem;
+}
+
+.translate-x-10 {
+  --tw-translate-x: 2.5rem;
+}
+
+.translate-x-11 {
+  --tw-translate-x: 2.75rem;
+}
+
+.translate-x-12 {
+  --tw-translate-x: 3rem;
+}
+
+.translate-x-14 {
+  --tw-translate-x: 3.5rem;
+}
+
+.translate-x-16 {
+  --tw-translate-x: 4rem;
+}
+
+.translate-x-20 {
+  --tw-translate-x: 5rem;
+}
+
+.translate-x-24 {
+  --tw-translate-x: 6rem;
+}
+
+.translate-x-28 {
+  --tw-translate-x: 7rem;
+}
+
+.translate-x-32 {
+  --tw-translate-x: 8rem;
+}
+
+.translate-x-36 {
+  --tw-translate-x: 9rem;
+}
+
+.translate-x-40 {
+  --tw-translate-x: 10rem;
+}
+
+.translate-x-44 {
+  --tw-translate-x: 11rem;
+}
+
+.translate-x-48 {
+  --tw-translate-x: 12rem;
+}
+
+.translate-x-52 {
+  --tw-translate-x: 13rem;
+}
+
+.translate-x-56 {
+  --tw-translate-x: 14rem;
+}
+
+.translate-x-60 {
+  --tw-translate-x: 15rem;
+}
+
+.translate-x-64 {
+  --tw-translate-x: 16rem;
+}
+
+.translate-x-72 {
+  --tw-translate-x: 18rem;
+}
+
+.translate-x-80 {
+  --tw-translate-x: 20rem;
+}
+
+.translate-x-96 {
+  --tw-translate-x: 24rem;
+}
+
+.translate-x-px {
+  --tw-translate-x: 1px;
+}
+
+.translate-x-0\\\\.5 {
+  --tw-translate-x: 0.125rem;
+}
+
+.translate-x-1\\\\.5 {
+  --tw-translate-x: 0.375rem;
+}
+
+.translate-x-2\\\\.5 {
+  --tw-translate-x: 0.625rem;
+}
+
+.translate-x-3\\\\.5 {
+  --tw-translate-x: 0.875rem;
+}
+
+.-translate-x-0 {
+  --tw-translate-x: 0px;
+}
+
+.-translate-x-1 {
+  --tw-translate-x: -0.25rem;
+}
+
+.-translate-x-2 {
+  --tw-translate-x: -0.5rem;
+}
+
+.-translate-x-3 {
+  --tw-translate-x: -0.75rem;
+}
+
+.-translate-x-4 {
+  --tw-translate-x: -1rem;
+}
+
+.-translate-x-5 {
+  --tw-translate-x: -1.25rem;
+}
+
+.-translate-x-6 {
+  --tw-translate-x: -1.5rem;
+}
+
+.-translate-x-7 {
+  --tw-translate-x: -1.75rem;
+}
+
+.-translate-x-8 {
+  --tw-translate-x: -2rem;
+}
+
+.-translate-x-9 {
+  --tw-translate-x: -2.25rem;
+}
+
+.-translate-x-10 {
+  --tw-translate-x: -2.5rem;
+}
+
+.-translate-x-11 {
+  --tw-translate-x: -2.75rem;
+}
+
+.-translate-x-12 {
+  --tw-translate-x: -3rem;
+}
+
+.-translate-x-14 {
+  --tw-translate-x: -3.5rem;
+}
+
+.-translate-x-16 {
+  --tw-translate-x: -4rem;
+}
+
+.-translate-x-20 {
+  --tw-translate-x: -5rem;
+}
+
+.-translate-x-24 {
+  --tw-translate-x: -6rem;
+}
+
+.-translate-x-28 {
+  --tw-translate-x: -7rem;
+}
+
+.-translate-x-32 {
+  --tw-translate-x: -8rem;
+}
+
+.-translate-x-36 {
+  --tw-translate-x: -9rem;
+}
+
+.-translate-x-40 {
+  --tw-translate-x: -10rem;
+}
+
+.-translate-x-44 {
+  --tw-translate-x: -11rem;
+}
+
+.-translate-x-48 {
+  --tw-translate-x: -12rem;
+}
+
+.-translate-x-52 {
+  --tw-translate-x: -13rem;
+}
+
+.-translate-x-56 {
+  --tw-translate-x: -14rem;
+}
+
+.-translate-x-60 {
+  --tw-translate-x: -15rem;
+}
+
+.-translate-x-64 {
+  --tw-translate-x: -16rem;
+}
+
+.-translate-x-72 {
+  --tw-translate-x: -18rem;
+}
+
+.-translate-x-80 {
+  --tw-translate-x: -20rem;
+}
+
+.-translate-x-96 {
+  --tw-translate-x: -24rem;
+}
+
+.-translate-x-px {
+  --tw-translate-x: -1px;
+}
+
+.-translate-x-0\\\\.5 {
+  --tw-translate-x: -0.125rem;
+}
+
+.-translate-x-1\\\\.5 {
+  --tw-translate-x: -0.375rem;
+}
+
+.-translate-x-2\\\\.5 {
+  --tw-translate-x: -0.625rem;
+}
+
+.-translate-x-3\\\\.5 {
+  --tw-translate-x: -0.875rem;
+}
+
+.translate-x-1\\\\/2 {
+  --tw-translate-x: 50%;
+}
+
+.translate-x-1\\\\/3 {
+  --tw-translate-x: 33.333333%;
+}
+
+.translate-x-2\\\\/3 {
+  --tw-translate-x: 66.666667%;
+}
+
+.translate-x-1\\\\/4 {
+  --tw-translate-x: 25%;
+}
+
+.translate-x-2\\\\/4 {
+  --tw-translate-x: 50%;
+}
+
+.translate-x-3\\\\/4 {
+  --tw-translate-x: 75%;
+}
+
+.translate-x-full {
+  --tw-translate-x: 100%;
+}
+
+.-translate-x-1\\\\/2 {
+  --tw-translate-x: -50%;
+}
+
+.-translate-x-1\\\\/3 {
+  --tw-translate-x: -33.333333%;
+}
+
+.-translate-x-2\\\\/3 {
+  --tw-translate-x: -66.666667%;
+}
+
+.-translate-x-1\\\\/4 {
+  --tw-translate-x: -25%;
+}
+
+.-translate-x-2\\\\/4 {
+  --tw-translate-x: -50%;
+}
+
+.-translate-x-3\\\\/4 {
+  --tw-translate-x: -75%;
+}
+
+.-translate-x-full {
+  --tw-translate-x: -100%;
+}
+
+.translate-y-0 {
+  --tw-translate-y: 0px;
+}
+
+.translate-y-1 {
+  --tw-translate-y: 0.25rem;
+}
+
+.translate-y-2 {
+  --tw-translate-y: 0.5rem;
+}
+
+.translate-y-3 {
+  --tw-translate-y: 0.75rem;
+}
+
+.translate-y-4 {
+  --tw-translate-y: 1rem;
+}
+
+.translate-y-5 {
+  --tw-translate-y: 1.25rem;
+}
+
+.translate-y-6 {
+  --tw-translate-y: 1.5rem;
+}
+
+.translate-y-7 {
+  --tw-translate-y: 1.75rem;
+}
+
+.translate-y-8 {
+  --tw-translate-y: 2rem;
+}
+
+.translate-y-9 {
+  --tw-translate-y: 2.25rem;
+}
+
+.translate-y-10 {
+  --tw-translate-y: 2.5rem;
+}
+
+.translate-y-11 {
+  --tw-translate-y: 2.75rem;
+}
+
+.translate-y-12 {
+  --tw-translate-y: 3rem;
+}
+
+.translate-y-14 {
+  --tw-translate-y: 3.5rem;
+}
+
+.translate-y-16 {
+  --tw-translate-y: 4rem;
+}
+
+.translate-y-20 {
+  --tw-translate-y: 5rem;
+}
+
+.translate-y-24 {
+  --tw-translate-y: 6rem;
+}
+
+.translate-y-28 {
+  --tw-translate-y: 7rem;
+}
+
+.translate-y-32 {
+  --tw-translate-y: 8rem;
+}
+
+.translate-y-36 {
+  --tw-translate-y: 9rem;
+}
+
+.translate-y-40 {
+  --tw-translate-y: 10rem;
+}
+
+.translate-y-44 {
+  --tw-translate-y: 11rem;
+}
+
+.translate-y-48 {
+  --tw-translate-y: 12rem;
+}
+
+.translate-y-52 {
+  --tw-translate-y: 13rem;
+}
+
+.translate-y-56 {
+  --tw-translate-y: 14rem;
+}
+
+.translate-y-60 {
+  --tw-translate-y: 15rem;
+}
+
+.translate-y-64 {
+  --tw-translate-y: 16rem;
+}
+
+.translate-y-72 {
+  --tw-translate-y: 18rem;
+}
+
+.translate-y-80 {
+  --tw-translate-y: 20rem;
+}
+
+.translate-y-96 {
+  --tw-translate-y: 24rem;
+}
+
+.translate-y-px {
+  --tw-translate-y: 1px;
+}
+
+.translate-y-0\\\\.5 {
+  --tw-translate-y: 0.125rem;
+}
+
+.translate-y-1\\\\.5 {
+  --tw-translate-y: 0.375rem;
+}
+
+.translate-y-2\\\\.5 {
+  --tw-translate-y: 0.625rem;
+}
+
+.translate-y-3\\\\.5 {
+  --tw-translate-y: 0.875rem;
+}
+
+.-translate-y-0 {
+  --tw-translate-y: 0px;
+}
+
+.-translate-y-1 {
+  --tw-translate-y: -0.25rem;
+}
+
+.-translate-y-2 {
+  --tw-translate-y: -0.5rem;
+}
+
+.-translate-y-3 {
+  --tw-translate-y: -0.75rem;
+}
+
+.-translate-y-4 {
+  --tw-translate-y: -1rem;
+}
+
+.-translate-y-5 {
+  --tw-translate-y: -1.25rem;
+}
+
+.-translate-y-6 {
+  --tw-translate-y: -1.5rem;
+}
+
+.-translate-y-7 {
+  --tw-translate-y: -1.75rem;
+}
+
+.-translate-y-8 {
+  --tw-translate-y: -2rem;
+}
+
+.-translate-y-9 {
+  --tw-translate-y: -2.25rem;
+}
+
+.-translate-y-10 {
+  --tw-translate-y: -2.5rem;
+}
+
+.-translate-y-11 {
+  --tw-translate-y: -2.75rem;
+}
+
+.-translate-y-12 {
+  --tw-translate-y: -3rem;
+}
+
+.-translate-y-14 {
+  --tw-translate-y: -3.5rem;
+}
+
+.-translate-y-16 {
+  --tw-translate-y: -4rem;
+}
+
+.-translate-y-20 {
+  --tw-translate-y: -5rem;
+}
+
+.-translate-y-24 {
+  --tw-translate-y: -6rem;
+}
+
+.-translate-y-28 {
+  --tw-translate-y: -7rem;
+}
+
+.-translate-y-32 {
+  --tw-translate-y: -8rem;
+}
+
+.-translate-y-36 {
+  --tw-translate-y: -9rem;
+}
+
+.-translate-y-40 {
+  --tw-translate-y: -10rem;
+}
+
+.-translate-y-44 {
+  --tw-translate-y: -11rem;
+}
+
+.-translate-y-48 {
+  --tw-translate-y: -12rem;
+}
+
+.-translate-y-52 {
+  --tw-translate-y: -13rem;
+}
+
+.-translate-y-56 {
+  --tw-translate-y: -14rem;
+}
+
+.-translate-y-60 {
+  --tw-translate-y: -15rem;
+}
+
+.-translate-y-64 {
+  --tw-translate-y: -16rem;
+}
+
+.-translate-y-72 {
+  --tw-translate-y: -18rem;
+}
+
+.-translate-y-80 {
+  --tw-translate-y: -20rem;
+}
+
+.-translate-y-96 {
+  --tw-translate-y: -24rem;
+}
+
+.-translate-y-px {
+  --tw-translate-y: -1px;
+}
+
+.-translate-y-0\\\\.5 {
+  --tw-translate-y: -0.125rem;
+}
+
+.-translate-y-1\\\\.5 {
+  --tw-translate-y: -0.375rem;
+}
+
+.-translate-y-2\\\\.5 {
+  --tw-translate-y: -0.625rem;
+}
+
+.-translate-y-3\\\\.5 {
+  --tw-translate-y: -0.875rem;
+}
+
+.translate-y-1\\\\/2 {
+  --tw-translate-y: 50%;
+}
+
+.translate-y-1\\\\/3 {
+  --tw-translate-y: 33.333333%;
+}
+
+.translate-y-2\\\\/3 {
+  --tw-translate-y: 66.666667%;
+}
+
+.translate-y-1\\\\/4 {
+  --tw-translate-y: 25%;
+}
+
+.translate-y-2\\\\/4 {
+  --tw-translate-y: 50%;
+}
+
+.translate-y-3\\\\/4 {
+  --tw-translate-y: 75%;
+}
+
+.translate-y-full {
+  --tw-translate-y: 100%;
+}
+
+.-translate-y-1\\\\/2 {
+  --tw-translate-y: -50%;
+}
+
+.-translate-y-1\\\\/3 {
+  --tw-translate-y: -33.333333%;
+}
+
+.-translate-y-2\\\\/3 {
+  --tw-translate-y: -66.666667%;
+}
+
+.-translate-y-1\\\\/4 {
+  --tw-translate-y: -25%;
+}
+
+.-translate-y-2\\\\/4 {
+  --tw-translate-y: -50%;
+}
+
+.-translate-y-3\\\\/4 {
+  --tw-translate-y: -75%;
+}
+
+.-translate-y-full {
+  --tw-translate-y: -100%;
+}
+
+.hover\\\\:translate-x-0:hover {
+  --tw-translate-x: 0px;
+}
+
+.hover\\\\:translate-x-1:hover {
+  --tw-translate-x: 0.25rem;
+}
+
+.hover\\\\:translate-x-2:hover {
+  --tw-translate-x: 0.5rem;
+}
+
+.hover\\\\:translate-x-3:hover {
+  --tw-translate-x: 0.75rem;
+}
+
+.hover\\\\:translate-x-4:hover {
+  --tw-translate-x: 1rem;
+}
+
+.hover\\\\:translate-x-5:hover {
+  --tw-translate-x: 1.25rem;
+}
+
+.hover\\\\:translate-x-6:hover {
+  --tw-translate-x: 1.5rem;
+}
+
+.hover\\\\:translate-x-7:hover {
+  --tw-translate-x: 1.75rem;
+}
+
+.hover\\\\:translate-x-8:hover {
+  --tw-translate-x: 2rem;
+}
+
+.hover\\\\:translate-x-9:hover {
+  --tw-translate-x: 2.25rem;
+}
+
+.hover\\\\:translate-x-10:hover {
+  --tw-translate-x: 2.5rem;
+}
+
+.hover\\\\:translate-x-11:hover {
+  --tw-translate-x: 2.75rem;
+}
+
+.hover\\\\:translate-x-12:hover {
+  --tw-translate-x: 3rem;
+}
+
+.hover\\\\:translate-x-14:hover {
+  --tw-translate-x: 3.5rem;
+}
+
+.hover\\\\:translate-x-16:hover {
+  --tw-translate-x: 4rem;
+}
+
+.hover\\\\:translate-x-20:hover {
+  --tw-translate-x: 5rem;
+}
+
+.hover\\\\:translate-x-24:hover {
+  --tw-translate-x: 6rem;
+}
+
+.hover\\\\:translate-x-28:hover {
+  --tw-translate-x: 7rem;
+}
+
+.hover\\\\:translate-x-32:hover {
+  --tw-translate-x: 8rem;
+}
+
+.hover\\\\:translate-x-36:hover {
+  --tw-translate-x: 9rem;
+}
+
+.hover\\\\:translate-x-40:hover {
+  --tw-translate-x: 10rem;
+}
+
+.hover\\\\:translate-x-44:hover {
+  --tw-translate-x: 11rem;
+}
+
+.hover\\\\:translate-x-48:hover {
+  --tw-translate-x: 12rem;
+}
+
+.hover\\\\:translate-x-52:hover {
+  --tw-translate-x: 13rem;
+}
+
+.hover\\\\:translate-x-56:hover {
+  --tw-translate-x: 14rem;
+}
+
+.hover\\\\:translate-x-60:hover {
+  --tw-translate-x: 15rem;
+}
+
+.hover\\\\:translate-x-64:hover {
+  --tw-translate-x: 16rem;
+}
+
+.hover\\\\:translate-x-72:hover {
+  --tw-translate-x: 18rem;
+}
+
+.hover\\\\:translate-x-80:hover {
+  --tw-translate-x: 20rem;
+}
+
+.hover\\\\:translate-x-96:hover {
+  --tw-translate-x: 24rem;
+}
+
+.hover\\\\:translate-x-px:hover {
+  --tw-translate-x: 1px;
+}
+
+.hover\\\\:translate-x-0\\\\.5:hover {
+  --tw-translate-x: 0.125rem;
+}
+
+.hover\\\\:translate-x-1\\\\.5:hover {
+  --tw-translate-x: 0.375rem;
+}
+
+.hover\\\\:translate-x-2\\\\.5:hover {
+  --tw-translate-x: 0.625rem;
+}
+
+.hover\\\\:translate-x-3\\\\.5:hover {
+  --tw-translate-x: 0.875rem;
+}
+
+.hover\\\\:-translate-x-0:hover {
+  --tw-translate-x: 0px;
+}
+
+.hover\\\\:-translate-x-1:hover {
+  --tw-translate-x: -0.25rem;
+}
+
+.hover\\\\:-translate-x-2:hover {
+  --tw-translate-x: -0.5rem;
+}
+
+.hover\\\\:-translate-x-3:hover {
+  --tw-translate-x: -0.75rem;
+}
+
+.hover\\\\:-translate-x-4:hover {
+  --tw-translate-x: -1rem;
+}
+
+.hover\\\\:-translate-x-5:hover {
+  --tw-translate-x: -1.25rem;
+}
+
+.hover\\\\:-translate-x-6:hover {
+  --tw-translate-x: -1.5rem;
+}
+
+.hover\\\\:-translate-x-7:hover {
+  --tw-translate-x: -1.75rem;
+}
+
+.hover\\\\:-translate-x-8:hover {
+  --tw-translate-x: -2rem;
+}
+
+.hover\\\\:-translate-x-9:hover {
+  --tw-translate-x: -2.25rem;
+}
+
+.hover\\\\:-translate-x-10:hover {
+  --tw-translate-x: -2.5rem;
+}
+
+.hover\\\\:-translate-x-11:hover {
+  --tw-translate-x: -2.75rem;
+}
+
+.hover\\\\:-translate-x-12:hover {
+  --tw-translate-x: -3rem;
+}
+
+.hover\\\\:-translate-x-14:hover {
+  --tw-translate-x: -3.5rem;
+}
+
+.hover\\\\:-translate-x-16:hover {
+  --tw-translate-x: -4rem;
+}
+
+.hover\\\\:-translate-x-20:hover {
+  --tw-translate-x: -5rem;
+}
+
+.hover\\\\:-translate-x-24:hover {
+  --tw-translate-x: -6rem;
+}
+
+.hover\\\\:-translate-x-28:hover {
+  --tw-translate-x: -7rem;
+}
+
+.hover\\\\:-translate-x-32:hover {
+  --tw-translate-x: -8rem;
+}
+
+.hover\\\\:-translate-x-36:hover {
+  --tw-translate-x: -9rem;
+}
+
+.hover\\\\:-translate-x-40:hover {
+  --tw-translate-x: -10rem;
+}
+
+.hover\\\\:-translate-x-44:hover {
+  --tw-translate-x: -11rem;
+}
+
+.hover\\\\:-translate-x-48:hover {
+  --tw-translate-x: -12rem;
+}
+
+.hover\\\\:-translate-x-52:hover {
+  --tw-translate-x: -13rem;
+}
+
+.hover\\\\:-translate-x-56:hover {
+  --tw-translate-x: -14rem;
+}
+
+.hover\\\\:-translate-x-60:hover {
+  --tw-translate-x: -15rem;
+}
+
+.hover\\\\:-translate-x-64:hover {
+  --tw-translate-x: -16rem;
+}
+
+.hover\\\\:-translate-x-72:hover {
+  --tw-translate-x: -18rem;
+}
+
+.hover\\\\:-translate-x-80:hover {
+  --tw-translate-x: -20rem;
+}
+
+.hover\\\\:-translate-x-96:hover {
+  --tw-translate-x: -24rem;
+}
+
+.hover\\\\:-translate-x-px:hover {
+  --tw-translate-x: -1px;
+}
+
+.hover\\\\:-translate-x-0\\\\.5:hover {
+  --tw-translate-x: -0.125rem;
+}
+
+.hover\\\\:-translate-x-1\\\\.5:hover {
+  --tw-translate-x: -0.375rem;
+}
+
+.hover\\\\:-translate-x-2\\\\.5:hover {
+  --tw-translate-x: -0.625rem;
+}
+
+.hover\\\\:-translate-x-3\\\\.5:hover {
+  --tw-translate-x: -0.875rem;
+}
+
+.hover\\\\:translate-x-1\\\\/2:hover {
+  --tw-translate-x: 50%;
+}
+
+.hover\\\\:translate-x-1\\\\/3:hover {
+  --tw-translate-x: 33.333333%;
+}
+
+.hover\\\\:translate-x-2\\\\/3:hover {
+  --tw-translate-x: 66.666667%;
+}
+
+.hover\\\\:translate-x-1\\\\/4:hover {
+  --tw-translate-x: 25%;
+}
+
+.hover\\\\:translate-x-2\\\\/4:hover {
+  --tw-translate-x: 50%;
+}
+
+.hover\\\\:translate-x-3\\\\/4:hover {
+  --tw-translate-x: 75%;
+}
+
+.hover\\\\:translate-x-full:hover {
+  --tw-translate-x: 100%;
+}
+
+.hover\\\\:-translate-x-1\\\\/2:hover {
+  --tw-translate-x: -50%;
+}
+
+.hover\\\\:-translate-x-1\\\\/3:hover {
+  --tw-translate-x: -33.333333%;
+}
+
+.hover\\\\:-translate-x-2\\\\/3:hover {
+  --tw-translate-x: -66.666667%;
+}
+
+.hover\\\\:-translate-x-1\\\\/4:hover {
+  --tw-translate-x: -25%;
+}
+
+.hover\\\\:-translate-x-2\\\\/4:hover {
+  --tw-translate-x: -50%;
+}
+
+.hover\\\\:-translate-x-3\\\\/4:hover {
+  --tw-translate-x: -75%;
+}
+
+.hover\\\\:-translate-x-full:hover {
+  --tw-translate-x: -100%;
+}
+
+.hover\\\\:translate-y-0:hover {
+  --tw-translate-y: 0px;
+}
+
+.hover\\\\:translate-y-1:hover {
+  --tw-translate-y: 0.25rem;
+}
+
+.hover\\\\:translate-y-2:hover {
+  --tw-translate-y: 0.5rem;
+}
+
+.hover\\\\:translate-y-3:hover {
+  --tw-translate-y: 0.75rem;
+}
+
+.hover\\\\:translate-y-4:hover {
+  --tw-translate-y: 1rem;
+}
+
+.hover\\\\:translate-y-5:hover {
+  --tw-translate-y: 1.25rem;
+}
+
+.hover\\\\:translate-y-6:hover {
+  --tw-translate-y: 1.5rem;
+}
+
+.hover\\\\:translate-y-7:hover {
+  --tw-translate-y: 1.75rem;
+}
+
+.hover\\\\:translate-y-8:hover {
+  --tw-translate-y: 2rem;
+}
+
+.hover\\\\:translate-y-9:hover {
+  --tw-translate-y: 2.25rem;
+}
+
+.hover\\\\:translate-y-10:hover {
+  --tw-translate-y: 2.5rem;
+}
+
+.hover\\\\:translate-y-11:hover {
+  --tw-translate-y: 2.75rem;
+}
+
+.hover\\\\:translate-y-12:hover {
+  --tw-translate-y: 3rem;
+}
+
+.hover\\\\:translate-y-14:hover {
+  --tw-translate-y: 3.5rem;
+}
+
+.hover\\\\:translate-y-16:hover {
+  --tw-translate-y: 4rem;
+}
+
+.hover\\\\:translate-y-20:hover {
+  --tw-translate-y: 5rem;
+}
+
+.hover\\\\:translate-y-24:hover {
+  --tw-translate-y: 6rem;
+}
+
+.hover\\\\:translate-y-28:hover {
+  --tw-translate-y: 7rem;
+}
+
+.hover\\\\:translate-y-32:hover {
+  --tw-translate-y: 8rem;
+}
+
+.hover\\\\:translate-y-36:hover {
+  --tw-translate-y: 9rem;
+}
+
+.hover\\\\:translate-y-40:hover {
+  --tw-translate-y: 10rem;
+}
+
+.hover\\\\:translate-y-44:hover {
+  --tw-translate-y: 11rem;
+}
+
+.hover\\\\:translate-y-48:hover {
+  --tw-translate-y: 12rem;
+}
+
+.hover\\\\:translate-y-52:hover {
+  --tw-translate-y: 13rem;
+}
+
+.hover\\\\:translate-y-56:hover {
+  --tw-translate-y: 14rem;
+}
+
+.hover\\\\:translate-y-60:hover {
+  --tw-translate-y: 15rem;
+}
+
+.hover\\\\:translate-y-64:hover {
+  --tw-translate-y: 16rem;
+}
+
+.hover\\\\:translate-y-72:hover {
+  --tw-translate-y: 18rem;
+}
+
+.hover\\\\:translate-y-80:hover {
+  --tw-translate-y: 20rem;
+}
+
+.hover\\\\:translate-y-96:hover {
+  --tw-translate-y: 24rem;
+}
+
+.hover\\\\:translate-y-px:hover {
+  --tw-translate-y: 1px;
+}
+
+.hover\\\\:translate-y-0\\\\.5:hover {
+  --tw-translate-y: 0.125rem;
+}
+
+.hover\\\\:translate-y-1\\\\.5:hover {
+  --tw-translate-y: 0.375rem;
+}
+
+.hover\\\\:translate-y-2\\\\.5:hover {
+  --tw-translate-y: 0.625rem;
+}
+
+.hover\\\\:translate-y-3\\\\.5:hover {
+  --tw-translate-y: 0.875rem;
+}
+
+.hover\\\\:-translate-y-0:hover {
+  --tw-translate-y: 0px;
+}
+
+.hover\\\\:-translate-y-1:hover {
+  --tw-translate-y: -0.25rem;
+}
+
+.hover\\\\:-translate-y-2:hover {
+  --tw-translate-y: -0.5rem;
+}
+
+.hover\\\\:-translate-y-3:hover {
+  --tw-translate-y: -0.75rem;
+}
+
+.hover\\\\:-translate-y-4:hover {
+  --tw-translate-y: -1rem;
+}
+
+.hover\\\\:-translate-y-5:hover {
+  --tw-translate-y: -1.25rem;
+}
+
+.hover\\\\:-translate-y-6:hover {
+  --tw-translate-y: -1.5rem;
+}
+
+.hover\\\\:-translate-y-7:hover {
+  --tw-translate-y: -1.75rem;
+}
+
+.hover\\\\:-translate-y-8:hover {
+  --tw-translate-y: -2rem;
+}
+
+.hover\\\\:-translate-y-9:hover {
+  --tw-translate-y: -2.25rem;
+}
+
+.hover\\\\:-translate-y-10:hover {
+  --tw-translate-y: -2.5rem;
+}
+
+.hover\\\\:-translate-y-11:hover {
+  --tw-translate-y: -2.75rem;
+}
+
+.hover\\\\:-translate-y-12:hover {
+  --tw-translate-y: -3rem;
+}
+
+.hover\\\\:-translate-y-14:hover {
+  --tw-translate-y: -3.5rem;
+}
+
+.hover\\\\:-translate-y-16:hover {
+  --tw-translate-y: -4rem;
+}
+
+.hover\\\\:-translate-y-20:hover {
+  --tw-translate-y: -5rem;
+}
+
+.hover\\\\:-translate-y-24:hover {
+  --tw-translate-y: -6rem;
+}
+
+.hover\\\\:-translate-y-28:hover {
+  --tw-translate-y: -7rem;
+}
+
+.hover\\\\:-translate-y-32:hover {
+  --tw-translate-y: -8rem;
+}
+
+.hover\\\\:-translate-y-36:hover {
+  --tw-translate-y: -9rem;
+}
+
+.hover\\\\:-translate-y-40:hover {
+  --tw-translate-y: -10rem;
+}
+
+.hover\\\\:-translate-y-44:hover {
+  --tw-translate-y: -11rem;
+}
+
+.hover\\\\:-translate-y-48:hover {
+  --tw-translate-y: -12rem;
+}
+
+.hover\\\\:-translate-y-52:hover {
+  --tw-translate-y: -13rem;
+}
+
+.hover\\\\:-translate-y-56:hover {
+  --tw-translate-y: -14rem;
+}
+
+.hover\\\\:-translate-y-60:hover {
+  --tw-translate-y: -15rem;
+}
+
+.hover\\\\:-translate-y-64:hover {
+  --tw-translate-y: -16rem;
+}
+
+.hover\\\\:-translate-y-72:hover {
+  --tw-translate-y: -18rem;
+}
+
+.hover\\\\:-translate-y-80:hover {
+  --tw-translate-y: -20rem;
+}
+
+.hover\\\\:-translate-y-96:hover {
+  --tw-translate-y: -24rem;
+}
+
+.hover\\\\:-translate-y-px:hover {
+  --tw-translate-y: -1px;
+}
+
+.hover\\\\:-translate-y-0\\\\.5:hover {
+  --tw-translate-y: -0.125rem;
+}
+
+.hover\\\\:-translate-y-1\\\\.5:hover {
+  --tw-translate-y: -0.375rem;
+}
+
+.hover\\\\:-translate-y-2\\\\.5:hover {
+  --tw-translate-y: -0.625rem;
+}
+
+.hover\\\\:-translate-y-3\\\\.5:hover {
+  --tw-translate-y: -0.875rem;
+}
+
+.hover\\\\:translate-y-1\\\\/2:hover {
+  --tw-translate-y: 50%;
+}
+
+.hover\\\\:translate-y-1\\\\/3:hover {
+  --tw-translate-y: 33.333333%;
+}
+
+.hover\\\\:translate-y-2\\\\/3:hover {
+  --tw-translate-y: 66.666667%;
+}
+
+.hover\\\\:translate-y-1\\\\/4:hover {
+  --tw-translate-y: 25%;
+}
+
+.hover\\\\:translate-y-2\\\\/4:hover {
+  --tw-translate-y: 50%;
+}
+
+.hover\\\\:translate-y-3\\\\/4:hover {
+  --tw-translate-y: 75%;
+}
+
+.hover\\\\:translate-y-full:hover {
+  --tw-translate-y: 100%;
+}
+
+.hover\\\\:-translate-y-1\\\\/2:hover {
+  --tw-translate-y: -50%;
+}
+
+.hover\\\\:-translate-y-1\\\\/3:hover {
+  --tw-translate-y: -33.333333%;
+}
+
+.hover\\\\:-translate-y-2\\\\/3:hover {
+  --tw-translate-y: -66.666667%;
+}
+
+.hover\\\\:-translate-y-1\\\\/4:hover {
+  --tw-translate-y: -25%;
+}
+
+.hover\\\\:-translate-y-2\\\\/4:hover {
+  --tw-translate-y: -50%;
+}
+
+.hover\\\\:-translate-y-3\\\\/4:hover {
+  --tw-translate-y: -75%;
+}
+
+.hover\\\\:-translate-y-full:hover {
+  --tw-translate-y: -100%;
+}
+
+.focus\\\\:translate-x-0:focus {
+  --tw-translate-x: 0px;
+}
+
+.focus\\\\:translate-x-1:focus {
+  --tw-translate-x: 0.25rem;
+}
+
+.focus\\\\:translate-x-2:focus {
+  --tw-translate-x: 0.5rem;
+}
+
+.focus\\\\:translate-x-3:focus {
+  --tw-translate-x: 0.75rem;
+}
+
+.focus\\\\:translate-x-4:focus {
+  --tw-translate-x: 1rem;
+}
+
+.focus\\\\:translate-x-5:focus {
+  --tw-translate-x: 1.25rem;
+}
+
+.focus\\\\:translate-x-6:focus {
+  --tw-translate-x: 1.5rem;
+}
+
+.focus\\\\:translate-x-7:focus {
+  --tw-translate-x: 1.75rem;
+}
+
+.focus\\\\:translate-x-8:focus {
+  --tw-translate-x: 2rem;
+}
+
+.focus\\\\:translate-x-9:focus {
+  --tw-translate-x: 2.25rem;
+}
+
+.focus\\\\:translate-x-10:focus {
+  --tw-translate-x: 2.5rem;
+}
+
+.focus\\\\:translate-x-11:focus {
+  --tw-translate-x: 2.75rem;
+}
+
+.focus\\\\:translate-x-12:focus {
+  --tw-translate-x: 3rem;
+}
+
+.focus\\\\:translate-x-14:focus {
+  --tw-translate-x: 3.5rem;
+}
+
+.focus\\\\:translate-x-16:focus {
+  --tw-translate-x: 4rem;
+}
+
+.focus\\\\:translate-x-20:focus {
+  --tw-translate-x: 5rem;
+}
+
+.focus\\\\:translate-x-24:focus {
+  --tw-translate-x: 6rem;
+}
+
+.focus\\\\:translate-x-28:focus {
+  --tw-translate-x: 7rem;
+}
+
+.focus\\\\:translate-x-32:focus {
+  --tw-translate-x: 8rem;
+}
+
+.focus\\\\:translate-x-36:focus {
+  --tw-translate-x: 9rem;
+}
+
+.focus\\\\:translate-x-40:focus {
+  --tw-translate-x: 10rem;
+}
+
+.focus\\\\:translate-x-44:focus {
+  --tw-translate-x: 11rem;
+}
+
+.focus\\\\:translate-x-48:focus {
+  --tw-translate-x: 12rem;
+}
+
+.focus\\\\:translate-x-52:focus {
+  --tw-translate-x: 13rem;
+}
+
+.focus\\\\:translate-x-56:focus {
+  --tw-translate-x: 14rem;
+}
+
+.focus\\\\:translate-x-60:focus {
+  --tw-translate-x: 15rem;
+}
+
+.focus\\\\:translate-x-64:focus {
+  --tw-translate-x: 16rem;
+}
+
+.focus\\\\:translate-x-72:focus {
+  --tw-translate-x: 18rem;
+}
+
+.focus\\\\:translate-x-80:focus {
+  --tw-translate-x: 20rem;
+}
+
+.focus\\\\:translate-x-96:focus {
+  --tw-translate-x: 24rem;
+}
+
+.focus\\\\:translate-x-px:focus {
+  --tw-translate-x: 1px;
+}
+
+.focus\\\\:translate-x-0\\\\.5:focus {
+  --tw-translate-x: 0.125rem;
+}
+
+.focus\\\\:translate-x-1\\\\.5:focus {
+  --tw-translate-x: 0.375rem;
+}
+
+.focus\\\\:translate-x-2\\\\.5:focus {
+  --tw-translate-x: 0.625rem;
+}
+
+.focus\\\\:translate-x-3\\\\.5:focus {
+  --tw-translate-x: 0.875rem;
+}
+
+.focus\\\\:-translate-x-0:focus {
+  --tw-translate-x: 0px;
+}
+
+.focus\\\\:-translate-x-1:focus {
+  --tw-translate-x: -0.25rem;
+}
+
+.focus\\\\:-translate-x-2:focus {
+  --tw-translate-x: -0.5rem;
+}
+
+.focus\\\\:-translate-x-3:focus {
+  --tw-translate-x: -0.75rem;
+}
+
+.focus\\\\:-translate-x-4:focus {
+  --tw-translate-x: -1rem;
+}
+
+.focus\\\\:-translate-x-5:focus {
+  --tw-translate-x: -1.25rem;
+}
+
+.focus\\\\:-translate-x-6:focus {
+  --tw-translate-x: -1.5rem;
+}
+
+.focus\\\\:-translate-x-7:focus {
+  --tw-translate-x: -1.75rem;
+}
+
+.focus\\\\:-translate-x-8:focus {
+  --tw-translate-x: -2rem;
+}
+
+.focus\\\\:-translate-x-9:focus {
+  --tw-translate-x: -2.25rem;
+}
+
+.focus\\\\:-translate-x-10:focus {
+  --tw-translate-x: -2.5rem;
+}
+
+.focus\\\\:-translate-x-11:focus {
+  --tw-translate-x: -2.75rem;
+}
+
+.focus\\\\:-translate-x-12:focus {
+  --tw-translate-x: -3rem;
+}
+
+.focus\\\\:-translate-x-14:focus {
+  --tw-translate-x: -3.5rem;
+}
+
+.focus\\\\:-translate-x-16:focus {
+  --tw-translate-x: -4rem;
+}
+
+.focus\\\\:-translate-x-20:focus {
+  --tw-translate-x: -5rem;
+}
+
+.focus\\\\:-translate-x-24:focus {
+  --tw-translate-x: -6rem;
+}
+
+.focus\\\\:-translate-x-28:focus {
+  --tw-translate-x: -7rem;
+}
+
+.focus\\\\:-translate-x-32:focus {
+  --tw-translate-x: -8rem;
+}
+
+.focus\\\\:-translate-x-36:focus {
+  --tw-translate-x: -9rem;
+}
+
+.focus\\\\:-translate-x-40:focus {
+  --tw-translate-x: -10rem;
+}
+
+.focus\\\\:-translate-x-44:focus {
+  --tw-translate-x: -11rem;
+}
+
+.focus\\\\:-translate-x-48:focus {
+  --tw-translate-x: -12rem;
+}
+
+.focus\\\\:-translate-x-52:focus {
+  --tw-translate-x: -13rem;
+}
+
+.focus\\\\:-translate-x-56:focus {
+  --tw-translate-x: -14rem;
+}
+
+.focus\\\\:-translate-x-60:focus {
+  --tw-translate-x: -15rem;
+}
+
+.focus\\\\:-translate-x-64:focus {
+  --tw-translate-x: -16rem;
+}
+
+.focus\\\\:-translate-x-72:focus {
+  --tw-translate-x: -18rem;
+}
+
+.focus\\\\:-translate-x-80:focus {
+  --tw-translate-x: -20rem;
+}
+
+.focus\\\\:-translate-x-96:focus {
+  --tw-translate-x: -24rem;
+}
+
+.focus\\\\:-translate-x-px:focus {
+  --tw-translate-x: -1px;
+}
+
+.focus\\\\:-translate-x-0\\\\.5:focus {
+  --tw-translate-x: -0.125rem;
+}
+
+.focus\\\\:-translate-x-1\\\\.5:focus {
+  --tw-translate-x: -0.375rem;
+}
+
+.focus\\\\:-translate-x-2\\\\.5:focus {
+  --tw-translate-x: -0.625rem;
+}
+
+.focus\\\\:-translate-x-3\\\\.5:focus {
+  --tw-translate-x: -0.875rem;
+}
+
+.focus\\\\:translate-x-1\\\\/2:focus {
+  --tw-translate-x: 50%;
+}
+
+.focus\\\\:translate-x-1\\\\/3:focus {
+  --tw-translate-x: 33.333333%;
+}
+
+.focus\\\\:translate-x-2\\\\/3:focus {
+  --tw-translate-x: 66.666667%;
+}
+
+.focus\\\\:translate-x-1\\\\/4:focus {
+  --tw-translate-x: 25%;
+}
+
+.focus\\\\:translate-x-2\\\\/4:focus {
+  --tw-translate-x: 50%;
+}
+
+.focus\\\\:translate-x-3\\\\/4:focus {
+  --tw-translate-x: 75%;
+}
+
+.focus\\\\:translate-x-full:focus {
+  --tw-translate-x: 100%;
+}
+
+.focus\\\\:-translate-x-1\\\\/2:focus {
+  --tw-translate-x: -50%;
+}
+
+.focus\\\\:-translate-x-1\\\\/3:focus {
+  --tw-translate-x: -33.333333%;
+}
+
+.focus\\\\:-translate-x-2\\\\/3:focus {
+  --tw-translate-x: -66.666667%;
+}
+
+.focus\\\\:-translate-x-1\\\\/4:focus {
+  --tw-translate-x: -25%;
+}
+
+.focus\\\\:-translate-x-2\\\\/4:focus {
+  --tw-translate-x: -50%;
+}
+
+.focus\\\\:-translate-x-3\\\\/4:focus {
+  --tw-translate-x: -75%;
+}
+
+.focus\\\\:-translate-x-full:focus {
+  --tw-translate-x: -100%;
+}
+
+.focus\\\\:translate-y-0:focus {
+  --tw-translate-y: 0px;
+}
+
+.focus\\\\:translate-y-1:focus {
+  --tw-translate-y: 0.25rem;
+}
+
+.focus\\\\:translate-y-2:focus {
+  --tw-translate-y: 0.5rem;
+}
+
+.focus\\\\:translate-y-3:focus {
+  --tw-translate-y: 0.75rem;
+}
+
+.focus\\\\:translate-y-4:focus {
+  --tw-translate-y: 1rem;
+}
+
+.focus\\\\:translate-y-5:focus {
+  --tw-translate-y: 1.25rem;
+}
+
+.focus\\\\:translate-y-6:focus {
+  --tw-translate-y: 1.5rem;
+}
+
+.focus\\\\:translate-y-7:focus {
+  --tw-translate-y: 1.75rem;
+}
+
+.focus\\\\:translate-y-8:focus {
+  --tw-translate-y: 2rem;
+}
+
+.focus\\\\:translate-y-9:focus {
+  --tw-translate-y: 2.25rem;
+}
+
+.focus\\\\:translate-y-10:focus {
+  --tw-translate-y: 2.5rem;
+}
+
+.focus\\\\:translate-y-11:focus {
+  --tw-translate-y: 2.75rem;
+}
+
+.focus\\\\:translate-y-12:focus {
+  --tw-translate-y: 3rem;
+}
+
+.focus\\\\:translate-y-14:focus {
+  --tw-translate-y: 3.5rem;
+}
+
+.focus\\\\:translate-y-16:focus {
+  --tw-translate-y: 4rem;
+}
+
+.focus\\\\:translate-y-20:focus {
+  --tw-translate-y: 5rem;
+}
+
+.focus\\\\:translate-y-24:focus {
+  --tw-translate-y: 6rem;
+}
+
+.focus\\\\:translate-y-28:focus {
+  --tw-translate-y: 7rem;
+}
+
+.focus\\\\:translate-y-32:focus {
+  --tw-translate-y: 8rem;
+}
+
+.focus\\\\:translate-y-36:focus {
+  --tw-translate-y: 9rem;
+}
+
+.focus\\\\:translate-y-40:focus {
+  --tw-translate-y: 10rem;
+}
+
+.focus\\\\:translate-y-44:focus {
+  --tw-translate-y: 11rem;
+}
+
+.focus\\\\:translate-y-48:focus {
+  --tw-translate-y: 12rem;
+}
+
+.focus\\\\:translate-y-52:focus {
+  --tw-translate-y: 13rem;
+}
+
+.focus\\\\:translate-y-56:focus {
+  --tw-translate-y: 14rem;
+}
+
+.focus\\\\:translate-y-60:focus {
+  --tw-translate-y: 15rem;
+}
+
+.focus\\\\:translate-y-64:focus {
+  --tw-translate-y: 16rem;
+}
+
+.focus\\\\:translate-y-72:focus {
+  --tw-translate-y: 18rem;
+}
+
+.focus\\\\:translate-y-80:focus {
+  --tw-translate-y: 20rem;
+}
+
+.focus\\\\:translate-y-96:focus {
+  --tw-translate-y: 24rem;
+}
+
+.focus\\\\:translate-y-px:focus {
+  --tw-translate-y: 1px;
+}
+
+.focus\\\\:translate-y-0\\\\.5:focus {
+  --tw-translate-y: 0.125rem;
+}
+
+.focus\\\\:translate-y-1\\\\.5:focus {
+  --tw-translate-y: 0.375rem;
+}
+
+.focus\\\\:translate-y-2\\\\.5:focus {
+  --tw-translate-y: 0.625rem;
+}
+
+.focus\\\\:translate-y-3\\\\.5:focus {
+  --tw-translate-y: 0.875rem;
+}
+
+.focus\\\\:-translate-y-0:focus {
+  --tw-translate-y: 0px;
+}
+
+.focus\\\\:-translate-y-1:focus {
+  --tw-translate-y: -0.25rem;
+}
+
+.focus\\\\:-translate-y-2:focus {
+  --tw-translate-y: -0.5rem;
+}
+
+.focus\\\\:-translate-y-3:focus {
+  --tw-translate-y: -0.75rem;
+}
+
+.focus\\\\:-translate-y-4:focus {
+  --tw-translate-y: -1rem;
+}
+
+.focus\\\\:-translate-y-5:focus {
+  --tw-translate-y: -1.25rem;
+}
+
+.focus\\\\:-translate-y-6:focus {
+  --tw-translate-y: -1.5rem;
+}
+
+.focus\\\\:-translate-y-7:focus {
+  --tw-translate-y: -1.75rem;
+}
+
+.focus\\\\:-translate-y-8:focus {
+  --tw-translate-y: -2rem;
+}
+
+.focus\\\\:-translate-y-9:focus {
+  --tw-translate-y: -2.25rem;
+}
+
+.focus\\\\:-translate-y-10:focus {
+  --tw-translate-y: -2.5rem;
+}
+
+.focus\\\\:-translate-y-11:focus {
+  --tw-translate-y: -2.75rem;
+}
+
+.focus\\\\:-translate-y-12:focus {
+  --tw-translate-y: -3rem;
+}
+
+.focus\\\\:-translate-y-14:focus {
+  --tw-translate-y: -3.5rem;
+}
+
+.focus\\\\:-translate-y-16:focus {
+  --tw-translate-y: -4rem;
+}
+
+.focus\\\\:-translate-y-20:focus {
+  --tw-translate-y: -5rem;
+}
+
+.focus\\\\:-translate-y-24:focus {
+  --tw-translate-y: -6rem;
+}
+
+.focus\\\\:-translate-y-28:focus {
+  --tw-translate-y: -7rem;
+}
+
+.focus\\\\:-translate-y-32:focus {
+  --tw-translate-y: -8rem;
+}
+
+.focus\\\\:-translate-y-36:focus {
+  --tw-translate-y: -9rem;
+}
+
+.focus\\\\:-translate-y-40:focus {
+  --tw-translate-y: -10rem;
+}
+
+.focus\\\\:-translate-y-44:focus {
+  --tw-translate-y: -11rem;
+}
+
+.focus\\\\:-translate-y-48:focus {
+  --tw-translate-y: -12rem;
+}
+
+.focus\\\\:-translate-y-52:focus {
+  --tw-translate-y: -13rem;
+}
+
+.focus\\\\:-translate-y-56:focus {
+  --tw-translate-y: -14rem;
+}
+
+.focus\\\\:-translate-y-60:focus {
+  --tw-translate-y: -15rem;
+}
+
+.focus\\\\:-translate-y-64:focus {
+  --tw-translate-y: -16rem;
+}
+
+.focus\\\\:-translate-y-72:focus {
+  --tw-translate-y: -18rem;
+}
+
+.focus\\\\:-translate-y-80:focus {
+  --tw-translate-y: -20rem;
+}
+
+.focus\\\\:-translate-y-96:focus {
+  --tw-translate-y: -24rem;
+}
+
+.focus\\\\:-translate-y-px:focus {
+  --tw-translate-y: -1px;
+}
+
+.focus\\\\:-translate-y-0\\\\.5:focus {
+  --tw-translate-y: -0.125rem;
+}
+
+.focus\\\\:-translate-y-1\\\\.5:focus {
+  --tw-translate-y: -0.375rem;
+}
+
+.focus\\\\:-translate-y-2\\\\.5:focus {
+  --tw-translate-y: -0.625rem;
+}
+
+.focus\\\\:-translate-y-3\\\\.5:focus {
+  --tw-translate-y: -0.875rem;
+}
+
+.focus\\\\:translate-y-1\\\\/2:focus {
+  --tw-translate-y: 50%;
+}
+
+.focus\\\\:translate-y-1\\\\/3:focus {
+  --tw-translate-y: 33.333333%;
+}
+
+.focus\\\\:translate-y-2\\\\/3:focus {
+  --tw-translate-y: 66.666667%;
+}
+
+.focus\\\\:translate-y-1\\\\/4:focus {
+  --tw-translate-y: 25%;
+}
+
+.focus\\\\:translate-y-2\\\\/4:focus {
+  --tw-translate-y: 50%;
+}
+
+.focus\\\\:translate-y-3\\\\/4:focus {
+  --tw-translate-y: 75%;
+}
+
+.focus\\\\:translate-y-full:focus {
+  --tw-translate-y: 100%;
+}
+
+.focus\\\\:-translate-y-1\\\\/2:focus {
+  --tw-translate-y: -50%;
+}
+
+.focus\\\\:-translate-y-1\\\\/3:focus {
+  --tw-translate-y: -33.333333%;
+}
+
+.focus\\\\:-translate-y-2\\\\/3:focus {
+  --tw-translate-y: -66.666667%;
+}
+
+.focus\\\\:-translate-y-1\\\\/4:focus {
+  --tw-translate-y: -25%;
+}
+
+.focus\\\\:-translate-y-2\\\\/4:focus {
+  --tw-translate-y: -50%;
+}
+
+.focus\\\\:-translate-y-3\\\\/4:focus {
+  --tw-translate-y: -75%;
+}
+
+.focus\\\\:-translate-y-full:focus {
+  --tw-translate-y: -100%;
+}
+
+.rotate-0 {
+  --tw-rotate: 0deg;
+}
+
+.rotate-1 {
+  --tw-rotate: 1deg;
+}
+
+.rotate-2 {
+  --tw-rotate: 2deg;
+}
+
+.rotate-3 {
+  --tw-rotate: 3deg;
+}
+
+.rotate-6 {
+  --tw-rotate: 6deg;
+}
+
+.rotate-12 {
+  --tw-rotate: 12deg;
+}
+
+.rotate-45 {
+  --tw-rotate: 45deg;
+}
+
+.rotate-90 {
+  --tw-rotate: 90deg;
+}
+
+.rotate-180 {
+  --tw-rotate: 180deg;
+}
+
+.-rotate-180 {
+  --tw-rotate: -180deg;
+}
+
+.-rotate-90 {
+  --tw-rotate: -90deg;
+}
+
+.-rotate-45 {
+  --tw-rotate: -45deg;
+}
+
+.-rotate-12 {
+  --tw-rotate: -12deg;
+}
+
+.-rotate-6 {
+  --tw-rotate: -6deg;
+}
+
+.-rotate-3 {
+  --tw-rotate: -3deg;
+}
+
+.-rotate-2 {
+  --tw-rotate: -2deg;
+}
+
+.-rotate-1 {
+  --tw-rotate: -1deg;
+}
+
+.-rotate-5 {
+  --tw-rotate: -5deg;
+}
+
+.active\\\\:rotate-0:active {
+  --tw-rotate: 0deg;
+}
+
+.active\\\\:rotate-1:active {
+  --tw-rotate: 1deg;
+}
+
+.active\\\\:rotate-2:active {
+  --tw-rotate: 2deg;
+}
+
+.active\\\\:rotate-3:active {
+  --tw-rotate: 3deg;
+}
+
+.active\\\\:rotate-6:active {
+  --tw-rotate: 6deg;
+}
+
+.active\\\\:rotate-12:active {
+  --tw-rotate: 12deg;
+}
+
+.active\\\\:rotate-45:active {
+  --tw-rotate: 45deg;
+}
+
+.active\\\\:rotate-90:active {
+  --tw-rotate: 90deg;
+}
+
+.active\\\\:rotate-180:active {
+  --tw-rotate: 180deg;
+}
+
+.active\\\\:-rotate-180:active {
+  --tw-rotate: -180deg;
+}
+
+.active\\\\:-rotate-90:active {
+  --tw-rotate: -90deg;
+}
+
+.active\\\\:-rotate-45:active {
+  --tw-rotate: -45deg;
+}
+
+.active\\\\:-rotate-12:active {
+  --tw-rotate: -12deg;
+}
+
+.active\\\\:-rotate-6:active {
+  --tw-rotate: -6deg;
+}
+
+.active\\\\:-rotate-3:active {
+  --tw-rotate: -3deg;
+}
+
+.active\\\\:-rotate-2:active {
+  --tw-rotate: -2deg;
+}
+
+.active\\\\:-rotate-1:active {
+  --tw-rotate: -1deg;
+}
+
+.active\\\\:-rotate-5:active {
+  --tw-rotate: -5deg;
+}
+
+.skew-x-0 {
+  --tw-skew-x: 0deg;
+}
+
+.skew-x-1 {
+  --tw-skew-x: 1deg;
+}
+
+.skew-x-2 {
+  --tw-skew-x: 2deg;
+}
+
+.skew-x-3 {
+  --tw-skew-x: 3deg;
+}
+
+.skew-x-6 {
+  --tw-skew-x: 6deg;
+}
+
+.skew-x-12 {
+  --tw-skew-x: 12deg;
+}
+
+.-skew-x-12 {
+  --tw-skew-x: -12deg;
+}
+
+.-skew-x-6 {
+  --tw-skew-x: -6deg;
+}
+
+.-skew-x-3 {
+  --tw-skew-x: -3deg;
+}
+
+.-skew-x-2 {
+  --tw-skew-x: -2deg;
+}
+
+.-skew-x-1 {
+  --tw-skew-x: -1deg;
+}
+
+.skew-y-0 {
+  --tw-skew-y: 0deg;
+}
+
+.skew-y-1 {
+  --tw-skew-y: 1deg;
+}
+
+.skew-y-2 {
+  --tw-skew-y: 2deg;
+}
+
+.skew-y-3 {
+  --tw-skew-y: 3deg;
+}
+
+.skew-y-6 {
+  --tw-skew-y: 6deg;
+}
+
+.skew-y-12 {
+  --tw-skew-y: 12deg;
+}
+
+.-skew-y-12 {
+  --tw-skew-y: -12deg;
+}
+
+.-skew-y-6 {
+  --tw-skew-y: -6deg;
+}
+
+.-skew-y-3 {
+  --tw-skew-y: -3deg;
+}
+
+.-skew-y-2 {
+  --tw-skew-y: -2deg;
+}
+
+.-skew-y-1 {
+  --tw-skew-y: -1deg;
+}
+
+.hover\\\\:skew-x-0:hover {
+  --tw-skew-x: 0deg;
+}
+
+.hover\\\\:skew-x-1:hover {
+  --tw-skew-x: 1deg;
+}
+
+.hover\\\\:skew-x-2:hover {
+  --tw-skew-x: 2deg;
+}
+
+.hover\\\\:skew-x-3:hover {
+  --tw-skew-x: 3deg;
+}
+
+.hover\\\\:skew-x-6:hover {
+  --tw-skew-x: 6deg;
+}
+
+.hover\\\\:skew-x-12:hover {
+  --tw-skew-x: 12deg;
+}
+
+.hover\\\\:-skew-x-12:hover {
+  --tw-skew-x: -12deg;
+}
+
+.hover\\\\:-skew-x-6:hover {
+  --tw-skew-x: -6deg;
+}
+
+.hover\\\\:-skew-x-3:hover {
+  --tw-skew-x: -3deg;
+}
+
+.hover\\\\:-skew-x-2:hover {
+  --tw-skew-x: -2deg;
+}
+
+.hover\\\\:-skew-x-1:hover {
+  --tw-skew-x: -1deg;
+}
+
+.hover\\\\:skew-y-0:hover {
+  --tw-skew-y: 0deg;
+}
+
+.hover\\\\:skew-y-1:hover {
+  --tw-skew-y: 1deg;
+}
+
+.hover\\\\:skew-y-2:hover {
+  --tw-skew-y: 2deg;
+}
+
+.hover\\\\:skew-y-3:hover {
+  --tw-skew-y: 3deg;
+}
+
+.hover\\\\:skew-y-6:hover {
+  --tw-skew-y: 6deg;
+}
+
+.hover\\\\:skew-y-12:hover {
+  --tw-skew-y: 12deg;
+}
+
+.hover\\\\:-skew-y-12:hover {
+  --tw-skew-y: -12deg;
+}
+
+.hover\\\\:-skew-y-6:hover {
+  --tw-skew-y: -6deg;
+}
+
+.hover\\\\:-skew-y-3:hover {
+  --tw-skew-y: -3deg;
+}
+
+.hover\\\\:-skew-y-2:hover {
+  --tw-skew-y: -2deg;
+}
+
+.hover\\\\:-skew-y-1:hover {
+  --tw-skew-y: -1deg;
+}
+
+.focus\\\\:skew-x-0:focus {
+  --tw-skew-x: 0deg;
+}
+
+.focus\\\\:skew-x-1:focus {
+  --tw-skew-x: 1deg;
+}
+
+.focus\\\\:skew-x-2:focus {
+  --tw-skew-x: 2deg;
+}
+
+.focus\\\\:skew-x-3:focus {
+  --tw-skew-x: 3deg;
+}
+
+.focus\\\\:skew-x-6:focus {
+  --tw-skew-x: 6deg;
+}
+
+.focus\\\\:skew-x-12:focus {
+  --tw-skew-x: 12deg;
+}
+
+.focus\\\\:-skew-x-12:focus {
+  --tw-skew-x: -12deg;
+}
+
+.focus\\\\:-skew-x-6:focus {
+  --tw-skew-x: -6deg;
+}
+
+.focus\\\\:-skew-x-3:focus {
+  --tw-skew-x: -3deg;
+}
+
+.focus\\\\:-skew-x-2:focus {
+  --tw-skew-x: -2deg;
+}
+
+.focus\\\\:-skew-x-1:focus {
+  --tw-skew-x: -1deg;
+}
+
+.focus\\\\:skew-y-0:focus {
+  --tw-skew-y: 0deg;
+}
+
+.focus\\\\:skew-y-1:focus {
+  --tw-skew-y: 1deg;
+}
+
+.focus\\\\:skew-y-2:focus {
+  --tw-skew-y: 2deg;
+}
+
+.focus\\\\:skew-y-3:focus {
+  --tw-skew-y: 3deg;
+}
+
+.focus\\\\:skew-y-6:focus {
+  --tw-skew-y: 6deg;
+}
+
+.focus\\\\:skew-y-12:focus {
+  --tw-skew-y: 12deg;
+}
+
+.focus\\\\:-skew-y-12:focus {
+  --tw-skew-y: -12deg;
+}
+
+.focus\\\\:-skew-y-6:focus {
+  --tw-skew-y: -6deg;
+}
+
+.focus\\\\:-skew-y-3:focus {
+  --tw-skew-y: -3deg;
+}
+
+.focus\\\\:-skew-y-2:focus {
+  --tw-skew-y: -2deg;
+}
+
+.focus\\\\:-skew-y-1:focus {
+  --tw-skew-y: -1deg;
+}
+
+.scale-0 {
+  --tw-scale-x: 0;
+  --tw-scale-y: 0;
+}
+
+.scale-50 {
+  --tw-scale-x: .5;
+  --tw-scale-y: .5;
+}
+
+.scale-75 {
+  --tw-scale-x: .75;
+  --tw-scale-y: .75;
+}
+
+.scale-90 {
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+}
+
+.scale-95 {
+  --tw-scale-x: .95;
+  --tw-scale-y: .95;
+}
+
+.scale-100 {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+}
+
+.scale-105 {
+  --tw-scale-x: 1.05;
+  --tw-scale-y: 1.05;
+}
+
+.scale-110 {
+  --tw-scale-x: 1.1;
+  --tw-scale-y: 1.1;
+}
+
+.scale-125 {
+  --tw-scale-x: 1.25;
+  --tw-scale-y: 1.25;
+}
+
+.scale-150 {
+  --tw-scale-x: 1.5;
+  --tw-scale-y: 1.5;
+}
+
+.hover\\\\:scale-0:hover {
+  --tw-scale-x: 0;
+  --tw-scale-y: 0;
+}
+
+.hover\\\\:scale-50:hover {
+  --tw-scale-x: .5;
+  --tw-scale-y: .5;
+}
+
+.hover\\\\:scale-75:hover {
+  --tw-scale-x: .75;
+  --tw-scale-y: .75;
+}
+
+.hover\\\\:scale-90:hover {
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+}
+
+.hover\\\\:scale-95:hover {
+  --tw-scale-x: .95;
+  --tw-scale-y: .95;
+}
+
+.hover\\\\:scale-100:hover {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+}
+
+.hover\\\\:scale-105:hover {
+  --tw-scale-x: 1.05;
+  --tw-scale-y: 1.05;
+}
+
+.hover\\\\:scale-110:hover {
+  --tw-scale-x: 1.1;
+  --tw-scale-y: 1.1;
+}
+
+.hover\\\\:scale-125:hover {
+  --tw-scale-x: 1.25;
+  --tw-scale-y: 1.25;
+}
+
+.hover\\\\:scale-150:hover {
+  --tw-scale-x: 1.5;
+  --tw-scale-y: 1.5;
+}
+
+.focus\\\\:scale-0:focus {
+  --tw-scale-x: 0;
+  --tw-scale-y: 0;
+}
+
+.focus\\\\:scale-50:focus {
+  --tw-scale-x: .5;
+  --tw-scale-y: .5;
+}
+
+.focus\\\\:scale-75:focus {
+  --tw-scale-x: .75;
+  --tw-scale-y: .75;
+}
+
+.focus\\\\:scale-90:focus {
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+}
+
+.focus\\\\:scale-95:focus {
+  --tw-scale-x: .95;
+  --tw-scale-y: .95;
+}
+
+.focus\\\\:scale-100:focus {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+}
+
+.focus\\\\:scale-105:focus {
+  --tw-scale-x: 1.05;
+  --tw-scale-y: 1.05;
+}
+
+.focus\\\\:scale-110:focus {
+  --tw-scale-x: 1.1;
+  --tw-scale-y: 1.1;
+}
+
+.focus\\\\:scale-125:focus {
+  --tw-scale-x: 1.25;
+  --tw-scale-y: 1.25;
+}
+
+.focus\\\\:scale-150:focus {
+  --tw-scale-x: 1.5;
+  --tw-scale-y: 1.5;
+}
+
+.active\\\\:scale-0:active {
+  --tw-scale-x: 0;
+  --tw-scale-y: 0;
+}
+
+.active\\\\:scale-50:active {
+  --tw-scale-x: .5;
+  --tw-scale-y: .5;
+}
+
+.active\\\\:scale-75:active {
+  --tw-scale-x: .75;
+  --tw-scale-y: .75;
+}
+
+.active\\\\:scale-90:active {
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+}
+
+.active\\\\:scale-95:active {
+  --tw-scale-x: .95;
+  --tw-scale-y: .95;
+}
+
+.active\\\\:scale-100:active {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+}
+
+.active\\\\:scale-105:active {
+  --tw-scale-x: 1.05;
+  --tw-scale-y: 1.05;
+}
+
+.active\\\\:scale-110:active {
+  --tw-scale-x: 1.1;
+  --tw-scale-y: 1.1;
+}
+
+.active\\\\:scale-125:active {
+  --tw-scale-x: 1.25;
+  --tw-scale-y: 1.25;
+}
+
+.active\\\\:scale-150:active {
+  --tw-scale-x: 1.5;
+  --tw-scale-y: 1.5;
+}
+
+.scale-x-0 {
+  --tw-scale-x: 0;
+}
+
+.scale-x-50 {
+  --tw-scale-x: .5;
+}
+
+.scale-x-75 {
+  --tw-scale-x: .75;
+}
+
+.scale-x-90 {
+  --tw-scale-x: .9;
+}
+
+.scale-x-95 {
+  --tw-scale-x: .95;
+}
+
+.scale-x-100 {
+  --tw-scale-x: 1;
+}
+
+.scale-x-105 {
+  --tw-scale-x: 1.05;
+}
+
+.scale-x-110 {
+  --tw-scale-x: 1.1;
+}
+
+.scale-x-125 {
+  --tw-scale-x: 1.25;
+}
+
+.scale-x-150 {
+  --tw-scale-x: 1.5;
+}
+
+.scale-y-0 {
+  --tw-scale-y: 0;
+}
+
+.scale-y-50 {
+  --tw-scale-y: .5;
+}
+
+.scale-y-75 {
+  --tw-scale-y: .75;
+}
+
+.scale-y-90 {
+  --tw-scale-y: .9;
+}
+
+.scale-y-95 {
+  --tw-scale-y: .95;
+}
+
+.scale-y-100 {
+  --tw-scale-y: 1;
+}
+
+.scale-y-105 {
+  --tw-scale-y: 1.05;
+}
+
+.scale-y-110 {
+  --tw-scale-y: 1.1;
+}
+
+.scale-y-125 {
+  --tw-scale-y: 1.25;
+}
+
+.scale-y-150 {
+  --tw-scale-y: 1.5;
+}
+
+.hover\\\\:scale-x-0:hover {
+  --tw-scale-x: 0;
+}
+
+.hover\\\\:scale-x-50:hover {
+  --tw-scale-x: .5;
+}
+
+.hover\\\\:scale-x-75:hover {
+  --tw-scale-x: .75;
+}
+
+.hover\\\\:scale-x-90:hover {
+  --tw-scale-x: .9;
+}
+
+.hover\\\\:scale-x-95:hover {
+  --tw-scale-x: .95;
+}
+
+.hover\\\\:scale-x-100:hover {
+  --tw-scale-x: 1;
+}
+
+.hover\\\\:scale-x-105:hover {
+  --tw-scale-x: 1.05;
+}
+
+.hover\\\\:scale-x-110:hover {
+  --tw-scale-x: 1.1;
+}
+
+.hover\\\\:scale-x-125:hover {
+  --tw-scale-x: 1.25;
+}
+
+.hover\\\\:scale-x-150:hover {
+  --tw-scale-x: 1.5;
+}
+
+.hover\\\\:scale-y-0:hover {
+  --tw-scale-y: 0;
+}
+
+.hover\\\\:scale-y-50:hover {
+  --tw-scale-y: .5;
+}
+
+.hover\\\\:scale-y-75:hover {
+  --tw-scale-y: .75;
+}
+
+.hover\\\\:scale-y-90:hover {
+  --tw-scale-y: .9;
+}
+
+.hover\\\\:scale-y-95:hover {
+  --tw-scale-y: .95;
+}
+
+.hover\\\\:scale-y-100:hover {
+  --tw-scale-y: 1;
+}
+
+.hover\\\\:scale-y-105:hover {
+  --tw-scale-y: 1.05;
+}
+
+.hover\\\\:scale-y-110:hover {
+  --tw-scale-y: 1.1;
+}
+
+.hover\\\\:scale-y-125:hover {
+  --tw-scale-y: 1.25;
+}
+
+.hover\\\\:scale-y-150:hover {
+  --tw-scale-y: 1.5;
+}
+
+.focus\\\\:scale-x-0:focus {
+  --tw-scale-x: 0;
+}
+
+.focus\\\\:scale-x-50:focus {
+  --tw-scale-x: .5;
+}
+
+.focus\\\\:scale-x-75:focus {
+  --tw-scale-x: .75;
+}
+
+.focus\\\\:scale-x-90:focus {
+  --tw-scale-x: .9;
+}
+
+.focus\\\\:scale-x-95:focus {
+  --tw-scale-x: .95;
+}
+
+.focus\\\\:scale-x-100:focus {
+  --tw-scale-x: 1;
+}
+
+.focus\\\\:scale-x-105:focus {
+  --tw-scale-x: 1.05;
+}
+
+.focus\\\\:scale-x-110:focus {
+  --tw-scale-x: 1.1;
+}
+
+.focus\\\\:scale-x-125:focus {
+  --tw-scale-x: 1.25;
+}
+
+.focus\\\\:scale-x-150:focus {
+  --tw-scale-x: 1.5;
+}
+
+.focus\\\\:scale-y-0:focus {
+  --tw-scale-y: 0;
+}
+
+.focus\\\\:scale-y-50:focus {
+  --tw-scale-y: .5;
+}
+
+.focus\\\\:scale-y-75:focus {
+  --tw-scale-y: .75;
+}
+
+.focus\\\\:scale-y-90:focus {
+  --tw-scale-y: .9;
+}
+
+.focus\\\\:scale-y-95:focus {
+  --tw-scale-y: .95;
+}
+
+.focus\\\\:scale-y-100:focus {
+  --tw-scale-y: 1;
+}
+
+.focus\\\\:scale-y-105:focus {
+  --tw-scale-y: 1.05;
+}
+
+.focus\\\\:scale-y-110:focus {
+  --tw-scale-y: 1.1;
+}
+
+.focus\\\\:scale-y-125:focus {
+  --tw-scale-y: 1.25;
+}
+
+.focus\\\\:scale-y-150:focus {
+  --tw-scale-y: 1.5;
+}
+
+.active\\\\:scale-x-0:active {
+  --tw-scale-x: 0;
+}
+
+.active\\\\:scale-x-50:active {
+  --tw-scale-x: .5;
+}
+
+.active\\\\:scale-x-75:active {
+  --tw-scale-x: .75;
+}
+
+.active\\\\:scale-x-90:active {
+  --tw-scale-x: .9;
+}
+
+.active\\\\:scale-x-95:active {
+  --tw-scale-x: .95;
+}
+
+.active\\\\:scale-x-100:active {
+  --tw-scale-x: 1;
+}
+
+.active\\\\:scale-x-105:active {
+  --tw-scale-x: 1.05;
+}
+
+.active\\\\:scale-x-110:active {
+  --tw-scale-x: 1.1;
+}
+
+.active\\\\:scale-x-125:active {
+  --tw-scale-x: 1.25;
+}
+
+.active\\\\:scale-x-150:active {
+  --tw-scale-x: 1.5;
+}
+
+.active\\\\:scale-y-0:active {
+  --tw-scale-y: 0;
+}
+
+.active\\\\:scale-y-50:active {
+  --tw-scale-y: .5;
+}
+
+.active\\\\:scale-y-75:active {
+  --tw-scale-y: .75;
+}
+
+.active\\\\:scale-y-90:active {
+  --tw-scale-y: .9;
+}
+
+.active\\\\:scale-y-95:active {
+  --tw-scale-y: .95;
+}
+
+.active\\\\:scale-y-100:active {
+  --tw-scale-y: 1;
+}
+
+.active\\\\:scale-y-105:active {
+  --tw-scale-y: 1.05;
+}
+
+.active\\\\:scale-y-110:active {
+  --tw-scale-y: 1.1;
+}
+
+.active\\\\:scale-y-125:active {
+  --tw-scale-y: 1.25;
+}
+
+.active\\\\:scale-y-150:active {
+  --tw-scale-y: 1.5;
+}
+
+@-webkit-keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@-webkit-keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@-webkit-keyframes pulse {
+  50% {
+    opacity: .5;
+  }
+}
+
+@keyframes pulse {
+  50% {
+    opacity: .5;
+  }
+}
+
+@-webkit-keyframes bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8,0,1,1);
+            animation-timing-function: cubic-bezier(0.8,0,1,1);
+  }
+
+  50% {
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0,0,0.2,1);
+            animation-timing-function: cubic-bezier(0,0,0.2,1);
+  }
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8,0,1,1);
+            animation-timing-function: cubic-bezier(0.8,0,1,1);
+  }
+
+  50% {
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0,0,0.2,1);
+            animation-timing-function: cubic-bezier(0,0,0.2,1);
+  }
+}
+
+@-webkit-keyframes fade-in {
+  0% {
+    opacity: 0%;
+  }
+
+  100% {
+    opacity: 100%;
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0%;
+  }
+
+  100% {
+    opacity: 100%;
+  }
+}
+
+.animate-none {
+  -webkit-animation: none;
+          animation: none;
+}
+
+.animate-spin {
+  -webkit-animation: spin 1s linear infinite;
+          animation: spin 1s linear infinite;
+}
+
+.animate-ping {
+  -webkit-animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+          animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+.animate-pulse {
+  -webkit-animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+          animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.animate-bounce {
+  -webkit-animation: bounce 1s infinite;
+          animation: bounce 1s infinite;
+}
+
+.animate-fade-in {
+  -webkit-animation: fade-in .25s linear;
+          animation: fade-in .25s linear;
+}
+
+.cursor-auto {
+  cursor: auto;
+}
+
+.cursor-default {
+  cursor: default;
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.cursor-wait {
+  cursor: wait;
+}
+
+.cursor-text {
+  cursor: text;
+}
+
+.cursor-move {
+  cursor: move;
+}
+
+.cursor-help {
+  cursor: help;
+}
+
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
+
+.cursor-col-resize {
+  cursor: col-resize;
+}
+
+.disabled\\\\:cursor-auto:disabled {
+  cursor: auto;
+}
+
+.disabled\\\\:cursor-default:disabled {
+  cursor: default;
+}
+
+.disabled\\\\:cursor-pointer:disabled {
+  cursor: pointer;
+}
+
+.disabled\\\\:cursor-wait:disabled {
+  cursor: wait;
+}
+
+.disabled\\\\:cursor-text:disabled {
+  cursor: text;
+}
+
+.disabled\\\\:cursor-move:disabled {
+  cursor: move;
+}
+
+.disabled\\\\:cursor-help:disabled {
+  cursor: help;
+}
+
+.disabled\\\\:cursor-not-allowed:disabled {
+  cursor: not-allowed;
+}
+
+.disabled\\\\:cursor-col-resize:disabled {
+  cursor: col-resize;
+}
+
+.select-none {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+
+.select-text {
+  -webkit-user-select: text;
+     -moz-user-select: text;
+      -ms-user-select: text;
+          user-select: text;
+}
+
+.select-all {
+  -webkit-user-select: all;
+     -moz-user-select: all;
+          user-select: all;
+}
+
+.select-auto {
+  -webkit-user-select: auto;
+     -moz-user-select: auto;
+      -ms-user-select: auto;
+          user-select: auto;
+}
+
+.resize-none {
+  resize: none;
+}
+
+.resize-y {
+  resize: vertical;
+}
+
+.resize-x {
+  resize: horizontal;
+}
+
+.resize {
+  resize: both;
+}
+
+.list-inside {
+  list-style-position: inside;
+}
+
+.list-outside {
+  list-style-position: outside;
+}
+
+.list-none {
+  list-style-type: none;
+}
+
+.list-disc {
+  list-style-type: disc;
+}
+
+.list-decimal {
+  list-style-type: decimal;
+}
+
+.appearance-none {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+}
+
+.auto-cols-auto {
+  grid-auto-columns: auto;
+}
+
+.auto-cols-min {
+  grid-auto-columns: -webkit-min-content;
+  grid-auto-columns: min-content;
+}
+
+.auto-cols-max {
+  grid-auto-columns: -webkit-max-content;
+  grid-auto-columns: max-content;
+}
+
+.auto-cols-fr {
+  grid-auto-columns: minmax(0, 1fr);
+}
+
+.grid-flow-row {
+  grid-auto-flow: row;
+}
+
+.grid-flow-col {
+  grid-auto-flow: column;
+}
+
+.grid-flow-row-dense {
+  grid-auto-flow: row dense;
+}
+
+.grid-flow-col-dense {
+  grid-auto-flow: column dense;
+}
+
+.auto-rows-auto {
+  grid-auto-rows: auto;
+}
+
+.auto-rows-min {
+  grid-auto-rows: -webkit-min-content;
+  grid-auto-rows: min-content;
+}
+
+.auto-rows-max {
+  grid-auto-rows: -webkit-max-content;
+  grid-auto-rows: max-content;
+}
+
+.auto-rows-fr {
+  grid-auto-rows: minmax(0, 1fr);
+}
+
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid-cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.grid-cols-5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.grid-cols-6 {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.grid-cols-7 {
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.grid-cols-8 {
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+}
+
+.grid-cols-9 {
+  grid-template-columns: repeat(9, minmax(0, 1fr));
+}
+
+.grid-cols-10 {
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+}
+
+.grid-cols-11 {
+  grid-template-columns: repeat(11, minmax(0, 1fr));
+}
+
+.grid-cols-12 {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+
+.grid-cols-none {
+  grid-template-columns: none;
+}
+
+.grid-cols-centered-2\\\\/3 {
+  grid-template-columns: 2fr 8fr 2fr;
+}
+
+.grid-cols-auto-2 {
+  grid-template-columns: auto auto;
+}
+
+.grid-cols-max-content-4 {
+  grid-template-columns: repeat(4, minmax(-webkit-max-content, 1fr));
+  grid-template-columns: repeat(4, minmax(max-content, 1fr));
+}
+
+.grid-cols-max-content-6 {
+  grid-template-columns: repeat(6, minmax(-webkit-max-content, 1fr));
+  grid-template-columns: repeat(6, minmax(max-content, 1fr));
+}
+
+.grid-rows-1 {
+  grid-template-rows: repeat(1, minmax(0, 1fr));
+}
+
+.grid-rows-2 {
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+}
+
+.grid-rows-3 {
+  grid-template-rows: repeat(3, minmax(0, 1fr));
+}
+
+.grid-rows-4 {
+  grid-template-rows: repeat(4, minmax(0, 1fr));
+}
+
+.grid-rows-5 {
+  grid-template-rows: repeat(5, minmax(0, 1fr));
+}
+
+.grid-rows-6 {
+  grid-template-rows: repeat(6, minmax(0, 1fr));
+}
+
+.grid-rows-none {
+  grid-template-rows: none;
+}
+
+.flex-row {
+  flex-direction: row;
+}
+
+.flex-row-reverse {
+  flex-direction: row-reverse;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.flex-col-reverse {
+  flex-direction: column-reverse;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.flex-wrap-reverse {
+  flex-wrap: wrap-reverse;
+}
+
+.flex-nowrap {
+  flex-wrap: nowrap;
+}
+
+.place-content-center {
+  place-content: center;
+}
+
+.place-content-start {
+  place-content: start;
+}
+
+.place-content-end {
+  place-content: end;
+}
+
+.place-content-between {
+  place-content: space-between;
+}
+
+.place-content-around {
+  place-content: space-around;
+}
+
+.place-content-evenly {
+  place-content: space-evenly;
+}
+
+.place-content-stretch {
+  place-content: stretch;
+}
+
+.place-items-start {
+  place-items: start;
+}
+
+.place-items-end {
+  place-items: end;
+}
+
+.place-items-center {
+  place-items: center;
+}
+
+.place-items-stretch {
+  place-items: stretch;
+}
+
+.content-center {
+  align-content: center;
+}
+
+.content-start {
+  align-content: flex-start;
+}
+
+.content-end {
+  align-content: flex-end;
+}
+
+.content-between {
+  align-content: space-between;
+}
+
+.content-around {
+  align-content: space-around;
+}
+
+.content-evenly {
+  align-content: space-evenly;
+}
+
+.items-start {
+  align-items: flex-start;
+}
+
+.items-end {
+  align-items: flex-end;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.items-baseline {
+  align-items: baseline;
+}
+
+.items-stretch {
+  align-items: stretch;
+}
+
+.justify-start {
+  justify-content: flex-start;
+}
+
+.justify-end {
+  justify-content: flex-end;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.justify-around {
+  justify-content: space-around;
+}
+
+.justify-evenly {
+  justify-content: space-evenly;
+}
+
+.justify-items-start {
+  justify-items: start;
+}
+
+.justify-items-end {
+  justify-items: end;
+}
+
+.justify-items-center {
+  justify-items: center;
+}
+
+.justify-items-stretch {
+  justify-items: stretch;
+}
+
+.gap-0 {
+  gap: 0px;
+}
+
+.gap-1 {
+  gap: 0.25rem;
+}
+
+.gap-2 {
+  gap: 0.5rem;
+}
+
+.gap-3 {
+  gap: 0.75rem;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.gap-5 {
+  gap: 1.25rem;
+}
+
+.gap-6 {
+  gap: 1.5rem;
+}
+
+.gap-7 {
+  gap: 1.75rem;
+}
+
+.gap-8 {
+  gap: 2rem;
+}
+
+.gap-9 {
+  gap: 2.25rem;
+}
+
+.gap-10 {
+  gap: 2.5rem;
+}
+
+.gap-11 {
+  gap: 2.75rem;
+}
+
+.gap-12 {
+  gap: 3rem;
+}
+
+.gap-14 {
+  gap: 3.5rem;
+}
+
+.gap-16 {
+  gap: 4rem;
+}
+
+.gap-20 {
+  gap: 5rem;
+}
+
+.gap-24 {
+  gap: 6rem;
+}
+
+.gap-28 {
+  gap: 7rem;
+}
+
+.gap-32 {
+  gap: 8rem;
+}
+
+.gap-36 {
+  gap: 9rem;
+}
+
+.gap-40 {
+  gap: 10rem;
+}
+
+.gap-44 {
+  gap: 11rem;
+}
+
+.gap-48 {
+  gap: 12rem;
+}
+
+.gap-52 {
+  gap: 13rem;
+}
+
+.gap-56 {
+  gap: 14rem;
+}
+
+.gap-60 {
+  gap: 15rem;
+}
+
+.gap-64 {
+  gap: 16rem;
+}
+
+.gap-72 {
+  gap: 18rem;
+}
+
+.gap-80 {
+  gap: 20rem;
+}
+
+.gap-96 {
+  gap: 24rem;
+}
+
+.gap-px {
+  gap: 1px;
+}
+
+.gap-0\\\\.5 {
+  gap: 0.125rem;
+}
+
+.gap-1\\\\.5 {
+  gap: 0.375rem;
+}
+
+.gap-2\\\\.5 {
+  gap: 0.625rem;
+}
+
+.gap-3\\\\.5 {
+  gap: 0.875rem;
+}
+
+.gap-x-0 {
+  -moz-column-gap: 0px;
+       column-gap: 0px;
+}
+
+.gap-x-1 {
+  -moz-column-gap: 0.25rem;
+       column-gap: 0.25rem;
+}
+
+.gap-x-2 {
+  -moz-column-gap: 0.5rem;
+       column-gap: 0.5rem;
+}
+
+.gap-x-3 {
+  -moz-column-gap: 0.75rem;
+       column-gap: 0.75rem;
+}
+
+.gap-x-4 {
+  -moz-column-gap: 1rem;
+       column-gap: 1rem;
+}
+
+.gap-x-5 {
+  -moz-column-gap: 1.25rem;
+       column-gap: 1.25rem;
+}
+
+.gap-x-6 {
+  -moz-column-gap: 1.5rem;
+       column-gap: 1.5rem;
+}
+
+.gap-x-7 {
+  -moz-column-gap: 1.75rem;
+       column-gap: 1.75rem;
+}
+
+.gap-x-8 {
+  -moz-column-gap: 2rem;
+       column-gap: 2rem;
+}
+
+.gap-x-9 {
+  -moz-column-gap: 2.25rem;
+       column-gap: 2.25rem;
+}
+
+.gap-x-10 {
+  -moz-column-gap: 2.5rem;
+       column-gap: 2.5rem;
+}
+
+.gap-x-11 {
+  -moz-column-gap: 2.75rem;
+       column-gap: 2.75rem;
+}
+
+.gap-x-12 {
+  -moz-column-gap: 3rem;
+       column-gap: 3rem;
+}
+
+.gap-x-14 {
+  -moz-column-gap: 3.5rem;
+       column-gap: 3.5rem;
+}
+
+.gap-x-16 {
+  -moz-column-gap: 4rem;
+       column-gap: 4rem;
+}
+
+.gap-x-20 {
+  -moz-column-gap: 5rem;
+       column-gap: 5rem;
+}
+
+.gap-x-24 {
+  -moz-column-gap: 6rem;
+       column-gap: 6rem;
+}
+
+.gap-x-28 {
+  -moz-column-gap: 7rem;
+       column-gap: 7rem;
+}
+
+.gap-x-32 {
+  -moz-column-gap: 8rem;
+       column-gap: 8rem;
+}
+
+.gap-x-36 {
+  -moz-column-gap: 9rem;
+       column-gap: 9rem;
+}
+
+.gap-x-40 {
+  -moz-column-gap: 10rem;
+       column-gap: 10rem;
+}
+
+.gap-x-44 {
+  -moz-column-gap: 11rem;
+       column-gap: 11rem;
+}
+
+.gap-x-48 {
+  -moz-column-gap: 12rem;
+       column-gap: 12rem;
+}
+
+.gap-x-52 {
+  -moz-column-gap: 13rem;
+       column-gap: 13rem;
+}
+
+.gap-x-56 {
+  -moz-column-gap: 14rem;
+       column-gap: 14rem;
+}
+
+.gap-x-60 {
+  -moz-column-gap: 15rem;
+       column-gap: 15rem;
+}
+
+.gap-x-64 {
+  -moz-column-gap: 16rem;
+       column-gap: 16rem;
+}
+
+.gap-x-72 {
+  -moz-column-gap: 18rem;
+       column-gap: 18rem;
+}
+
+.gap-x-80 {
+  -moz-column-gap: 20rem;
+       column-gap: 20rem;
+}
+
+.gap-x-96 {
+  -moz-column-gap: 24rem;
+       column-gap: 24rem;
+}
+
+.gap-x-px {
+  -moz-column-gap: 1px;
+       column-gap: 1px;
+}
+
+.gap-x-0\\\\.5 {
+  -moz-column-gap: 0.125rem;
+       column-gap: 0.125rem;
+}
+
+.gap-x-1\\\\.5 {
+  -moz-column-gap: 0.375rem;
+       column-gap: 0.375rem;
+}
+
+.gap-x-2\\\\.5 {
+  -moz-column-gap: 0.625rem;
+       column-gap: 0.625rem;
+}
+
+.gap-x-3\\\\.5 {
+  -moz-column-gap: 0.875rem;
+       column-gap: 0.875rem;
+}
+
+.gap-y-0 {
+  row-gap: 0px;
+}
+
+.gap-y-1 {
+  row-gap: 0.25rem;
+}
+
+.gap-y-2 {
+  row-gap: 0.5rem;
+}
+
+.gap-y-3 {
+  row-gap: 0.75rem;
+}
+
+.gap-y-4 {
+  row-gap: 1rem;
+}
+
+.gap-y-5 {
+  row-gap: 1.25rem;
+}
+
+.gap-y-6 {
+  row-gap: 1.5rem;
+}
+
+.gap-y-7 {
+  row-gap: 1.75rem;
+}
+
+.gap-y-8 {
+  row-gap: 2rem;
+}
+
+.gap-y-9 {
+  row-gap: 2.25rem;
+}
+
+.gap-y-10 {
+  row-gap: 2.5rem;
+}
+
+.gap-y-11 {
+  row-gap: 2.75rem;
+}
+
+.gap-y-12 {
+  row-gap: 3rem;
+}
+
+.gap-y-14 {
+  row-gap: 3.5rem;
+}
+
+.gap-y-16 {
+  row-gap: 4rem;
+}
+
+.gap-y-20 {
+  row-gap: 5rem;
+}
+
+.gap-y-24 {
+  row-gap: 6rem;
+}
+
+.gap-y-28 {
+  row-gap: 7rem;
+}
+
+.gap-y-32 {
+  row-gap: 8rem;
+}
+
+.gap-y-36 {
+  row-gap: 9rem;
+}
+
+.gap-y-40 {
+  row-gap: 10rem;
+}
+
+.gap-y-44 {
+  row-gap: 11rem;
+}
+
+.gap-y-48 {
+  row-gap: 12rem;
+}
+
+.gap-y-52 {
+  row-gap: 13rem;
+}
+
+.gap-y-56 {
+  row-gap: 14rem;
+}
+
+.gap-y-60 {
+  row-gap: 15rem;
+}
+
+.gap-y-64 {
+  row-gap: 16rem;
+}
+
+.gap-y-72 {
+  row-gap: 18rem;
+}
+
+.gap-y-80 {
+  row-gap: 20rem;
+}
+
+.gap-y-96 {
+  row-gap: 24rem;
+}
+
+.gap-y-px {
+  row-gap: 1px;
+}
+
+.gap-y-0\\\\.5 {
+  row-gap: 0.125rem;
+}
+
+.gap-y-1\\\\.5 {
+  row-gap: 0.375rem;
+}
+
+.gap-y-2\\\\.5 {
+  row-gap: 0.625rem;
+}
+
+.gap-y-3\\\\.5 {
+  row-gap: 0.875rem;
+}
+
+.space-x-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0px * var(--tw-space-x-reverse));
+  margin-left: calc(0px * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1rem * var(--tw-space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(1.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-7 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(1.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2rem * var(--tw-space-x-reverse));
+  margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-9 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(2.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-11 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(2.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-12 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(3rem * var(--tw-space-x-reverse));
+  margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-14 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(3.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(3.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-16 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(4rem * var(--tw-space-x-reverse));
+  margin-left: calc(4rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(5rem * var(--tw-space-x-reverse));
+  margin-left: calc(5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-24 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(6rem * var(--tw-space-x-reverse));
+  margin-left: calc(6rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-28 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(7rem * var(--tw-space-x-reverse));
+  margin-left: calc(7rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-32 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(8rem * var(--tw-space-x-reverse));
+  margin-left: calc(8rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-36 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(9rem * var(--tw-space-x-reverse));
+  margin-left: calc(9rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(10rem * var(--tw-space-x-reverse));
+  margin-left: calc(10rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-44 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(11rem * var(--tw-space-x-reverse));
+  margin-left: calc(11rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-48 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(12rem * var(--tw-space-x-reverse));
+  margin-left: calc(12rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-52 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(13rem * var(--tw-space-x-reverse));
+  margin-left: calc(13rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-56 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(14rem * var(--tw-space-x-reverse));
+  margin-left: calc(14rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(15rem * var(--tw-space-x-reverse));
+  margin-left: calc(15rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-64 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(16rem * var(--tw-space-x-reverse));
+  margin-left: calc(16rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-72 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(18rem * var(--tw-space-x-reverse));
+  margin-left: calc(18rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(20rem * var(--tw-space-x-reverse));
+  margin-left: calc(20rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-96 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(24rem * var(--tw-space-x-reverse));
+  margin-left: calc(24rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-px > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1px * var(--tw-space-x-reverse));
+  margin-left: calc(1px * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.125rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.125rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-1\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.375rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.375rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-2\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.625rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.625rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-3\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.875rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.875rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0px * var(--tw-space-x-reverse));
+  margin-left: calc(0px * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-7 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-9 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-11 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-12 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-3rem * var(--tw-space-x-reverse));
+  margin-left: calc(-3rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-14 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-3.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-3.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-16 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-4rem * var(--tw-space-x-reverse));
+  margin-left: calc(-4rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-24 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-6rem * var(--tw-space-x-reverse));
+  margin-left: calc(-6rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-28 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-7rem * var(--tw-space-x-reverse));
+  margin-left: calc(-7rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-32 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-8rem * var(--tw-space-x-reverse));
+  margin-left: calc(-8rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-36 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-9rem * var(--tw-space-x-reverse));
+  margin-left: calc(-9rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-10rem * var(--tw-space-x-reverse));
+  margin-left: calc(-10rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-44 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-11rem * var(--tw-space-x-reverse));
+  margin-left: calc(-11rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-48 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-12rem * var(--tw-space-x-reverse));
+  margin-left: calc(-12rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-52 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-13rem * var(--tw-space-x-reverse));
+  margin-left: calc(-13rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-56 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-14rem * var(--tw-space-x-reverse));
+  margin-left: calc(-14rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-15rem * var(--tw-space-x-reverse));
+  margin-left: calc(-15rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-64 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-16rem * var(--tw-space-x-reverse));
+  margin-left: calc(-16rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-72 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-18rem * var(--tw-space-x-reverse));
+  margin-left: calc(-18rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-20rem * var(--tw-space-x-reverse));
+  margin-left: calc(-20rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-96 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-24rem * var(--tw-space-x-reverse));
+  margin-left: calc(-24rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-px > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1px * var(--tw-space-x-reverse));
+  margin-left: calc(-1px * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.125rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.125rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-1\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.375rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.375rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-2\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.625rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.625rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-x-3\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.875rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.875rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0px * var(--tw-space-y-reverse));
+}
+
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
+}
+
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.75rem * var(--tw-space-y-reverse));
+}
+
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+
+.space-y-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.25rem * var(--tw-space-y-reverse));
+}
+
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-7 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.75rem * var(--tw-space-y-reverse));
+}
+
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+}
+
+.space-y-9 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2.25rem * var(--tw-space-y-reverse));
+}
+
+.space-y-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-11 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2.75rem * var(--tw-space-y-reverse));
+}
+
+.space-y-12 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(3rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(3rem * var(--tw-space-y-reverse));
+}
+
+.space-y-14 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(3.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(3.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-16 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(4rem * var(--tw-space-y-reverse));
+}
+
+.space-y-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-24 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(6rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(6rem * var(--tw-space-y-reverse));
+}
+
+.space-y-28 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(7rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(7rem * var(--tw-space-y-reverse));
+}
+
+.space-y-32 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(8rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(8rem * var(--tw-space-y-reverse));
+}
+
+.space-y-36 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(9rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(9rem * var(--tw-space-y-reverse));
+}
+
+.space-y-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(10rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(10rem * var(--tw-space-y-reverse));
+}
+
+.space-y-44 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(11rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(11rem * var(--tw-space-y-reverse));
+}
+
+.space-y-48 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(12rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(12rem * var(--tw-space-y-reverse));
+}
+
+.space-y-52 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(13rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(13rem * var(--tw-space-y-reverse));
+}
+
+.space-y-56 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(14rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(14rem * var(--tw-space-y-reverse));
+}
+
+.space-y-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(15rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(15rem * var(--tw-space-y-reverse));
+}
+
+.space-y-64 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(16rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(16rem * var(--tw-space-y-reverse));
+}
+
+.space-y-72 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(18rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(18rem * var(--tw-space-y-reverse));
+}
+
+.space-y-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(20rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(20rem * var(--tw-space-y-reverse));
+}
+
+.space-y-96 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(24rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(24rem * var(--tw-space-y-reverse));
+}
+
+.space-y-px > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1px * var(--tw-space-y-reverse));
+}
+
+.space-y-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.125rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.125rem * var(--tw-space-y-reverse));
+}
+
+.space-y-1\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.375rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.375rem * var(--tw-space-y-reverse));
+}
+
+.space-y-2\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.625rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.625rem * var(--tw-space-y-reverse));
+}
+
+.space-y-3\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.875rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.875rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0px * var(--tw-space-y-reverse));
+}
+
+.-space-y-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.25rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.75rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1.25rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-7 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1.75rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-9 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2.25rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-11 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2.75rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-12 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-3rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-3rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-14 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-3.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-3.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-16 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-4rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-4rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-5rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-24 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-6rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-6rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-28 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-7rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-7rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-32 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-8rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-8rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-36 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-9rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-9rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-10rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-10rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-44 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-11rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-11rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-48 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-12rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-12rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-52 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-13rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-13rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-56 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-14rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-14rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-15rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-15rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-64 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-16rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-16rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-72 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-18rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-18rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-20rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-20rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-96 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-24rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-24rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-px > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1px * var(--tw-space-y-reverse));
+}
+
+.-space-y-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.125rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.125rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-1\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.375rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.375rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-2\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.625rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.625rem * var(--tw-space-y-reverse));
+}
+
+.-space-y-3\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.875rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.875rem * var(--tw-space-y-reverse));
+}
+
+.space-y-reverse > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 1;
+}
+
+.space-x-reverse > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 1;
+}
+
+.divide-x-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(0px * var(--tw-divide-x-reverse));
+  border-left-width: calc(0px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(2px * var(--tw-divide-x-reverse));
+  border-left-width: calc(2px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(4px * var(--tw-divide-x-reverse));
+  border-left-width: calc(4px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-x-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(8px * var(--tw-divide-x-reverse));
+  border-left-width: calc(8px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-x > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(1px * var(--tw-divide-x-reverse));
+  border-left-width: calc(1px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-y-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(0px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(0px * var(--tw-divide-y-reverse));
+}
+
+.divide-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(2px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(2px * var(--tw-divide-y-reverse));
+}
+
+.divide-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(4px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(4px * var(--tw-divide-y-reverse));
+}
+
+.divide-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(8px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(8px * var(--tw-divide-y-reverse));
+}
+
+.divide-y > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
+}
+
+.divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 1;
+}
+
+.divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 1;
+}
+
+.divide-solid > :not([hidden]) ~ :not([hidden]) {
+  border-style: solid;
+}
+
+.divide-dashed > :not([hidden]) ~ :not([hidden]) {
+  border-style: dashed;
+}
+
+.divide-dotted > :not([hidden]) ~ :not([hidden]) {
+  border-style: dotted;
+}
+
+.divide-double > :not([hidden]) ~ :not([hidden]) {
+  border-style: double;
+}
+
+.divide-none > :not([hidden]) ~ :not([hidden]) {
+  border-style: none;
+}
+
+.divide-current > :not([hidden]) ~ :not([hidden]) {
+  border-color: currentColor;
+}
+
+.divide-transparent > :not([hidden]) ~ :not([hidden]) {
+  border-color: transparent;
+}
+
+.divide-falcon > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--falcon);
+}
+
+.divide-basement > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--basement);
+}
+
+.divide-blue > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--blue);
+}
+
+.divide-body-and-labels > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--body-and-labels);
+}
+
+.divide-brand > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--brand);
+}
+
+.divide-code-base-64 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--code-base-64);
+}
+
+.divide-code-bg > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--code-bg);
+}
+
+.divide-code-outline > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--code-outline);
+}
+
+.divide-code-text > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--code-text);
+}
+
+.divide-critical > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--critical);
+}
+
+.divide-destructive-hover > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--destructive-hover);
+}
+
+.divide-destructive-idle > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--destructive-idle);
+}
+
+.divide-destructive-pressed > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--destructive-pressed);
+}
+
+.divide-disabled > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--disabled);
+}
+
+.divide-disc-operations > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--disc-operations);
+}
+
+.divide-dns-requests > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--dns-requests);
+}
+
+.divide-focus > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--focus);
+}
+
+.divide-graph-1 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-1);
+}
+
+.divide-graph-10 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-10);
+}
+
+.divide-graph-11 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-11);
+}
+
+.divide-graph-2 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-2);
+}
+
+.divide-graph-3 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-3);
+}
+
+.divide-graph-4 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-4);
+}
+
+.divide-graph-5 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-5);
+}
+
+.divide-graph-6 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-6);
+}
+
+.divide-graph-7 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-7);
+}
+
+.divide-graph-8 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-8);
+}
+
+.divide-graph-9 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-9);
+}
+
+.divide-graph-disabled > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--graph-disabled);
+}
+
+.divide-ground-floor > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--ground-floor);
+}
+
+.divide-high > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--high);
+}
+
+.divide-informational > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--informational);
+}
+
+.divide-lines-dark > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--lines-dark);
+}
+
+.divide-lines-light > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--lines-light);
+}
+
+.divide-low > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--low);
+}
+
+.divide-medium > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--medium);
+}
+
+.divide-mezzanine > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--mezzanine);
+}
+
+.divide-nav-text-and-icons > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--nav-text-and-icons);
+}
+
+.divide-nav-text-secondary > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--nav-text-secondary);
+}
+
+.divide-network-operations > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--network-operations);
+}
+
+.divide-normal-hover > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--normal-hover);
+}
+
+.divide-normal-idle > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--normal-idle);
+}
+
+.divide-normal-pressed > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--normal-pressed);
+}
+
+.divide-overlay-0\\\\.5 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--overlay-0\\\\.5);
+}
+
+.divide-overlay-1 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--overlay-1);
+}
+
+.divide-overlay-2 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--overlay-2);
+}
+
+.divide-positive > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--positive);
+}
+
+.divide-primary-hover > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--primary-hover);
+}
+
+.divide-primary-idle > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--primary-idle);
+}
+
+.divide-primary-pressed > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--primary-pressed);
+}
+
+.divide-process-operations > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--process-operations);
+}
+
+.divide-purple > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--purple);
+}
+
+.divide-registry-operations > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--registry-operations);
+}
+
+.divide-selected > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--selected);
+}
+
+.divide-surface-2xl > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-2xl);
+}
+
+.divide-surface-base > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-base);
+}
+
+.divide-surface-inner > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-inner);
+}
+
+.divide-surface-lg > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-lg);
+}
+
+.divide-surface-md > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-md);
+}
+
+.divide-surface-xl > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--surface-xl);
+}
+
+.divide-text-and-icons > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--text-and-icons);
+}
+
+.divide-titles-and-attributes > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--titles-and-attributes);
+}
+
+.divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0;
+}
+
+.divide-opacity-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.05;
+}
+
+.divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.1;
+}
+
+.divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.2;
+}
+
+.divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.25;
+}
+
+.divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.3;
+}
+
+.divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.4;
+}
+
+.divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.5;
+}
+
+.divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.6;
+}
+
+.divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.7;
+}
+
+.divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.75;
+}
+
+.divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.8;
+}
+
+.divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.9;
+}
+
+.divide-opacity-95 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.95;
+}
+
+.divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+}
+
+.place-self-auto {
+  place-self: auto;
+}
+
+.place-self-start {
+  place-self: start;
+}
+
+.place-self-end {
+  place-self: end;
+}
+
+.place-self-center {
+  place-self: center;
+}
+
+.place-self-stretch {
+  place-self: stretch;
+}
+
+.self-auto {
+  align-self: auto;
+}
+
+.self-start {
+  align-self: flex-start;
+}
+
+.self-end {
+  align-self: flex-end;
+}
+
+.self-center {
+  align-self: center;
+}
+
+.self-stretch {
+  align-self: stretch;
+}
+
+.self-baseline {
+  align-self: baseline;
+}
+
+.justify-self-auto {
+  justify-self: auto;
+}
+
+.justify-self-start {
+  justify-self: start;
+}
+
+.justify-self-end {
+  justify-self: end;
+}
+
+.justify-self-center {
+  justify-self: center;
+}
+
+.justify-self-stretch {
+  justify-self: stretch;
+}
+
+.overflow-auto {
+  overflow: auto;
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.overflow-visible {
+  overflow: visible;
+}
+
+.overflow-scroll {
+  overflow: scroll;
+}
+
+.overflow-x-auto {
+  overflow-x: auto;
+}
+
+.overflow-y-auto {
+  overflow-y: auto;
+}
+
+.overflow-x-hidden {
+  overflow-x: hidden;
+}
+
+.overflow-y-hidden {
+  overflow-y: hidden;
+}
+
+.overflow-x-visible {
+  overflow-x: visible;
+}
+
+.overflow-y-visible {
+  overflow-y: visible;
+}
+
+.overflow-x-scroll {
+  overflow-x: scroll;
+}
+
+.overflow-y-scroll {
+  overflow-y: scroll;
+}
+
+.overscroll-auto {
+  -ms-scroll-chaining: chained;
+      overscroll-behavior: auto;
+}
+
+.overscroll-contain {
+  -ms-scroll-chaining: none;
+      overscroll-behavior: contain;
+}
+
+.overscroll-none {
+  -ms-scroll-chaining: none;
+      overscroll-behavior: none;
+}
+
+.overscroll-y-auto {
+  overscroll-behavior-y: auto;
+}
+
+.overscroll-y-contain {
+  overscroll-behavior-y: contain;
+}
+
+.overscroll-y-none {
+  overscroll-behavior-y: none;
+}
+
+.overscroll-x-auto {
+  overscroll-behavior-x: auto;
+}
+
+.overscroll-x-contain {
+  overscroll-behavior-x: contain;
+}
+
+.overscroll-x-none {
+  overscroll-behavior-x: none;
+}
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overflow-ellipsis {
+  text-overflow: ellipsis;
+}
+
+.overflow-clip {
+  text-overflow: clip;
+}
+
+.whitespace-normal {
+  white-space: normal;
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+
+.whitespace-pre {
+  white-space: pre;
+}
+
+.whitespace-pre-line {
+  white-space: pre-line;
+}
+
+.whitespace-pre-wrap {
+  white-space: pre-wrap;
+}
+
+.break-normal {
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.break-words {
+  overflow-wrap: break-word;
+}
+
+.break-all {
+  word-break: break-all;
+}
+
+.rounded-none {
+  border-radius: 0px;
+}
+
+.rounded-sm {
+  border-radius: 0.125rem;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.rounded-md {
+  border-radius: 0.375rem;
+}
+
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
+.rounded-2xl {
+  border-radius: 1rem;
+}
+
+.rounded-3xl {
+  border-radius: 1.5rem;
+}
+
+.rounded-full {
+  border-radius: 9999px;
+}
+
+.focus\\\\:rounded-none:focus {
+  border-radius: 0px;
+}
+
+.focus\\\\:rounded-sm:focus {
+  border-radius: 0.125rem;
+}
+
+.focus\\\\:rounded:focus {
+  border-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-md:focus {
+  border-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-lg:focus {
+  border-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-xl:focus {
+  border-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-2xl:focus {
+  border-radius: 1rem;
+}
+
+.focus\\\\:rounded-3xl:focus {
+  border-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-full:focus {
+  border-radius: 9999px;
+}
+
+.first\\\\:rounded-none:first-child {
+  border-radius: 0px;
+}
+
+.first\\\\:rounded-sm:first-child {
+  border-radius: 0.125rem;
+}
+
+.first\\\\:rounded:first-child {
+  border-radius: 0.25rem;
+}
+
+.first\\\\:rounded-md:first-child {
+  border-radius: 0.375rem;
+}
+
+.first\\\\:rounded-lg:first-child {
+  border-radius: 0.5rem;
+}
+
+.first\\\\:rounded-xl:first-child {
+  border-radius: 0.75rem;
+}
+
+.first\\\\:rounded-2xl:first-child {
+  border-radius: 1rem;
+}
+
+.first\\\\:rounded-3xl:first-child {
+  border-radius: 1.5rem;
+}
+
+.first\\\\:rounded-full:first-child {
+  border-radius: 9999px;
+}
+
+.last\\\\:rounded-none:last-child {
+  border-radius: 0px;
+}
+
+.last\\\\:rounded-sm:last-child {
+  border-radius: 0.125rem;
+}
+
+.last\\\\:rounded:last-child {
+  border-radius: 0.25rem;
+}
+
+.last\\\\:rounded-md:last-child {
+  border-radius: 0.375rem;
+}
+
+.last\\\\:rounded-lg:last-child {
+  border-radius: 0.5rem;
+}
+
+.last\\\\:rounded-xl:last-child {
+  border-radius: 0.75rem;
+}
+
+.last\\\\:rounded-2xl:last-child {
+  border-radius: 1rem;
+}
+
+.last\\\\:rounded-3xl:last-child {
+  border-radius: 1.5rem;
+}
+
+.last\\\\:rounded-full:last-child {
+  border-radius: 9999px;
+}
+
+.rounded-t-none {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.rounded-t-sm {
+  border-top-left-radius: 0.125rem;
+  border-top-right-radius: 0.125rem;
+}
+
+.rounded-t {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.rounded-t-md {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+.rounded-t-lg {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.rounded-t-xl {
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.rounded-t-2xl {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.rounded-t-3xl {
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+}
+
+.rounded-t-full {
+  border-top-left-radius: 9999px;
+  border-top-right-radius: 9999px;
+}
+
+.rounded-r-none {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.rounded-r-sm {
+  border-top-right-radius: 0.125rem;
+  border-bottom-right-radius: 0.125rem;
+}
+
+.rounded-r {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.rounded-r-md {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.rounded-r-lg {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.rounded-r-xl {
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.rounded-r-2xl {
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.rounded-r-3xl {
+  border-top-right-radius: 1.5rem;
+  border-bottom-right-radius: 1.5rem;
+}
+
+.rounded-r-full {
+  border-top-right-radius: 9999px;
+  border-bottom-right-radius: 9999px;
+}
+
+.rounded-b-none {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.rounded-b-sm {
+  border-bottom-right-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.rounded-b {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.rounded-b-md {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.rounded-b-lg {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.rounded-b-xl {
+  border-bottom-right-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.rounded-b-2xl {
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.rounded-b-3xl {
+  border-bottom-right-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.rounded-b-full {
+  border-bottom-right-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.rounded-l-none {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.rounded-l-sm {
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.rounded-l {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.rounded-l-md {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.rounded-l-lg {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.rounded-l-xl {
+  border-top-left-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.rounded-l-2xl {
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.rounded-l-3xl {
+  border-top-left-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.rounded-l-full {
+  border-top-left-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.focus\\\\:rounded-t-none:focus {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.focus\\\\:rounded-t-sm:focus {
+  border-top-left-radius: 0.125rem;
+  border-top-right-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-t:focus {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-t-md:focus {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-t-lg:focus {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-t-xl:focus {
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-t-2xl:focus {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.focus\\\\:rounded-t-3xl:focus {
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-t-full:focus {
+  border-top-left-radius: 9999px;
+  border-top-right-radius: 9999px;
+}
+
+.focus\\\\:rounded-r-none:focus {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.focus\\\\:rounded-r-sm:focus {
+  border-top-right-radius: 0.125rem;
+  border-bottom-right-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-r:focus {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-r-md:focus {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-r-lg:focus {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-r-xl:focus {
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-r-2xl:focus {
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.focus\\\\:rounded-r-3xl:focus {
+  border-top-right-radius: 1.5rem;
+  border-bottom-right-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-r-full:focus {
+  border-top-right-radius: 9999px;
+  border-bottom-right-radius: 9999px;
+}
+
+.focus\\\\:rounded-b-none:focus {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.focus\\\\:rounded-b-sm:focus {
+  border-bottom-right-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-b:focus {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-b-md:focus {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-b-lg:focus {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-b-xl:focus {
+  border-bottom-right-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-b-2xl:focus {
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.focus\\\\:rounded-b-3xl:focus {
+  border-bottom-right-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-b-full:focus {
+  border-bottom-right-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.focus\\\\:rounded-l-none:focus {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.focus\\\\:rounded-l-sm:focus {
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-l:focus {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-l-md:focus {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-l-lg:focus {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-l-xl:focus {
+  border-top-left-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-l-2xl:focus {
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.focus\\\\:rounded-l-3xl:focus {
+  border-top-left-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-l-full:focus {
+  border-top-left-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.first\\\\:rounded-t-none:first-child {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.first\\\\:rounded-t-sm:first-child {
+  border-top-left-radius: 0.125rem;
+  border-top-right-radius: 0.125rem;
+}
+
+.first\\\\:rounded-t:first-child {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.first\\\\:rounded-t-md:first-child {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+.first\\\\:rounded-t-lg:first-child {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.first\\\\:rounded-t-xl:first-child {
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.first\\\\:rounded-t-2xl:first-child {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.first\\\\:rounded-t-3xl:first-child {
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+}
+
+.first\\\\:rounded-t-full:first-child {
+  border-top-left-radius: 9999px;
+  border-top-right-radius: 9999px;
+}
+
+.first\\\\:rounded-r-none:first-child {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.first\\\\:rounded-r-sm:first-child {
+  border-top-right-radius: 0.125rem;
+  border-bottom-right-radius: 0.125rem;
+}
+
+.first\\\\:rounded-r:first-child {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.first\\\\:rounded-r-md:first-child {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.first\\\\:rounded-r-lg:first-child {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.first\\\\:rounded-r-xl:first-child {
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.first\\\\:rounded-r-2xl:first-child {
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.first\\\\:rounded-r-3xl:first-child {
+  border-top-right-radius: 1.5rem;
+  border-bottom-right-radius: 1.5rem;
+}
+
+.first\\\\:rounded-r-full:first-child {
+  border-top-right-radius: 9999px;
+  border-bottom-right-radius: 9999px;
+}
+
+.first\\\\:rounded-b-none:first-child {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.first\\\\:rounded-b-sm:first-child {
+  border-bottom-right-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.first\\\\:rounded-b:first-child {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.first\\\\:rounded-b-md:first-child {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.first\\\\:rounded-b-lg:first-child {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.first\\\\:rounded-b-xl:first-child {
+  border-bottom-right-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.first\\\\:rounded-b-2xl:first-child {
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.first\\\\:rounded-b-3xl:first-child {
+  border-bottom-right-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.first\\\\:rounded-b-full:first-child {
+  border-bottom-right-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.first\\\\:rounded-l-none:first-child {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.first\\\\:rounded-l-sm:first-child {
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.first\\\\:rounded-l:first-child {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.first\\\\:rounded-l-md:first-child {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.first\\\\:rounded-l-lg:first-child {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.first\\\\:rounded-l-xl:first-child {
+  border-top-left-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.first\\\\:rounded-l-2xl:first-child {
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.first\\\\:rounded-l-3xl:first-child {
+  border-top-left-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.first\\\\:rounded-l-full:first-child {
+  border-top-left-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.last\\\\:rounded-t-none:last-child {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.last\\\\:rounded-t-sm:last-child {
+  border-top-left-radius: 0.125rem;
+  border-top-right-radius: 0.125rem;
+}
+
+.last\\\\:rounded-t:last-child {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.last\\\\:rounded-t-md:last-child {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+.last\\\\:rounded-t-lg:last-child {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.last\\\\:rounded-t-xl:last-child {
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.last\\\\:rounded-t-2xl:last-child {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.last\\\\:rounded-t-3xl:last-child {
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+}
+
+.last\\\\:rounded-t-full:last-child {
+  border-top-left-radius: 9999px;
+  border-top-right-radius: 9999px;
+}
+
+.last\\\\:rounded-r-none:last-child {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.last\\\\:rounded-r-sm:last-child {
+  border-top-right-radius: 0.125rem;
+  border-bottom-right-radius: 0.125rem;
+}
+
+.last\\\\:rounded-r:last-child {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.last\\\\:rounded-r-md:last-child {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.last\\\\:rounded-r-lg:last-child {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.last\\\\:rounded-r-xl:last-child {
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.last\\\\:rounded-r-2xl:last-child {
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.last\\\\:rounded-r-3xl:last-child {
+  border-top-right-radius: 1.5rem;
+  border-bottom-right-radius: 1.5rem;
+}
+
+.last\\\\:rounded-r-full:last-child {
+  border-top-right-radius: 9999px;
+  border-bottom-right-radius: 9999px;
+}
+
+.last\\\\:rounded-b-none:last-child {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.last\\\\:rounded-b-sm:last-child {
+  border-bottom-right-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.last\\\\:rounded-b:last-child {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.last\\\\:rounded-b-md:last-child {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.last\\\\:rounded-b-lg:last-child {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.last\\\\:rounded-b-xl:last-child {
+  border-bottom-right-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.last\\\\:rounded-b-2xl:last-child {
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.last\\\\:rounded-b-3xl:last-child {
+  border-bottom-right-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.last\\\\:rounded-b-full:last-child {
+  border-bottom-right-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.last\\\\:rounded-l-none:last-child {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.last\\\\:rounded-l-sm:last-child {
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.last\\\\:rounded-l:last-child {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.last\\\\:rounded-l-md:last-child {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.last\\\\:rounded-l-lg:last-child {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.last\\\\:rounded-l-xl:last-child {
+  border-top-left-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.last\\\\:rounded-l-2xl:last-child {
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.last\\\\:rounded-l-3xl:last-child {
+  border-top-left-radius: 1.5rem;
+  border-bottom-left-radius: 1.5rem;
+}
+
+.last\\\\:rounded-l-full:last-child {
+  border-top-left-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.rounded-tl-none {
+  border-top-left-radius: 0px;
+}
+
+.rounded-tl-sm {
+  border-top-left-radius: 0.125rem;
+}
+
+.rounded-tl {
+  border-top-left-radius: 0.25rem;
+}
+
+.rounded-tl-md {
+  border-top-left-radius: 0.375rem;
+}
+
+.rounded-tl-lg {
+  border-top-left-radius: 0.5rem;
+}
+
+.rounded-tl-xl {
+  border-top-left-radius: 0.75rem;
+}
+
+.rounded-tl-2xl {
+  border-top-left-radius: 1rem;
+}
+
+.rounded-tl-3xl {
+  border-top-left-radius: 1.5rem;
+}
+
+.rounded-tl-full {
+  border-top-left-radius: 9999px;
+}
+
+.rounded-tr-none {
+  border-top-right-radius: 0px;
+}
+
+.rounded-tr-sm {
+  border-top-right-radius: 0.125rem;
+}
+
+.rounded-tr {
+  border-top-right-radius: 0.25rem;
+}
+
+.rounded-tr-md {
+  border-top-right-radius: 0.375rem;
+}
+
+.rounded-tr-lg {
+  border-top-right-radius: 0.5rem;
+}
+
+.rounded-tr-xl {
+  border-top-right-radius: 0.75rem;
+}
+
+.rounded-tr-2xl {
+  border-top-right-radius: 1rem;
+}
+
+.rounded-tr-3xl {
+  border-top-right-radius: 1.5rem;
+}
+
+.rounded-tr-full {
+  border-top-right-radius: 9999px;
+}
+
+.rounded-br-none {
+  border-bottom-right-radius: 0px;
+}
+
+.rounded-br-sm {
+  border-bottom-right-radius: 0.125rem;
+}
+
+.rounded-br {
+  border-bottom-right-radius: 0.25rem;
+}
+
+.rounded-br-md {
+  border-bottom-right-radius: 0.375rem;
+}
+
+.rounded-br-lg {
+  border-bottom-right-radius: 0.5rem;
+}
+
+.rounded-br-xl {
+  border-bottom-right-radius: 0.75rem;
+}
+
+.rounded-br-2xl {
+  border-bottom-right-radius: 1rem;
+}
+
+.rounded-br-3xl {
+  border-bottom-right-radius: 1.5rem;
+}
+
+.rounded-br-full {
+  border-bottom-right-radius: 9999px;
+}
+
+.rounded-bl-none {
+  border-bottom-left-radius: 0px;
+}
+
+.rounded-bl-sm {
+  border-bottom-left-radius: 0.125rem;
+}
+
+.rounded-bl {
+  border-bottom-left-radius: 0.25rem;
+}
+
+.rounded-bl-md {
+  border-bottom-left-radius: 0.375rem;
+}
+
+.rounded-bl-lg {
+  border-bottom-left-radius: 0.5rem;
+}
+
+.rounded-bl-xl {
+  border-bottom-left-radius: 0.75rem;
+}
+
+.rounded-bl-2xl {
+  border-bottom-left-radius: 1rem;
+}
+
+.rounded-bl-3xl {
+  border-bottom-left-radius: 1.5rem;
+}
+
+.rounded-bl-full {
+  border-bottom-left-radius: 9999px;
+}
+
+.focus\\\\:rounded-tl-none:focus {
+  border-top-left-radius: 0px;
+}
+
+.focus\\\\:rounded-tl-sm:focus {
+  border-top-left-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-tl:focus {
+  border-top-left-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-tl-md:focus {
+  border-top-left-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-tl-lg:focus {
+  border-top-left-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-tl-xl:focus {
+  border-top-left-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-tl-2xl:focus {
+  border-top-left-radius: 1rem;
+}
+
+.focus\\\\:rounded-tl-3xl:focus {
+  border-top-left-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-tl-full:focus {
+  border-top-left-radius: 9999px;
+}
+
+.focus\\\\:rounded-tr-none:focus {
+  border-top-right-radius: 0px;
+}
+
+.focus\\\\:rounded-tr-sm:focus {
+  border-top-right-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-tr:focus {
+  border-top-right-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-tr-md:focus {
+  border-top-right-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-tr-lg:focus {
+  border-top-right-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-tr-xl:focus {
+  border-top-right-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-tr-2xl:focus {
+  border-top-right-radius: 1rem;
+}
+
+.focus\\\\:rounded-tr-3xl:focus {
+  border-top-right-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-tr-full:focus {
+  border-top-right-radius: 9999px;
+}
+
+.focus\\\\:rounded-br-none:focus {
+  border-bottom-right-radius: 0px;
+}
+
+.focus\\\\:rounded-br-sm:focus {
+  border-bottom-right-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-br:focus {
+  border-bottom-right-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-br-md:focus {
+  border-bottom-right-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-br-lg:focus {
+  border-bottom-right-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-br-xl:focus {
+  border-bottom-right-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-br-2xl:focus {
+  border-bottom-right-radius: 1rem;
+}
+
+.focus\\\\:rounded-br-3xl:focus {
+  border-bottom-right-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-br-full:focus {
+  border-bottom-right-radius: 9999px;
+}
+
+.focus\\\\:rounded-bl-none:focus {
+  border-bottom-left-radius: 0px;
+}
+
+.focus\\\\:rounded-bl-sm:focus {
+  border-bottom-left-radius: 0.125rem;
+}
+
+.focus\\\\:rounded-bl:focus {
+  border-bottom-left-radius: 0.25rem;
+}
+
+.focus\\\\:rounded-bl-md:focus {
+  border-bottom-left-radius: 0.375rem;
+}
+
+.focus\\\\:rounded-bl-lg:focus {
+  border-bottom-left-radius: 0.5rem;
+}
+
+.focus\\\\:rounded-bl-xl:focus {
+  border-bottom-left-radius: 0.75rem;
+}
+
+.focus\\\\:rounded-bl-2xl:focus {
+  border-bottom-left-radius: 1rem;
+}
+
+.focus\\\\:rounded-bl-3xl:focus {
+  border-bottom-left-radius: 1.5rem;
+}
+
+.focus\\\\:rounded-bl-full:focus {
+  border-bottom-left-radius: 9999px;
+}
+
+.first\\\\:rounded-tl-none:first-child {
+  border-top-left-radius: 0px;
+}
+
+.first\\\\:rounded-tl-sm:first-child {
+  border-top-left-radius: 0.125rem;
+}
+
+.first\\\\:rounded-tl:first-child {
+  border-top-left-radius: 0.25rem;
+}
+
+.first\\\\:rounded-tl-md:first-child {
+  border-top-left-radius: 0.375rem;
+}
+
+.first\\\\:rounded-tl-lg:first-child {
+  border-top-left-radius: 0.5rem;
+}
+
+.first\\\\:rounded-tl-xl:first-child {
+  border-top-left-radius: 0.75rem;
+}
+
+.first\\\\:rounded-tl-2xl:first-child {
+  border-top-left-radius: 1rem;
+}
+
+.first\\\\:rounded-tl-3xl:first-child {
+  border-top-left-radius: 1.5rem;
+}
+
+.first\\\\:rounded-tl-full:first-child {
+  border-top-left-radius: 9999px;
+}
+
+.first\\\\:rounded-tr-none:first-child {
+  border-top-right-radius: 0px;
+}
+
+.first\\\\:rounded-tr-sm:first-child {
+  border-top-right-radius: 0.125rem;
+}
+
+.first\\\\:rounded-tr:first-child {
+  border-top-right-radius: 0.25rem;
+}
+
+.first\\\\:rounded-tr-md:first-child {
+  border-top-right-radius: 0.375rem;
+}
+
+.first\\\\:rounded-tr-lg:first-child {
+  border-top-right-radius: 0.5rem;
+}
+
+.first\\\\:rounded-tr-xl:first-child {
+  border-top-right-radius: 0.75rem;
+}
+
+.first\\\\:rounded-tr-2xl:first-child {
+  border-top-right-radius: 1rem;
+}
+
+.first\\\\:rounded-tr-3xl:first-child {
+  border-top-right-radius: 1.5rem;
+}
+
+.first\\\\:rounded-tr-full:first-child {
+  border-top-right-radius: 9999px;
+}
+
+.first\\\\:rounded-br-none:first-child {
+  border-bottom-right-radius: 0px;
+}
+
+.first\\\\:rounded-br-sm:first-child {
+  border-bottom-right-radius: 0.125rem;
+}
+
+.first\\\\:rounded-br:first-child {
+  border-bottom-right-radius: 0.25rem;
+}
+
+.first\\\\:rounded-br-md:first-child {
+  border-bottom-right-radius: 0.375rem;
+}
+
+.first\\\\:rounded-br-lg:first-child {
+  border-bottom-right-radius: 0.5rem;
+}
+
+.first\\\\:rounded-br-xl:first-child {
+  border-bottom-right-radius: 0.75rem;
+}
+
+.first\\\\:rounded-br-2xl:first-child {
+  border-bottom-right-radius: 1rem;
+}
+
+.first\\\\:rounded-br-3xl:first-child {
+  border-bottom-right-radius: 1.5rem;
+}
+
+.first\\\\:rounded-br-full:first-child {
+  border-bottom-right-radius: 9999px;
+}
+
+.first\\\\:rounded-bl-none:first-child {
+  border-bottom-left-radius: 0px;
+}
+
+.first\\\\:rounded-bl-sm:first-child {
+  border-bottom-left-radius: 0.125rem;
+}
+
+.first\\\\:rounded-bl:first-child {
+  border-bottom-left-radius: 0.25rem;
+}
+
+.first\\\\:rounded-bl-md:first-child {
+  border-bottom-left-radius: 0.375rem;
+}
+
+.first\\\\:rounded-bl-lg:first-child {
+  border-bottom-left-radius: 0.5rem;
+}
+
+.first\\\\:rounded-bl-xl:first-child {
+  border-bottom-left-radius: 0.75rem;
+}
+
+.first\\\\:rounded-bl-2xl:first-child {
+  border-bottom-left-radius: 1rem;
+}
+
+.first\\\\:rounded-bl-3xl:first-child {
+  border-bottom-left-radius: 1.5rem;
+}
+
+.first\\\\:rounded-bl-full:first-child {
+  border-bottom-left-radius: 9999px;
+}
+
+.last\\\\:rounded-tl-none:last-child {
+  border-top-left-radius: 0px;
+}
+
+.last\\\\:rounded-tl-sm:last-child {
+  border-top-left-radius: 0.125rem;
+}
+
+.last\\\\:rounded-tl:last-child {
+  border-top-left-radius: 0.25rem;
+}
+
+.last\\\\:rounded-tl-md:last-child {
+  border-top-left-radius: 0.375rem;
+}
+
+.last\\\\:rounded-tl-lg:last-child {
+  border-top-left-radius: 0.5rem;
+}
+
+.last\\\\:rounded-tl-xl:last-child {
+  border-top-left-radius: 0.75rem;
+}
+
+.last\\\\:rounded-tl-2xl:last-child {
+  border-top-left-radius: 1rem;
+}
+
+.last\\\\:rounded-tl-3xl:last-child {
+  border-top-left-radius: 1.5rem;
+}
+
+.last\\\\:rounded-tl-full:last-child {
+  border-top-left-radius: 9999px;
+}
+
+.last\\\\:rounded-tr-none:last-child {
+  border-top-right-radius: 0px;
+}
+
+.last\\\\:rounded-tr-sm:last-child {
+  border-top-right-radius: 0.125rem;
+}
+
+.last\\\\:rounded-tr:last-child {
+  border-top-right-radius: 0.25rem;
+}
+
+.last\\\\:rounded-tr-md:last-child {
+  border-top-right-radius: 0.375rem;
+}
+
+.last\\\\:rounded-tr-lg:last-child {
+  border-top-right-radius: 0.5rem;
+}
+
+.last\\\\:rounded-tr-xl:last-child {
+  border-top-right-radius: 0.75rem;
+}
+
+.last\\\\:rounded-tr-2xl:last-child {
+  border-top-right-radius: 1rem;
+}
+
+.last\\\\:rounded-tr-3xl:last-child {
+  border-top-right-radius: 1.5rem;
+}
+
+.last\\\\:rounded-tr-full:last-child {
+  border-top-right-radius: 9999px;
+}
+
+.last\\\\:rounded-br-none:last-child {
+  border-bottom-right-radius: 0px;
+}
+
+.last\\\\:rounded-br-sm:last-child {
+  border-bottom-right-radius: 0.125rem;
+}
+
+.last\\\\:rounded-br:last-child {
+  border-bottom-right-radius: 0.25rem;
+}
+
+.last\\\\:rounded-br-md:last-child {
+  border-bottom-right-radius: 0.375rem;
+}
+
+.last\\\\:rounded-br-lg:last-child {
+  border-bottom-right-radius: 0.5rem;
+}
+
+.last\\\\:rounded-br-xl:last-child {
+  border-bottom-right-radius: 0.75rem;
+}
+
+.last\\\\:rounded-br-2xl:last-child {
+  border-bottom-right-radius: 1rem;
+}
+
+.last\\\\:rounded-br-3xl:last-child {
+  border-bottom-right-radius: 1.5rem;
+}
+
+.last\\\\:rounded-br-full:last-child {
+  border-bottom-right-radius: 9999px;
+}
+
+.last\\\\:rounded-bl-none:last-child {
+  border-bottom-left-radius: 0px;
+}
+
+.last\\\\:rounded-bl-sm:last-child {
+  border-bottom-left-radius: 0.125rem;
+}
+
+.last\\\\:rounded-bl:last-child {
+  border-bottom-left-radius: 0.25rem;
+}
+
+.last\\\\:rounded-bl-md:last-child {
+  border-bottom-left-radius: 0.375rem;
+}
+
+.last\\\\:rounded-bl-lg:last-child {
+  border-bottom-left-radius: 0.5rem;
+}
+
+.last\\\\:rounded-bl-xl:last-child {
+  border-bottom-left-radius: 0.75rem;
+}
+
+.last\\\\:rounded-bl-2xl:last-child {
+  border-bottom-left-radius: 1rem;
+}
+
+.last\\\\:rounded-bl-3xl:last-child {
+  border-bottom-left-radius: 1.5rem;
+}
+
+.last\\\\:rounded-bl-full:last-child {
+  border-bottom-left-radius: 9999px;
+}
+
+.border-0 {
+  border-width: 0px;
+}
+
+.border-2 {
+  border-width: 2px;
+}
+
+.border-4 {
+  border-width: 4px;
+}
+
+.border-8 {
+  border-width: 8px;
+}
+
+.border {
+  border-width: 1px;
+}
+
+.first\\\\:border-0:first-child {
+  border-width: 0px;
+}
+
+.first\\\\:border-2:first-child {
+  border-width: 2px;
+}
+
+.first\\\\:border-4:first-child {
+  border-width: 4px;
+}
+
+.first\\\\:border-8:first-child {
+  border-width: 8px;
+}
+
+.first\\\\:border:first-child {
+  border-width: 1px;
+}
+
+.last\\\\:border-0:last-child {
+  border-width: 0px;
+}
+
+.last\\\\:border-2:last-child {
+  border-width: 2px;
+}
+
+.last\\\\:border-4:last-child {
+  border-width: 4px;
+}
+
+.last\\\\:border-8:last-child {
+  border-width: 8px;
+}
+
+.last\\\\:border:last-child {
+  border-width: 1px;
+}
+
+.active\\\\:border-0:active {
+  border-width: 0px;
+}
+
+.active\\\\:border-2:active {
+  border-width: 2px;
+}
+
+.active\\\\:border-4:active {
+  border-width: 4px;
+}
+
+.active\\\\:border-8:active {
+  border-width: 8px;
+}
+
+.active\\\\:border:active {
+  border-width: 1px;
+}
+
+.border-t-0 {
+  border-top-width: 0px;
+}
+
+.border-t-2 {
+  border-top-width: 2px;
+}
+
+.border-t-4 {
+  border-top-width: 4px;
+}
+
+.border-t-8 {
+  border-top-width: 8px;
+}
+
+.border-t {
+  border-top-width: 1px;
+}
+
+.border-r-0 {
+  border-right-width: 0px;
+}
+
+.border-r-2 {
+  border-right-width: 2px;
+}
+
+.border-r-4 {
+  border-right-width: 4px;
+}
+
+.border-r-8 {
+  border-right-width: 8px;
+}
+
+.border-r {
+  border-right-width: 1px;
+}
+
+.border-b-0 {
+  border-bottom-width: 0px;
+}
+
+.border-b-2 {
+  border-bottom-width: 2px;
+}
+
+.border-b-4 {
+  border-bottom-width: 4px;
+}
+
+.border-b-8 {
+  border-bottom-width: 8px;
+}
+
+.border-b {
+  border-bottom-width: 1px;
+}
+
+.border-l-0 {
+  border-left-width: 0px;
+}
+
+.border-l-2 {
+  border-left-width: 2px;
+}
+
+.border-l-4 {
+  border-left-width: 4px;
+}
+
+.border-l-8 {
+  border-left-width: 8px;
+}
+
+.border-l {
+  border-left-width: 1px;
+}
+
+.first\\\\:border-t-0:first-child {
+  border-top-width: 0px;
+}
+
+.first\\\\:border-t-2:first-child {
+  border-top-width: 2px;
+}
+
+.first\\\\:border-t-4:first-child {
+  border-top-width: 4px;
+}
+
+.first\\\\:border-t-8:first-child {
+  border-top-width: 8px;
+}
+
+.first\\\\:border-t:first-child {
+  border-top-width: 1px;
+}
+
+.first\\\\:border-r-0:first-child {
+  border-right-width: 0px;
+}
+
+.first\\\\:border-r-2:first-child {
+  border-right-width: 2px;
+}
+
+.first\\\\:border-r-4:first-child {
+  border-right-width: 4px;
+}
+
+.first\\\\:border-r-8:first-child {
+  border-right-width: 8px;
+}
+
+.first\\\\:border-r:first-child {
+  border-right-width: 1px;
+}
+
+.first\\\\:border-b-0:first-child {
+  border-bottom-width: 0px;
+}
+
+.first\\\\:border-b-2:first-child {
+  border-bottom-width: 2px;
+}
+
+.first\\\\:border-b-4:first-child {
+  border-bottom-width: 4px;
+}
+
+.first\\\\:border-b-8:first-child {
+  border-bottom-width: 8px;
+}
+
+.first\\\\:border-b:first-child {
+  border-bottom-width: 1px;
+}
+
+.first\\\\:border-l-0:first-child {
+  border-left-width: 0px;
+}
+
+.first\\\\:border-l-2:first-child {
+  border-left-width: 2px;
+}
+
+.first\\\\:border-l-4:first-child {
+  border-left-width: 4px;
+}
+
+.first\\\\:border-l-8:first-child {
+  border-left-width: 8px;
+}
+
+.first\\\\:border-l:first-child {
+  border-left-width: 1px;
+}
+
+.last\\\\:border-t-0:last-child {
+  border-top-width: 0px;
+}
+
+.last\\\\:border-t-2:last-child {
+  border-top-width: 2px;
+}
+
+.last\\\\:border-t-4:last-child {
+  border-top-width: 4px;
+}
+
+.last\\\\:border-t-8:last-child {
+  border-top-width: 8px;
+}
+
+.last\\\\:border-t:last-child {
+  border-top-width: 1px;
+}
+
+.last\\\\:border-r-0:last-child {
+  border-right-width: 0px;
+}
+
+.last\\\\:border-r-2:last-child {
+  border-right-width: 2px;
+}
+
+.last\\\\:border-r-4:last-child {
+  border-right-width: 4px;
+}
+
+.last\\\\:border-r-8:last-child {
+  border-right-width: 8px;
+}
+
+.last\\\\:border-r:last-child {
+  border-right-width: 1px;
+}
+
+.last\\\\:border-b-0:last-child {
+  border-bottom-width: 0px;
+}
+
+.last\\\\:border-b-2:last-child {
+  border-bottom-width: 2px;
+}
+
+.last\\\\:border-b-4:last-child {
+  border-bottom-width: 4px;
+}
+
+.last\\\\:border-b-8:last-child {
+  border-bottom-width: 8px;
+}
+
+.last\\\\:border-b:last-child {
+  border-bottom-width: 1px;
+}
+
+.last\\\\:border-l-0:last-child {
+  border-left-width: 0px;
+}
+
+.last\\\\:border-l-2:last-child {
+  border-left-width: 2px;
+}
+
+.last\\\\:border-l-4:last-child {
+  border-left-width: 4px;
+}
+
+.last\\\\:border-l-8:last-child {
+  border-left-width: 8px;
+}
+
+.last\\\\:border-l:last-child {
+  border-left-width: 1px;
+}
+
+.active\\\\:border-t-0:active {
+  border-top-width: 0px;
+}
+
+.active\\\\:border-t-2:active {
+  border-top-width: 2px;
+}
+
+.active\\\\:border-t-4:active {
+  border-top-width: 4px;
+}
+
+.active\\\\:border-t-8:active {
+  border-top-width: 8px;
+}
+
+.active\\\\:border-t:active {
+  border-top-width: 1px;
+}
+
+.active\\\\:border-r-0:active {
+  border-right-width: 0px;
+}
+
+.active\\\\:border-r-2:active {
+  border-right-width: 2px;
+}
+
+.active\\\\:border-r-4:active {
+  border-right-width: 4px;
+}
+
+.active\\\\:border-r-8:active {
+  border-right-width: 8px;
+}
+
+.active\\\\:border-r:active {
+  border-right-width: 1px;
+}
+
+.active\\\\:border-b-0:active {
+  border-bottom-width: 0px;
+}
+
+.active\\\\:border-b-2:active {
+  border-bottom-width: 2px;
+}
+
+.active\\\\:border-b-4:active {
+  border-bottom-width: 4px;
+}
+
+.active\\\\:border-b-8:active {
+  border-bottom-width: 8px;
+}
+
+.active\\\\:border-b:active {
+  border-bottom-width: 1px;
+}
+
+.active\\\\:border-l-0:active {
+  border-left-width: 0px;
+}
+
+.active\\\\:border-l-2:active {
+  border-left-width: 2px;
+}
+
+.active\\\\:border-l-4:active {
+  border-left-width: 4px;
+}
+
+.active\\\\:border-l-8:active {
+  border-left-width: 8px;
+}
+
+.active\\\\:border-l:active {
+  border-left-width: 1px;
+}
+
+.border-solid {
+  border-style: solid;
+}
+
+.border-dashed {
+  border-style: dashed;
+}
+
+.border-dotted {
+  border-style: dotted;
+}
+
+.border-double {
+  border-style: double;
+}
+
+.border-none {
+  border-style: none;
+}
+
+.border-current {
+  border-color: currentColor;
+}
+
+.border-transparent {
+  border-color: transparent;
+}
+
+.border-falcon {
+  border-color: var(--falcon);
+}
+
+.border-basement {
+  border-color: var(--basement);
+}
+
+.border-blue {
+  border-color: var(--blue);
+}
+
+.border-body-and-labels {
+  border-color: var(--body-and-labels);
+}
+
+.border-brand {
+  border-color: var(--brand);
+}
+
+.border-code-base-64 {
+  border-color: var(--code-base-64);
+}
+
+.border-code-bg {
+  border-color: var(--code-bg);
+}
+
+.border-code-outline {
+  border-color: var(--code-outline);
+}
+
+.border-code-text {
+  border-color: var(--code-text);
+}
+
+.border-critical {
+  border-color: var(--critical);
+}
+
+.border-destructive-hover {
+  border-color: var(--destructive-hover);
+}
+
+.border-destructive-idle {
+  border-color: var(--destructive-idle);
+}
+
+.border-destructive-pressed {
+  border-color: var(--destructive-pressed);
+}
+
+.border-disabled {
+  border-color: var(--disabled);
+}
+
+.border-disc-operations {
+  border-color: var(--disc-operations);
+}
+
+.border-dns-requests {
+  border-color: var(--dns-requests);
+}
+
+.border-focus {
+  border-color: var(--focus);
+}
+
+.border-graph-1 {
+  border-color: var(--graph-1);
+}
+
+.border-graph-10 {
+  border-color: var(--graph-10);
+}
+
+.border-graph-11 {
+  border-color: var(--graph-11);
+}
+
+.border-graph-2 {
+  border-color: var(--graph-2);
+}
+
+.border-graph-3 {
+  border-color: var(--graph-3);
+}
+
+.border-graph-4 {
+  border-color: var(--graph-4);
+}
+
+.border-graph-5 {
+  border-color: var(--graph-5);
+}
+
+.border-graph-6 {
+  border-color: var(--graph-6);
+}
+
+.border-graph-7 {
+  border-color: var(--graph-7);
+}
+
+.border-graph-8 {
+  border-color: var(--graph-8);
+}
+
+.border-graph-9 {
+  border-color: var(--graph-9);
+}
+
+.border-graph-disabled {
+  border-color: var(--graph-disabled);
+}
+
+.border-ground-floor {
+  border-color: var(--ground-floor);
+}
+
+.border-high {
+  border-color: var(--high);
+}
+
+.border-informational {
+  border-color: var(--informational);
+}
+
+.border-lines-dark {
+  border-color: var(--lines-dark);
+}
+
+.border-lines-light {
+  border-color: var(--lines-light);
+}
+
+.border-low {
+  border-color: var(--low);
+}
+
+.border-medium {
+  border-color: var(--medium);
+}
+
+.border-mezzanine {
+  border-color: var(--mezzanine);
+}
+
+.border-nav-text-and-icons {
+  border-color: var(--nav-text-and-icons);
+}
+
+.border-nav-text-secondary {
+  border-color: var(--nav-text-secondary);
+}
+
+.border-network-operations {
+  border-color: var(--network-operations);
+}
+
+.border-normal-hover {
+  border-color: var(--normal-hover);
+}
+
+.border-normal-idle {
+  border-color: var(--normal-idle);
+}
+
+.border-normal-pressed {
+  border-color: var(--normal-pressed);
+}
+
+.border-overlay-0\\\\.5 {
+  border-color: var(--overlay-0\\\\.5);
+}
+
+.border-overlay-1 {
+  border-color: var(--overlay-1);
+}
+
+.border-overlay-2 {
+  border-color: var(--overlay-2);
+}
+
+.border-positive {
+  border-color: var(--positive);
+}
+
+.border-primary-hover {
+  border-color: var(--primary-hover);
+}
+
+.border-primary-idle {
+  border-color: var(--primary-idle);
+}
+
+.border-primary-pressed {
+  border-color: var(--primary-pressed);
+}
+
+.border-process-operations {
+  border-color: var(--process-operations);
+}
+
+.border-purple {
+  border-color: var(--purple);
+}
+
+.border-registry-operations {
+  border-color: var(--registry-operations);
+}
+
+.border-selected {
+  border-color: var(--selected);
+}
+
+.border-surface-2xl {
+  border-color: var(--surface-2xl);
+}
+
+.border-surface-base {
+  border-color: var(--surface-base);
+}
+
+.border-surface-inner {
+  border-color: var(--surface-inner);
+}
+
+.border-surface-lg {
+  border-color: var(--surface-lg);
+}
+
+.border-surface-md {
+  border-color: var(--surface-md);
+}
+
+.border-surface-xl {
+  border-color: var(--surface-xl);
+}
+
+.border-text-and-icons {
+  border-color: var(--text-and-icons);
+}
+
+.border-titles-and-attributes {
+  border-color: var(--titles-and-attributes);
+}
+
+.hover\\\\:border-current:hover {
+  border-color: currentColor;
+}
+
+.hover\\\\:border-transparent:hover {
+  border-color: transparent;
+}
+
+.hover\\\\:border-falcon:hover {
+  border-color: var(--falcon);
+}
+
+.hover\\\\:border-basement:hover {
+  border-color: var(--basement);
+}
+
+.hover\\\\:border-blue:hover {
+  border-color: var(--blue);
+}
+
+.hover\\\\:border-body-and-labels:hover {
+  border-color: var(--body-and-labels);
+}
+
+.hover\\\\:border-brand:hover {
+  border-color: var(--brand);
+}
+
+.hover\\\\:border-code-base-64:hover {
+  border-color: var(--code-base-64);
+}
+
+.hover\\\\:border-code-bg:hover {
+  border-color: var(--code-bg);
+}
+
+.hover\\\\:border-code-outline:hover {
+  border-color: var(--code-outline);
+}
+
+.hover\\\\:border-code-text:hover {
+  border-color: var(--code-text);
+}
+
+.hover\\\\:border-critical:hover {
+  border-color: var(--critical);
+}
+
+.hover\\\\:border-destructive-hover:hover {
+  border-color: var(--destructive-hover);
+}
+
+.hover\\\\:border-destructive-idle:hover {
+  border-color: var(--destructive-idle);
+}
+
+.hover\\\\:border-destructive-pressed:hover {
+  border-color: var(--destructive-pressed);
+}
+
+.hover\\\\:border-disabled:hover {
+  border-color: var(--disabled);
+}
+
+.hover\\\\:border-disc-operations:hover {
+  border-color: var(--disc-operations);
+}
+
+.hover\\\\:border-dns-requests:hover {
+  border-color: var(--dns-requests);
+}
+
+.hover\\\\:border-focus:hover {
+  border-color: var(--focus);
+}
+
+.hover\\\\:border-graph-1:hover {
+  border-color: var(--graph-1);
+}
+
+.hover\\\\:border-graph-10:hover {
+  border-color: var(--graph-10);
+}
+
+.hover\\\\:border-graph-11:hover {
+  border-color: var(--graph-11);
+}
+
+.hover\\\\:border-graph-2:hover {
+  border-color: var(--graph-2);
+}
+
+.hover\\\\:border-graph-3:hover {
+  border-color: var(--graph-3);
+}
+
+.hover\\\\:border-graph-4:hover {
+  border-color: var(--graph-4);
+}
+
+.hover\\\\:border-graph-5:hover {
+  border-color: var(--graph-5);
+}
+
+.hover\\\\:border-graph-6:hover {
+  border-color: var(--graph-6);
+}
+
+.hover\\\\:border-graph-7:hover {
+  border-color: var(--graph-7);
+}
+
+.hover\\\\:border-graph-8:hover {
+  border-color: var(--graph-8);
+}
+
+.hover\\\\:border-graph-9:hover {
+  border-color: var(--graph-9);
+}
+
+.hover\\\\:border-graph-disabled:hover {
+  border-color: var(--graph-disabled);
+}
+
+.hover\\\\:border-ground-floor:hover {
+  border-color: var(--ground-floor);
+}
+
+.hover\\\\:border-high:hover {
+  border-color: var(--high);
+}
+
+.hover\\\\:border-informational:hover {
+  border-color: var(--informational);
+}
+
+.hover\\\\:border-lines-dark:hover {
+  border-color: var(--lines-dark);
+}
+
+.hover\\\\:border-lines-light:hover {
+  border-color: var(--lines-light);
+}
+
+.hover\\\\:border-low:hover {
+  border-color: var(--low);
+}
+
+.hover\\\\:border-medium:hover {
+  border-color: var(--medium);
+}
+
+.hover\\\\:border-mezzanine:hover {
+  border-color: var(--mezzanine);
+}
+
+.hover\\\\:border-nav-text-and-icons:hover {
+  border-color: var(--nav-text-and-icons);
+}
+
+.hover\\\\:border-nav-text-secondary:hover {
+  border-color: var(--nav-text-secondary);
+}
+
+.hover\\\\:border-network-operations:hover {
+  border-color: var(--network-operations);
+}
+
+.hover\\\\:border-normal-hover:hover {
+  border-color: var(--normal-hover);
+}
+
+.hover\\\\:border-normal-idle:hover {
+  border-color: var(--normal-idle);
+}
+
+.hover\\\\:border-normal-pressed:hover {
+  border-color: var(--normal-pressed);
+}
+
+.hover\\\\:border-overlay-0\\\\.5:hover {
+  border-color: var(--overlay-0\\\\.5);
+}
+
+.hover\\\\:border-overlay-1:hover {
+  border-color: var(--overlay-1);
+}
+
+.hover\\\\:border-overlay-2:hover {
+  border-color: var(--overlay-2);
+}
+
+.hover\\\\:border-positive:hover {
+  border-color: var(--positive);
+}
+
+.hover\\\\:border-primary-hover:hover {
+  border-color: var(--primary-hover);
+}
+
+.hover\\\\:border-primary-idle:hover {
+  border-color: var(--primary-idle);
+}
+
+.hover\\\\:border-primary-pressed:hover {
+  border-color: var(--primary-pressed);
+}
+
+.hover\\\\:border-process-operations:hover {
+  border-color: var(--process-operations);
+}
+
+.hover\\\\:border-purple:hover {
+  border-color: var(--purple);
+}
+
+.hover\\\\:border-registry-operations:hover {
+  border-color: var(--registry-operations);
+}
+
+.hover\\\\:border-selected:hover {
+  border-color: var(--selected);
+}
+
+.hover\\\\:border-surface-2xl:hover {
+  border-color: var(--surface-2xl);
+}
+
+.hover\\\\:border-surface-base:hover {
+  border-color: var(--surface-base);
+}
+
+.hover\\\\:border-surface-inner:hover {
+  border-color: var(--surface-inner);
+}
+
+.hover\\\\:border-surface-lg:hover {
+  border-color: var(--surface-lg);
+}
+
+.hover\\\\:border-surface-md:hover {
+  border-color: var(--surface-md);
+}
+
+.hover\\\\:border-surface-xl:hover {
+  border-color: var(--surface-xl);
+}
+
+.hover\\\\:border-text-and-icons:hover {
+  border-color: var(--text-and-icons);
+}
+
+.hover\\\\:border-titles-and-attributes:hover {
+  border-color: var(--titles-and-attributes);
+}
+
+.active\\\\:border-current:active {
+  border-color: currentColor;
+}
+
+.active\\\\:border-transparent:active {
+  border-color: transparent;
+}
+
+.active\\\\:border-falcon:active {
+  border-color: var(--falcon);
+}
+
+.active\\\\:border-basement:active {
+  border-color: var(--basement);
+}
+
+.active\\\\:border-blue:active {
+  border-color: var(--blue);
+}
+
+.active\\\\:border-body-and-labels:active {
+  border-color: var(--body-and-labels);
+}
+
+.active\\\\:border-brand:active {
+  border-color: var(--brand);
+}
+
+.active\\\\:border-code-base-64:active {
+  border-color: var(--code-base-64);
+}
+
+.active\\\\:border-code-bg:active {
+  border-color: var(--code-bg);
+}
+
+.active\\\\:border-code-outline:active {
+  border-color: var(--code-outline);
+}
+
+.active\\\\:border-code-text:active {
+  border-color: var(--code-text);
+}
+
+.active\\\\:border-critical:active {
+  border-color: var(--critical);
+}
+
+.active\\\\:border-destructive-hover:active {
+  border-color: var(--destructive-hover);
+}
+
+.active\\\\:border-destructive-idle:active {
+  border-color: var(--destructive-idle);
+}
+
+.active\\\\:border-destructive-pressed:active {
+  border-color: var(--destructive-pressed);
+}
+
+.active\\\\:border-disabled:active {
+  border-color: var(--disabled);
+}
+
+.active\\\\:border-disc-operations:active {
+  border-color: var(--disc-operations);
+}
+
+.active\\\\:border-dns-requests:active {
+  border-color: var(--dns-requests);
+}
+
+.active\\\\:border-focus:active {
+  border-color: var(--focus);
+}
+
+.active\\\\:border-graph-1:active {
+  border-color: var(--graph-1);
+}
+
+.active\\\\:border-graph-10:active {
+  border-color: var(--graph-10);
+}
+
+.active\\\\:border-graph-11:active {
+  border-color: var(--graph-11);
+}
+
+.active\\\\:border-graph-2:active {
+  border-color: var(--graph-2);
+}
+
+.active\\\\:border-graph-3:active {
+  border-color: var(--graph-3);
+}
+
+.active\\\\:border-graph-4:active {
+  border-color: var(--graph-4);
+}
+
+.active\\\\:border-graph-5:active {
+  border-color: var(--graph-5);
+}
+
+.active\\\\:border-graph-6:active {
+  border-color: var(--graph-6);
+}
+
+.active\\\\:border-graph-7:active {
+  border-color: var(--graph-7);
+}
+
+.active\\\\:border-graph-8:active {
+  border-color: var(--graph-8);
+}
+
+.active\\\\:border-graph-9:active {
+  border-color: var(--graph-9);
+}
+
+.active\\\\:border-graph-disabled:active {
+  border-color: var(--graph-disabled);
+}
+
+.active\\\\:border-ground-floor:active {
+  border-color: var(--ground-floor);
+}
+
+.active\\\\:border-high:active {
+  border-color: var(--high);
+}
+
+.active\\\\:border-informational:active {
+  border-color: var(--informational);
+}
+
+.active\\\\:border-lines-dark:active {
+  border-color: var(--lines-dark);
+}
+
+.active\\\\:border-lines-light:active {
+  border-color: var(--lines-light);
+}
+
+.active\\\\:border-low:active {
+  border-color: var(--low);
+}
+
+.active\\\\:border-medium:active {
+  border-color: var(--medium);
+}
+
+.active\\\\:border-mezzanine:active {
+  border-color: var(--mezzanine);
+}
+
+.active\\\\:border-nav-text-and-icons:active {
+  border-color: var(--nav-text-and-icons);
+}
+
+.active\\\\:border-nav-text-secondary:active {
+  border-color: var(--nav-text-secondary);
+}
+
+.active\\\\:border-network-operations:active {
+  border-color: var(--network-operations);
+}
+
+.active\\\\:border-normal-hover:active {
+  border-color: var(--normal-hover);
+}
+
+.active\\\\:border-normal-idle:active {
+  border-color: var(--normal-idle);
+}
+
+.active\\\\:border-normal-pressed:active {
+  border-color: var(--normal-pressed);
+}
+
+.active\\\\:border-overlay-0\\\\.5:active {
+  border-color: var(--overlay-0\\\\.5);
+}
+
+.active\\\\:border-overlay-1:active {
+  border-color: var(--overlay-1);
+}
+
+.active\\\\:border-overlay-2:active {
+  border-color: var(--overlay-2);
+}
+
+.active\\\\:border-positive:active {
+  border-color: var(--positive);
+}
+
+.active\\\\:border-primary-hover:active {
+  border-color: var(--primary-hover);
+}
+
+.active\\\\:border-primary-idle:active {
+  border-color: var(--primary-idle);
+}
+
+.active\\\\:border-primary-pressed:active {
+  border-color: var(--primary-pressed);
+}
+
+.active\\\\:border-process-operations:active {
+  border-color: var(--process-operations);
+}
+
+.active\\\\:border-purple:active {
+  border-color: var(--purple);
+}
+
+.active\\\\:border-registry-operations:active {
+  border-color: var(--registry-operations);
+}
+
+.active\\\\:border-selected:active {
+  border-color: var(--selected);
+}
+
+.active\\\\:border-surface-2xl:active {
+  border-color: var(--surface-2xl);
+}
+
+.active\\\\:border-surface-base:active {
+  border-color: var(--surface-base);
+}
+
+.active\\\\:border-surface-inner:active {
+  border-color: var(--surface-inner);
+}
+
+.active\\\\:border-surface-lg:active {
+  border-color: var(--surface-lg);
+}
+
+.active\\\\:border-surface-md:active {
+  border-color: var(--surface-md);
+}
+
+.active\\\\:border-surface-xl:active {
+  border-color: var(--surface-xl);
+}
+
+.active\\\\:border-text-and-icons:active {
+  border-color: var(--text-and-icons);
+}
+
+.active\\\\:border-titles-and-attributes:active {
+  border-color: var(--titles-and-attributes);
+}
+
+.border-opacity-0 {
+  --tw-border-opacity: 0;
+}
+
+.border-opacity-5 {
+  --tw-border-opacity: 0.05;
+}
+
+.border-opacity-10 {
+  --tw-border-opacity: 0.1;
+}
+
+.border-opacity-20 {
+  --tw-border-opacity: 0.2;
+}
+
+.border-opacity-25 {
+  --tw-border-opacity: 0.25;
+}
+
+.border-opacity-30 {
+  --tw-border-opacity: 0.3;
+}
+
+.border-opacity-40 {
+  --tw-border-opacity: 0.4;
+}
+
+.border-opacity-50 {
+  --tw-border-opacity: 0.5;
+}
+
+.border-opacity-60 {
+  --tw-border-opacity: 0.6;
+}
+
+.border-opacity-70 {
+  --tw-border-opacity: 0.7;
+}
+
+.border-opacity-75 {
+  --tw-border-opacity: 0.75;
+}
+
+.border-opacity-80 {
+  --tw-border-opacity: 0.8;
+}
+
+.border-opacity-90 {
+  --tw-border-opacity: 0.9;
+}
+
+.border-opacity-95 {
+  --tw-border-opacity: 0.95;
+}
+
+.border-opacity-100 {
+  --tw-border-opacity: 1;
+}
+
+.hover\\\\:border-opacity-0:hover {
+  --tw-border-opacity: 0;
+}
+
+.hover\\\\:border-opacity-5:hover {
+  --tw-border-opacity: 0.05;
+}
+
+.hover\\\\:border-opacity-10:hover {
+  --tw-border-opacity: 0.1;
+}
+
+.hover\\\\:border-opacity-20:hover {
+  --tw-border-opacity: 0.2;
+}
+
+.hover\\\\:border-opacity-25:hover {
+  --tw-border-opacity: 0.25;
+}
+
+.hover\\\\:border-opacity-30:hover {
+  --tw-border-opacity: 0.3;
+}
+
+.hover\\\\:border-opacity-40:hover {
+  --tw-border-opacity: 0.4;
+}
+
+.hover\\\\:border-opacity-50:hover {
+  --tw-border-opacity: 0.5;
+}
+
+.hover\\\\:border-opacity-60:hover {
+  --tw-border-opacity: 0.6;
+}
+
+.hover\\\\:border-opacity-70:hover {
+  --tw-border-opacity: 0.7;
+}
+
+.hover\\\\:border-opacity-75:hover {
+  --tw-border-opacity: 0.75;
+}
+
+.hover\\\\:border-opacity-80:hover {
+  --tw-border-opacity: 0.8;
+}
+
+.hover\\\\:border-opacity-90:hover {
+  --tw-border-opacity: 0.9;
+}
+
+.hover\\\\:border-opacity-95:hover {
+  --tw-border-opacity: 0.95;
+}
+
+.hover\\\\:border-opacity-100:hover {
+  --tw-border-opacity: 1;
+}
+
+.focus\\\\:border-opacity-0:focus {
+  --tw-border-opacity: 0;
+}
+
+.focus\\\\:border-opacity-5:focus {
+  --tw-border-opacity: 0.05;
+}
+
+.focus\\\\:border-opacity-10:focus {
+  --tw-border-opacity: 0.1;
+}
+
+.focus\\\\:border-opacity-20:focus {
+  --tw-border-opacity: 0.2;
+}
+
+.focus\\\\:border-opacity-25:focus {
+  --tw-border-opacity: 0.25;
+}
+
+.focus\\\\:border-opacity-30:focus {
+  --tw-border-opacity: 0.3;
+}
+
+.focus\\\\:border-opacity-40:focus {
+  --tw-border-opacity: 0.4;
+}
+
+.focus\\\\:border-opacity-50:focus {
+  --tw-border-opacity: 0.5;
+}
+
+.focus\\\\:border-opacity-60:focus {
+  --tw-border-opacity: 0.6;
+}
+
+.focus\\\\:border-opacity-70:focus {
+  --tw-border-opacity: 0.7;
+}
+
+.focus\\\\:border-opacity-75:focus {
+  --tw-border-opacity: 0.75;
+}
+
+.focus\\\\:border-opacity-80:focus {
+  --tw-border-opacity: 0.8;
+}
+
+.focus\\\\:border-opacity-90:focus {
+  --tw-border-opacity: 0.9;
+}
+
+.focus\\\\:border-opacity-95:focus {
+  --tw-border-opacity: 0.95;
+}
+
+.focus\\\\:border-opacity-100:focus {
+  --tw-border-opacity: 1;
+}
+
+.bg-current {
+  background-color: currentColor;
+}
+
+.bg-transparent {
+  background-color: transparent;
+}
+
+.bg-falcon {
+  background-color: var(--falcon);
+}
+
+.bg-basement {
+  background-color: var(--basement);
+}
+
+.bg-blue {
+  background-color: var(--blue);
+}
+
+.bg-body-and-labels {
+  background-color: var(--body-and-labels);
+}
+
+.bg-brand {
+  background-color: var(--brand);
+}
+
+.bg-code-base-64 {
+  background-color: var(--code-base-64);
+}
+
+.bg-code-bg {
+  background-color: var(--code-bg);
+}
+
+.bg-code-outline {
+  background-color: var(--code-outline);
+}
+
+.bg-code-text {
+  background-color: var(--code-text);
+}
+
+.bg-critical {
+  background-color: var(--critical);
+}
+
+.bg-destructive-hover {
+  background-color: var(--destructive-hover);
+}
+
+.bg-destructive-idle {
+  background-color: var(--destructive-idle);
+}
+
+.bg-destructive-pressed {
+  background-color: var(--destructive-pressed);
+}
+
+.bg-disabled {
+  background-color: var(--disabled);
+}
+
+.bg-disc-operations {
+  background-color: var(--disc-operations);
+}
+
+.bg-dns-requests {
+  background-color: var(--dns-requests);
+}
+
+.bg-focus {
+  background-color: var(--focus);
+}
+
+.bg-graph-1 {
+  background-color: var(--graph-1);
+}
+
+.bg-graph-10 {
+  background-color: var(--graph-10);
+}
+
+.bg-graph-11 {
+  background-color: var(--graph-11);
+}
+
+.bg-graph-2 {
+  background-color: var(--graph-2);
+}
+
+.bg-graph-3 {
+  background-color: var(--graph-3);
+}
+
+.bg-graph-4 {
+  background-color: var(--graph-4);
+}
+
+.bg-graph-5 {
+  background-color: var(--graph-5);
+}
+
+.bg-graph-6 {
+  background-color: var(--graph-6);
+}
+
+.bg-graph-7 {
+  background-color: var(--graph-7);
+}
+
+.bg-graph-8 {
+  background-color: var(--graph-8);
+}
+
+.bg-graph-9 {
+  background-color: var(--graph-9);
+}
+
+.bg-graph-disabled {
+  background-color: var(--graph-disabled);
+}
+
+.bg-ground-floor {
+  background-color: var(--ground-floor);
+}
+
+.bg-high {
+  background-color: var(--high);
+}
+
+.bg-informational {
+  background-color: var(--informational);
+}
+
+.bg-lines-dark {
+  background-color: var(--lines-dark);
+}
+
+.bg-lines-light {
+  background-color: var(--lines-light);
+}
+
+.bg-low {
+  background-color: var(--low);
+}
+
+.bg-medium {
+  background-color: var(--medium);
+}
+
+.bg-mezzanine {
+  background-color: var(--mezzanine);
+}
+
+.bg-nav-text-and-icons {
+  background-color: var(--nav-text-and-icons);
+}
+
+.bg-nav-text-secondary {
+  background-color: var(--nav-text-secondary);
+}
+
+.bg-network-operations {
+  background-color: var(--network-operations);
+}
+
+.bg-normal-hover {
+  background-color: var(--normal-hover);
+}
+
+.bg-normal-idle {
+  background-color: var(--normal-idle);
+}
+
+.bg-normal-pressed {
+  background-color: var(--normal-pressed);
+}
+
+.bg-overlay-0\\\\.5 {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.bg-overlay-1 {
+  background-color: var(--overlay-1);
+}
+
+.bg-overlay-2 {
+  background-color: var(--overlay-2);
+}
+
+.bg-positive {
+  background-color: var(--positive);
+}
+
+.bg-primary-hover {
+  background-color: var(--primary-hover);
+}
+
+.bg-primary-idle {
+  background-color: var(--primary-idle);
+}
+
+.bg-primary-pressed {
+  background-color: var(--primary-pressed);
+}
+
+.bg-process-operations {
+  background-color: var(--process-operations);
+}
+
+.bg-purple {
+  background-color: var(--purple);
+}
+
+.bg-registry-operations {
+  background-color: var(--registry-operations);
+}
+
+.bg-selected {
+  background-color: var(--selected);
+}
+
+.bg-surface-2xl {
+  background-color: var(--surface-2xl);
+}
+
+.bg-surface-base {
+  background-color: var(--surface-base);
+}
+
+.bg-surface-inner {
+  background-color: var(--surface-inner);
+}
+
+.bg-surface-lg {
+  background-color: var(--surface-lg);
+}
+
+.bg-surface-md {
+  background-color: var(--surface-md);
+}
+
+.bg-surface-xl {
+  background-color: var(--surface-xl);
+}
+
+.bg-text-and-icons {
+  background-color: var(--text-and-icons);
+}
+
+.bg-titles-and-attributes {
+  background-color: var(--titles-and-attributes);
+}
+
+.even\\\\:bg-current:nth-child(even) {
+  background-color: currentColor;
+}
+
+.even\\\\:bg-transparent:nth-child(even) {
+  background-color: transparent;
+}
+
+.even\\\\:bg-falcon:nth-child(even) {
+  background-color: var(--falcon);
+}
+
+.even\\\\:bg-basement:nth-child(even) {
+  background-color: var(--basement);
+}
+
+.even\\\\:bg-blue:nth-child(even) {
+  background-color: var(--blue);
+}
+
+.even\\\\:bg-body-and-labels:nth-child(even) {
+  background-color: var(--body-and-labels);
+}
+
+.even\\\\:bg-brand:nth-child(even) {
+  background-color: var(--brand);
+}
+
+.even\\\\:bg-code-base-64:nth-child(even) {
+  background-color: var(--code-base-64);
+}
+
+.even\\\\:bg-code-bg:nth-child(even) {
+  background-color: var(--code-bg);
+}
+
+.even\\\\:bg-code-outline:nth-child(even) {
+  background-color: var(--code-outline);
+}
+
+.even\\\\:bg-code-text:nth-child(even) {
+  background-color: var(--code-text);
+}
+
+.even\\\\:bg-critical:nth-child(even) {
+  background-color: var(--critical);
+}
+
+.even\\\\:bg-destructive-hover:nth-child(even) {
+  background-color: var(--destructive-hover);
+}
+
+.even\\\\:bg-destructive-idle:nth-child(even) {
+  background-color: var(--destructive-idle);
+}
+
+.even\\\\:bg-destructive-pressed:nth-child(even) {
+  background-color: var(--destructive-pressed);
+}
+
+.even\\\\:bg-disabled:nth-child(even) {
+  background-color: var(--disabled);
+}
+
+.even\\\\:bg-disc-operations:nth-child(even) {
+  background-color: var(--disc-operations);
+}
+
+.even\\\\:bg-dns-requests:nth-child(even) {
+  background-color: var(--dns-requests);
+}
+
+.even\\\\:bg-focus:nth-child(even) {
+  background-color: var(--focus);
+}
+
+.even\\\\:bg-graph-1:nth-child(even) {
+  background-color: var(--graph-1);
+}
+
+.even\\\\:bg-graph-10:nth-child(even) {
+  background-color: var(--graph-10);
+}
+
+.even\\\\:bg-graph-11:nth-child(even) {
+  background-color: var(--graph-11);
+}
+
+.even\\\\:bg-graph-2:nth-child(even) {
+  background-color: var(--graph-2);
+}
+
+.even\\\\:bg-graph-3:nth-child(even) {
+  background-color: var(--graph-3);
+}
+
+.even\\\\:bg-graph-4:nth-child(even) {
+  background-color: var(--graph-4);
+}
+
+.even\\\\:bg-graph-5:nth-child(even) {
+  background-color: var(--graph-5);
+}
+
+.even\\\\:bg-graph-6:nth-child(even) {
+  background-color: var(--graph-6);
+}
+
+.even\\\\:bg-graph-7:nth-child(even) {
+  background-color: var(--graph-7);
+}
+
+.even\\\\:bg-graph-8:nth-child(even) {
+  background-color: var(--graph-8);
+}
+
+.even\\\\:bg-graph-9:nth-child(even) {
+  background-color: var(--graph-9);
+}
+
+.even\\\\:bg-graph-disabled:nth-child(even) {
+  background-color: var(--graph-disabled);
+}
+
+.even\\\\:bg-ground-floor:nth-child(even) {
+  background-color: var(--ground-floor);
+}
+
+.even\\\\:bg-high:nth-child(even) {
+  background-color: var(--high);
+}
+
+.even\\\\:bg-informational:nth-child(even) {
+  background-color: var(--informational);
+}
+
+.even\\\\:bg-lines-dark:nth-child(even) {
+  background-color: var(--lines-dark);
+}
+
+.even\\\\:bg-lines-light:nth-child(even) {
+  background-color: var(--lines-light);
+}
+
+.even\\\\:bg-low:nth-child(even) {
+  background-color: var(--low);
+}
+
+.even\\\\:bg-medium:nth-child(even) {
+  background-color: var(--medium);
+}
+
+.even\\\\:bg-mezzanine:nth-child(even) {
+  background-color: var(--mezzanine);
+}
+
+.even\\\\:bg-nav-text-and-icons:nth-child(even) {
+  background-color: var(--nav-text-and-icons);
+}
+
+.even\\\\:bg-nav-text-secondary:nth-child(even) {
+  background-color: var(--nav-text-secondary);
+}
+
+.even\\\\:bg-network-operations:nth-child(even) {
+  background-color: var(--network-operations);
+}
+
+.even\\\\:bg-normal-hover:nth-child(even) {
+  background-color: var(--normal-hover);
+}
+
+.even\\\\:bg-normal-idle:nth-child(even) {
+  background-color: var(--normal-idle);
+}
+
+.even\\\\:bg-normal-pressed:nth-child(even) {
+  background-color: var(--normal-pressed);
+}
+
+.even\\\\:bg-overlay-0\\\\.5:nth-child(even) {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.even\\\\:bg-overlay-1:nth-child(even) {
+  background-color: var(--overlay-1);
+}
+
+.even\\\\:bg-overlay-2:nth-child(even) {
+  background-color: var(--overlay-2);
+}
+
+.even\\\\:bg-positive:nth-child(even) {
+  background-color: var(--positive);
+}
+
+.even\\\\:bg-primary-hover:nth-child(even) {
+  background-color: var(--primary-hover);
+}
+
+.even\\\\:bg-primary-idle:nth-child(even) {
+  background-color: var(--primary-idle);
+}
+
+.even\\\\:bg-primary-pressed:nth-child(even) {
+  background-color: var(--primary-pressed);
+}
+
+.even\\\\:bg-process-operations:nth-child(even) {
+  background-color: var(--process-operations);
+}
+
+.even\\\\:bg-purple:nth-child(even) {
+  background-color: var(--purple);
+}
+
+.even\\\\:bg-registry-operations:nth-child(even) {
+  background-color: var(--registry-operations);
+}
+
+.even\\\\:bg-selected:nth-child(even) {
+  background-color: var(--selected);
+}
+
+.even\\\\:bg-surface-2xl:nth-child(even) {
+  background-color: var(--surface-2xl);
+}
+
+.even\\\\:bg-surface-base:nth-child(even) {
+  background-color: var(--surface-base);
+}
+
+.even\\\\:bg-surface-inner:nth-child(even) {
+  background-color: var(--surface-inner);
+}
+
+.even\\\\:bg-surface-lg:nth-child(even) {
+  background-color: var(--surface-lg);
+}
+
+.even\\\\:bg-surface-md:nth-child(even) {
+  background-color: var(--surface-md);
+}
+
+.even\\\\:bg-surface-xl:nth-child(even) {
+  background-color: var(--surface-xl);
+}
+
+.even\\\\:bg-text-and-icons:nth-child(even) {
+  background-color: var(--text-and-icons);
+}
+
+.even\\\\:bg-titles-and-attributes:nth-child(even) {
+  background-color: var(--titles-and-attributes);
+}
+
+.group:hover .group-hover\\\\:bg-current {
+  background-color: currentColor;
+}
+
+.group:hover .group-hover\\\\:bg-transparent {
+  background-color: transparent;
+}
+
+.group:hover .group-hover\\\\:bg-falcon {
+  background-color: var(--falcon);
+}
+
+.group:hover .group-hover\\\\:bg-basement {
+  background-color: var(--basement);
+}
+
+.group:hover .group-hover\\\\:bg-blue {
+  background-color: var(--blue);
+}
+
+.group:hover .group-hover\\\\:bg-body-and-labels {
+  background-color: var(--body-and-labels);
+}
+
+.group:hover .group-hover\\\\:bg-brand {
+  background-color: var(--brand);
+}
+
+.group:hover .group-hover\\\\:bg-code-base-64 {
+  background-color: var(--code-base-64);
+}
+
+.group:hover .group-hover\\\\:bg-code-bg {
+  background-color: var(--code-bg);
+}
+
+.group:hover .group-hover\\\\:bg-code-outline {
+  background-color: var(--code-outline);
+}
+
+.group:hover .group-hover\\\\:bg-code-text {
+  background-color: var(--code-text);
+}
+
+.group:hover .group-hover\\\\:bg-critical {
+  background-color: var(--critical);
+}
+
+.group:hover .group-hover\\\\:bg-destructive-hover {
+  background-color: var(--destructive-hover);
+}
+
+.group:hover .group-hover\\\\:bg-destructive-idle {
+  background-color: var(--destructive-idle);
+}
+
+.group:hover .group-hover\\\\:bg-destructive-pressed {
+  background-color: var(--destructive-pressed);
+}
+
+.group:hover .group-hover\\\\:bg-disabled {
+  background-color: var(--disabled);
+}
+
+.group:hover .group-hover\\\\:bg-disc-operations {
+  background-color: var(--disc-operations);
+}
+
+.group:hover .group-hover\\\\:bg-dns-requests {
+  background-color: var(--dns-requests);
+}
+
+.group:hover .group-hover\\\\:bg-focus {
+  background-color: var(--focus);
+}
+
+.group:hover .group-hover\\\\:bg-graph-1 {
+  background-color: var(--graph-1);
+}
+
+.group:hover .group-hover\\\\:bg-graph-10 {
+  background-color: var(--graph-10);
+}
+
+.group:hover .group-hover\\\\:bg-graph-11 {
+  background-color: var(--graph-11);
+}
+
+.group:hover .group-hover\\\\:bg-graph-2 {
+  background-color: var(--graph-2);
+}
+
+.group:hover .group-hover\\\\:bg-graph-3 {
+  background-color: var(--graph-3);
+}
+
+.group:hover .group-hover\\\\:bg-graph-4 {
+  background-color: var(--graph-4);
+}
+
+.group:hover .group-hover\\\\:bg-graph-5 {
+  background-color: var(--graph-5);
+}
+
+.group:hover .group-hover\\\\:bg-graph-6 {
+  background-color: var(--graph-6);
+}
+
+.group:hover .group-hover\\\\:bg-graph-7 {
+  background-color: var(--graph-7);
+}
+
+.group:hover .group-hover\\\\:bg-graph-8 {
+  background-color: var(--graph-8);
+}
+
+.group:hover .group-hover\\\\:bg-graph-9 {
+  background-color: var(--graph-9);
+}
+
+.group:hover .group-hover\\\\:bg-graph-disabled {
+  background-color: var(--graph-disabled);
+}
+
+.group:hover .group-hover\\\\:bg-ground-floor {
+  background-color: var(--ground-floor);
+}
+
+.group:hover .group-hover\\\\:bg-high {
+  background-color: var(--high);
+}
+
+.group:hover .group-hover\\\\:bg-informational {
+  background-color: var(--informational);
+}
+
+.group:hover .group-hover\\\\:bg-lines-dark {
+  background-color: var(--lines-dark);
+}
+
+.group:hover .group-hover\\\\:bg-lines-light {
+  background-color: var(--lines-light);
+}
+
+.group:hover .group-hover\\\\:bg-low {
+  background-color: var(--low);
+}
+
+.group:hover .group-hover\\\\:bg-medium {
+  background-color: var(--medium);
+}
+
+.group:hover .group-hover\\\\:bg-mezzanine {
+  background-color: var(--mezzanine);
+}
+
+.group:hover .group-hover\\\\:bg-nav-text-and-icons {
+  background-color: var(--nav-text-and-icons);
+}
+
+.group:hover .group-hover\\\\:bg-nav-text-secondary {
+  background-color: var(--nav-text-secondary);
+}
+
+.group:hover .group-hover\\\\:bg-network-operations {
+  background-color: var(--network-operations);
+}
+
+.group:hover .group-hover\\\\:bg-normal-hover {
+  background-color: var(--normal-hover);
+}
+
+.group:hover .group-hover\\\\:bg-normal-idle {
+  background-color: var(--normal-idle);
+}
+
+.group:hover .group-hover\\\\:bg-normal-pressed {
+  background-color: var(--normal-pressed);
+}
+
+.group:hover .group-hover\\\\:bg-overlay-0\\\\.5 {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.group:hover .group-hover\\\\:bg-overlay-1 {
+  background-color: var(--overlay-1);
+}
+
+.group:hover .group-hover\\\\:bg-overlay-2 {
+  background-color: var(--overlay-2);
+}
+
+.group:hover .group-hover\\\\:bg-positive {
+  background-color: var(--positive);
+}
+
+.group:hover .group-hover\\\\:bg-primary-hover {
+  background-color: var(--primary-hover);
+}
+
+.group:hover .group-hover\\\\:bg-primary-idle {
+  background-color: var(--primary-idle);
+}
+
+.group:hover .group-hover\\\\:bg-primary-pressed {
+  background-color: var(--primary-pressed);
+}
+
+.group:hover .group-hover\\\\:bg-process-operations {
+  background-color: var(--process-operations);
+}
+
+.group:hover .group-hover\\\\:bg-purple {
+  background-color: var(--purple);
+}
+
+.group:hover .group-hover\\\\:bg-registry-operations {
+  background-color: var(--registry-operations);
+}
+
+.group:hover .group-hover\\\\:bg-selected {
+  background-color: var(--selected);
+}
+
+.group:hover .group-hover\\\\:bg-surface-2xl {
+  background-color: var(--surface-2xl);
+}
+
+.group:hover .group-hover\\\\:bg-surface-base {
+  background-color: var(--surface-base);
+}
+
+.group:hover .group-hover\\\\:bg-surface-inner {
+  background-color: var(--surface-inner);
+}
+
+.group:hover .group-hover\\\\:bg-surface-lg {
+  background-color: var(--surface-lg);
+}
+
+.group:hover .group-hover\\\\:bg-surface-md {
+  background-color: var(--surface-md);
+}
+
+.group:hover .group-hover\\\\:bg-surface-xl {
+  background-color: var(--surface-xl);
+}
+
+.group:hover .group-hover\\\\:bg-text-and-icons {
+  background-color: var(--text-and-icons);
+}
+
+.group:hover .group-hover\\\\:bg-titles-and-attributes {
+  background-color: var(--titles-and-attributes);
+}
+
+.hover\\\\:bg-current:hover {
+  background-color: currentColor;
+}
+
+.hover\\\\:bg-transparent:hover {
+  background-color: transparent;
+}
+
+.hover\\\\:bg-falcon:hover {
+  background-color: var(--falcon);
+}
+
+.hover\\\\:bg-basement:hover {
+  background-color: var(--basement);
+}
+
+.hover\\\\:bg-blue:hover {
+  background-color: var(--blue);
+}
+
+.hover\\\\:bg-body-and-labels:hover {
+  background-color: var(--body-and-labels);
+}
+
+.hover\\\\:bg-brand:hover {
+  background-color: var(--brand);
+}
+
+.hover\\\\:bg-code-base-64:hover {
+  background-color: var(--code-base-64);
+}
+
+.hover\\\\:bg-code-bg:hover {
+  background-color: var(--code-bg);
+}
+
+.hover\\\\:bg-code-outline:hover {
+  background-color: var(--code-outline);
+}
+
+.hover\\\\:bg-code-text:hover {
+  background-color: var(--code-text);
+}
+
+.hover\\\\:bg-critical:hover {
+  background-color: var(--critical);
+}
+
+.hover\\\\:bg-destructive-hover:hover {
+  background-color: var(--destructive-hover);
+}
+
+.hover\\\\:bg-destructive-idle:hover {
+  background-color: var(--destructive-idle);
+}
+
+.hover\\\\:bg-destructive-pressed:hover {
+  background-color: var(--destructive-pressed);
+}
+
+.hover\\\\:bg-disabled:hover {
+  background-color: var(--disabled);
+}
+
+.hover\\\\:bg-disc-operations:hover {
+  background-color: var(--disc-operations);
+}
+
+.hover\\\\:bg-dns-requests:hover {
+  background-color: var(--dns-requests);
+}
+
+.hover\\\\:bg-focus:hover {
+  background-color: var(--focus);
+}
+
+.hover\\\\:bg-graph-1:hover {
+  background-color: var(--graph-1);
+}
+
+.hover\\\\:bg-graph-10:hover {
+  background-color: var(--graph-10);
+}
+
+.hover\\\\:bg-graph-11:hover {
+  background-color: var(--graph-11);
+}
+
+.hover\\\\:bg-graph-2:hover {
+  background-color: var(--graph-2);
+}
+
+.hover\\\\:bg-graph-3:hover {
+  background-color: var(--graph-3);
+}
+
+.hover\\\\:bg-graph-4:hover {
+  background-color: var(--graph-4);
+}
+
+.hover\\\\:bg-graph-5:hover {
+  background-color: var(--graph-5);
+}
+
+.hover\\\\:bg-graph-6:hover {
+  background-color: var(--graph-6);
+}
+
+.hover\\\\:bg-graph-7:hover {
+  background-color: var(--graph-7);
+}
+
+.hover\\\\:bg-graph-8:hover {
+  background-color: var(--graph-8);
+}
+
+.hover\\\\:bg-graph-9:hover {
+  background-color: var(--graph-9);
+}
+
+.hover\\\\:bg-graph-disabled:hover {
+  background-color: var(--graph-disabled);
+}
+
+.hover\\\\:bg-ground-floor:hover {
+  background-color: var(--ground-floor);
+}
+
+.hover\\\\:bg-high:hover {
+  background-color: var(--high);
+}
+
+.hover\\\\:bg-informational:hover {
+  background-color: var(--informational);
+}
+
+.hover\\\\:bg-lines-dark:hover {
+  background-color: var(--lines-dark);
+}
+
+.hover\\\\:bg-lines-light:hover {
+  background-color: var(--lines-light);
+}
+
+.hover\\\\:bg-low:hover {
+  background-color: var(--low);
+}
+
+.hover\\\\:bg-medium:hover {
+  background-color: var(--medium);
+}
+
+.hover\\\\:bg-mezzanine:hover {
+  background-color: var(--mezzanine);
+}
+
+.hover\\\\:bg-nav-text-and-icons:hover {
+  background-color: var(--nav-text-and-icons);
+}
+
+.hover\\\\:bg-nav-text-secondary:hover {
+  background-color: var(--nav-text-secondary);
+}
+
+.hover\\\\:bg-network-operations:hover {
+  background-color: var(--network-operations);
+}
+
+.hover\\\\:bg-normal-hover:hover {
+  background-color: var(--normal-hover);
+}
+
+.hover\\\\:bg-normal-idle:hover {
+  background-color: var(--normal-idle);
+}
+
+.hover\\\\:bg-normal-pressed:hover {
+  background-color: var(--normal-pressed);
+}
+
+.hover\\\\:bg-overlay-0\\\\.5:hover {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.hover\\\\:bg-overlay-1:hover {
+  background-color: var(--overlay-1);
+}
+
+.hover\\\\:bg-overlay-2:hover {
+  background-color: var(--overlay-2);
+}
+
+.hover\\\\:bg-positive:hover {
+  background-color: var(--positive);
+}
+
+.hover\\\\:bg-primary-hover:hover {
+  background-color: var(--primary-hover);
+}
+
+.hover\\\\:bg-primary-idle:hover {
+  background-color: var(--primary-idle);
+}
+
+.hover\\\\:bg-primary-pressed:hover {
+  background-color: var(--primary-pressed);
+}
+
+.hover\\\\:bg-process-operations:hover {
+  background-color: var(--process-operations);
+}
+
+.hover\\\\:bg-purple:hover {
+  background-color: var(--purple);
+}
+
+.hover\\\\:bg-registry-operations:hover {
+  background-color: var(--registry-operations);
+}
+
+.hover\\\\:bg-selected:hover {
+  background-color: var(--selected);
+}
+
+.hover\\\\:bg-surface-2xl:hover {
+  background-color: var(--surface-2xl);
+}
+
+.hover\\\\:bg-surface-base:hover {
+  background-color: var(--surface-base);
+}
+
+.hover\\\\:bg-surface-inner:hover {
+  background-color: var(--surface-inner);
+}
+
+.hover\\\\:bg-surface-lg:hover {
+  background-color: var(--surface-lg);
+}
+
+.hover\\\\:bg-surface-md:hover {
+  background-color: var(--surface-md);
+}
+
+.hover\\\\:bg-surface-xl:hover {
+  background-color: var(--surface-xl);
+}
+
+.hover\\\\:bg-text-and-icons:hover {
+  background-color: var(--text-and-icons);
+}
+
+.hover\\\\:bg-titles-and-attributes:hover {
+  background-color: var(--titles-and-attributes);
+}
+
+.focus\\\\:bg-current:focus {
+  background-color: currentColor;
+}
+
+.focus\\\\:bg-transparent:focus {
+  background-color: transparent;
+}
+
+.focus\\\\:bg-falcon:focus {
+  background-color: var(--falcon);
+}
+
+.focus\\\\:bg-basement:focus {
+  background-color: var(--basement);
+}
+
+.focus\\\\:bg-blue:focus {
+  background-color: var(--blue);
+}
+
+.focus\\\\:bg-body-and-labels:focus {
+  background-color: var(--body-and-labels);
+}
+
+.focus\\\\:bg-brand:focus {
+  background-color: var(--brand);
+}
+
+.focus\\\\:bg-code-base-64:focus {
+  background-color: var(--code-base-64);
+}
+
+.focus\\\\:bg-code-bg:focus {
+  background-color: var(--code-bg);
+}
+
+.focus\\\\:bg-code-outline:focus {
+  background-color: var(--code-outline);
+}
+
+.focus\\\\:bg-code-text:focus {
+  background-color: var(--code-text);
+}
+
+.focus\\\\:bg-critical:focus {
+  background-color: var(--critical);
+}
+
+.focus\\\\:bg-destructive-hover:focus {
+  background-color: var(--destructive-hover);
+}
+
+.focus\\\\:bg-destructive-idle:focus {
+  background-color: var(--destructive-idle);
+}
+
+.focus\\\\:bg-destructive-pressed:focus {
+  background-color: var(--destructive-pressed);
+}
+
+.focus\\\\:bg-disabled:focus {
+  background-color: var(--disabled);
+}
+
+.focus\\\\:bg-disc-operations:focus {
+  background-color: var(--disc-operations);
+}
+
+.focus\\\\:bg-dns-requests:focus {
+  background-color: var(--dns-requests);
+}
+
+.focus\\\\:bg-focus:focus {
+  background-color: var(--focus);
+}
+
+.focus\\\\:bg-graph-1:focus {
+  background-color: var(--graph-1);
+}
+
+.focus\\\\:bg-graph-10:focus {
+  background-color: var(--graph-10);
+}
+
+.focus\\\\:bg-graph-11:focus {
+  background-color: var(--graph-11);
+}
+
+.focus\\\\:bg-graph-2:focus {
+  background-color: var(--graph-2);
+}
+
+.focus\\\\:bg-graph-3:focus {
+  background-color: var(--graph-3);
+}
+
+.focus\\\\:bg-graph-4:focus {
+  background-color: var(--graph-4);
+}
+
+.focus\\\\:bg-graph-5:focus {
+  background-color: var(--graph-5);
+}
+
+.focus\\\\:bg-graph-6:focus {
+  background-color: var(--graph-6);
+}
+
+.focus\\\\:bg-graph-7:focus {
+  background-color: var(--graph-7);
+}
+
+.focus\\\\:bg-graph-8:focus {
+  background-color: var(--graph-8);
+}
+
+.focus\\\\:bg-graph-9:focus {
+  background-color: var(--graph-9);
+}
+
+.focus\\\\:bg-graph-disabled:focus {
+  background-color: var(--graph-disabled);
+}
+
+.focus\\\\:bg-ground-floor:focus {
+  background-color: var(--ground-floor);
+}
+
+.focus\\\\:bg-high:focus {
+  background-color: var(--high);
+}
+
+.focus\\\\:bg-informational:focus {
+  background-color: var(--informational);
+}
+
+.focus\\\\:bg-lines-dark:focus {
+  background-color: var(--lines-dark);
+}
+
+.focus\\\\:bg-lines-light:focus {
+  background-color: var(--lines-light);
+}
+
+.focus\\\\:bg-low:focus {
+  background-color: var(--low);
+}
+
+.focus\\\\:bg-medium:focus {
+  background-color: var(--medium);
+}
+
+.focus\\\\:bg-mezzanine:focus {
+  background-color: var(--mezzanine);
+}
+
+.focus\\\\:bg-nav-text-and-icons:focus {
+  background-color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:bg-nav-text-secondary:focus {
+  background-color: var(--nav-text-secondary);
+}
+
+.focus\\\\:bg-network-operations:focus {
+  background-color: var(--network-operations);
+}
+
+.focus\\\\:bg-normal-hover:focus {
+  background-color: var(--normal-hover);
+}
+
+.focus\\\\:bg-normal-idle:focus {
+  background-color: var(--normal-idle);
+}
+
+.focus\\\\:bg-normal-pressed:focus {
+  background-color: var(--normal-pressed);
+}
+
+.focus\\\\:bg-overlay-0\\\\.5:focus {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:bg-overlay-1:focus {
+  background-color: var(--overlay-1);
+}
+
+.focus\\\\:bg-overlay-2:focus {
+  background-color: var(--overlay-2);
+}
+
+.focus\\\\:bg-positive:focus {
+  background-color: var(--positive);
+}
+
+.focus\\\\:bg-primary-hover:focus {
+  background-color: var(--primary-hover);
+}
+
+.focus\\\\:bg-primary-idle:focus {
+  background-color: var(--primary-idle);
+}
+
+.focus\\\\:bg-primary-pressed:focus {
+  background-color: var(--primary-pressed);
+}
+
+.focus\\\\:bg-process-operations:focus {
+  background-color: var(--process-operations);
+}
+
+.focus\\\\:bg-purple:focus {
+  background-color: var(--purple);
+}
+
+.focus\\\\:bg-registry-operations:focus {
+  background-color: var(--registry-operations);
+}
+
+.focus\\\\:bg-selected:focus {
+  background-color: var(--selected);
+}
+
+.focus\\\\:bg-surface-2xl:focus {
+  background-color: var(--surface-2xl);
+}
+
+.focus\\\\:bg-surface-base:focus {
+  background-color: var(--surface-base);
+}
+
+.focus\\\\:bg-surface-inner:focus {
+  background-color: var(--surface-inner);
+}
+
+.focus\\\\:bg-surface-lg:focus {
+  background-color: var(--surface-lg);
+}
+
+.focus\\\\:bg-surface-md:focus {
+  background-color: var(--surface-md);
+}
+
+.focus\\\\:bg-surface-xl:focus {
+  background-color: var(--surface-xl);
+}
+
+.focus\\\\:bg-text-and-icons:focus {
+  background-color: var(--text-and-icons);
+}
+
+.focus\\\\:bg-titles-and-attributes:focus {
+  background-color: var(--titles-and-attributes);
+}
+
+.focus-within\\\\:bg-current:focus-within {
+  background-color: currentColor;
+}
+
+.focus-within\\\\:bg-transparent:focus-within {
+  background-color: transparent;
+}
+
+.focus-within\\\\:bg-falcon:focus-within {
+  background-color: var(--falcon);
+}
+
+.focus-within\\\\:bg-basement:focus-within {
+  background-color: var(--basement);
+}
+
+.focus-within\\\\:bg-blue:focus-within {
+  background-color: var(--blue);
+}
+
+.focus-within\\\\:bg-body-and-labels:focus-within {
+  background-color: var(--body-and-labels);
+}
+
+.focus-within\\\\:bg-brand:focus-within {
+  background-color: var(--brand);
+}
+
+.focus-within\\\\:bg-code-base-64:focus-within {
+  background-color: var(--code-base-64);
+}
+
+.focus-within\\\\:bg-code-bg:focus-within {
+  background-color: var(--code-bg);
+}
+
+.focus-within\\\\:bg-code-outline:focus-within {
+  background-color: var(--code-outline);
+}
+
+.focus-within\\\\:bg-code-text:focus-within {
+  background-color: var(--code-text);
+}
+
+.focus-within\\\\:bg-critical:focus-within {
+  background-color: var(--critical);
+}
+
+.focus-within\\\\:bg-destructive-hover:focus-within {
+  background-color: var(--destructive-hover);
+}
+
+.focus-within\\\\:bg-destructive-idle:focus-within {
+  background-color: var(--destructive-idle);
+}
+
+.focus-within\\\\:bg-destructive-pressed:focus-within {
+  background-color: var(--destructive-pressed);
+}
+
+.focus-within\\\\:bg-disabled:focus-within {
+  background-color: var(--disabled);
+}
+
+.focus-within\\\\:bg-disc-operations:focus-within {
+  background-color: var(--disc-operations);
+}
+
+.focus-within\\\\:bg-dns-requests:focus-within {
+  background-color: var(--dns-requests);
+}
+
+.focus-within\\\\:bg-focus:focus-within {
+  background-color: var(--focus);
+}
+
+.focus-within\\\\:bg-graph-1:focus-within {
+  background-color: var(--graph-1);
+}
+
+.focus-within\\\\:bg-graph-10:focus-within {
+  background-color: var(--graph-10);
+}
+
+.focus-within\\\\:bg-graph-11:focus-within {
+  background-color: var(--graph-11);
+}
+
+.focus-within\\\\:bg-graph-2:focus-within {
+  background-color: var(--graph-2);
+}
+
+.focus-within\\\\:bg-graph-3:focus-within {
+  background-color: var(--graph-3);
+}
+
+.focus-within\\\\:bg-graph-4:focus-within {
+  background-color: var(--graph-4);
+}
+
+.focus-within\\\\:bg-graph-5:focus-within {
+  background-color: var(--graph-5);
+}
+
+.focus-within\\\\:bg-graph-6:focus-within {
+  background-color: var(--graph-6);
+}
+
+.focus-within\\\\:bg-graph-7:focus-within {
+  background-color: var(--graph-7);
+}
+
+.focus-within\\\\:bg-graph-8:focus-within {
+  background-color: var(--graph-8);
+}
+
+.focus-within\\\\:bg-graph-9:focus-within {
+  background-color: var(--graph-9);
+}
+
+.focus-within\\\\:bg-graph-disabled:focus-within {
+  background-color: var(--graph-disabled);
+}
+
+.focus-within\\\\:bg-ground-floor:focus-within {
+  background-color: var(--ground-floor);
+}
+
+.focus-within\\\\:bg-high:focus-within {
+  background-color: var(--high);
+}
+
+.focus-within\\\\:bg-informational:focus-within {
+  background-color: var(--informational);
+}
+
+.focus-within\\\\:bg-lines-dark:focus-within {
+  background-color: var(--lines-dark);
+}
+
+.focus-within\\\\:bg-lines-light:focus-within {
+  background-color: var(--lines-light);
+}
+
+.focus-within\\\\:bg-low:focus-within {
+  background-color: var(--low);
+}
+
+.focus-within\\\\:bg-medium:focus-within {
+  background-color: var(--medium);
+}
+
+.focus-within\\\\:bg-mezzanine:focus-within {
+  background-color: var(--mezzanine);
+}
+
+.focus-within\\\\:bg-nav-text-and-icons:focus-within {
+  background-color: var(--nav-text-and-icons);
+}
+
+.focus-within\\\\:bg-nav-text-secondary:focus-within {
+  background-color: var(--nav-text-secondary);
+}
+
+.focus-within\\\\:bg-network-operations:focus-within {
+  background-color: var(--network-operations);
+}
+
+.focus-within\\\\:bg-normal-hover:focus-within {
+  background-color: var(--normal-hover);
+}
+
+.focus-within\\\\:bg-normal-idle:focus-within {
+  background-color: var(--normal-idle);
+}
+
+.focus-within\\\\:bg-normal-pressed:focus-within {
+  background-color: var(--normal-pressed);
+}
+
+.focus-within\\\\:bg-overlay-0\\\\.5:focus-within {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.focus-within\\\\:bg-overlay-1:focus-within {
+  background-color: var(--overlay-1);
+}
+
+.focus-within\\\\:bg-overlay-2:focus-within {
+  background-color: var(--overlay-2);
+}
+
+.focus-within\\\\:bg-positive:focus-within {
+  background-color: var(--positive);
+}
+
+.focus-within\\\\:bg-primary-hover:focus-within {
+  background-color: var(--primary-hover);
+}
+
+.focus-within\\\\:bg-primary-idle:focus-within {
+  background-color: var(--primary-idle);
+}
+
+.focus-within\\\\:bg-primary-pressed:focus-within {
+  background-color: var(--primary-pressed);
+}
+
+.focus-within\\\\:bg-process-operations:focus-within {
+  background-color: var(--process-operations);
+}
+
+.focus-within\\\\:bg-purple:focus-within {
+  background-color: var(--purple);
+}
+
+.focus-within\\\\:bg-registry-operations:focus-within {
+  background-color: var(--registry-operations);
+}
+
+.focus-within\\\\:bg-selected:focus-within {
+  background-color: var(--selected);
+}
+
+.focus-within\\\\:bg-surface-2xl:focus-within {
+  background-color: var(--surface-2xl);
+}
+
+.focus-within\\\\:bg-surface-base:focus-within {
+  background-color: var(--surface-base);
+}
+
+.focus-within\\\\:bg-surface-inner:focus-within {
+  background-color: var(--surface-inner);
+}
+
+.focus-within\\\\:bg-surface-lg:focus-within {
+  background-color: var(--surface-lg);
+}
+
+.focus-within\\\\:bg-surface-md:focus-within {
+  background-color: var(--surface-md);
+}
+
+.focus-within\\\\:bg-surface-xl:focus-within {
+  background-color: var(--surface-xl);
+}
+
+.focus-within\\\\:bg-text-and-icons:focus-within {
+  background-color: var(--text-and-icons);
+}
+
+.focus-within\\\\:bg-titles-and-attributes:focus-within {
+  background-color: var(--titles-and-attributes);
+}
+
+.focus-visible\\\\:bg-current:focus-visible {
+  background-color: currentColor;
+}
+
+.focus-visible\\\\:bg-transparent:focus-visible {
+  background-color: transparent;
+}
+
+.focus-visible\\\\:bg-falcon:focus-visible {
+  background-color: var(--falcon);
+}
+
+.focus-visible\\\\:bg-basement:focus-visible {
+  background-color: var(--basement);
+}
+
+.focus-visible\\\\:bg-blue:focus-visible {
+  background-color: var(--blue);
+}
+
+.focus-visible\\\\:bg-body-and-labels:focus-visible {
+  background-color: var(--body-and-labels);
+}
+
+.focus-visible\\\\:bg-brand:focus-visible {
+  background-color: var(--brand);
+}
+
+.focus-visible\\\\:bg-code-base-64:focus-visible {
+  background-color: var(--code-base-64);
+}
+
+.focus-visible\\\\:bg-code-bg:focus-visible {
+  background-color: var(--code-bg);
+}
+
+.focus-visible\\\\:bg-code-outline:focus-visible {
+  background-color: var(--code-outline);
+}
+
+.focus-visible\\\\:bg-code-text:focus-visible {
+  background-color: var(--code-text);
+}
+
+.focus-visible\\\\:bg-critical:focus-visible {
+  background-color: var(--critical);
+}
+
+.focus-visible\\\\:bg-destructive-hover:focus-visible {
+  background-color: var(--destructive-hover);
+}
+
+.focus-visible\\\\:bg-destructive-idle:focus-visible {
+  background-color: var(--destructive-idle);
+}
+
+.focus-visible\\\\:bg-destructive-pressed:focus-visible {
+  background-color: var(--destructive-pressed);
+}
+
+.focus-visible\\\\:bg-disabled:focus-visible {
+  background-color: var(--disabled);
+}
+
+.focus-visible\\\\:bg-disc-operations:focus-visible {
+  background-color: var(--disc-operations);
+}
+
+.focus-visible\\\\:bg-dns-requests:focus-visible {
+  background-color: var(--dns-requests);
+}
+
+.focus-visible\\\\:bg-focus:focus-visible {
+  background-color: var(--focus);
+}
+
+.focus-visible\\\\:bg-graph-1:focus-visible {
+  background-color: var(--graph-1);
+}
+
+.focus-visible\\\\:bg-graph-10:focus-visible {
+  background-color: var(--graph-10);
+}
+
+.focus-visible\\\\:bg-graph-11:focus-visible {
+  background-color: var(--graph-11);
+}
+
+.focus-visible\\\\:bg-graph-2:focus-visible {
+  background-color: var(--graph-2);
+}
+
+.focus-visible\\\\:bg-graph-3:focus-visible {
+  background-color: var(--graph-3);
+}
+
+.focus-visible\\\\:bg-graph-4:focus-visible {
+  background-color: var(--graph-4);
+}
+
+.focus-visible\\\\:bg-graph-5:focus-visible {
+  background-color: var(--graph-5);
+}
+
+.focus-visible\\\\:bg-graph-6:focus-visible {
+  background-color: var(--graph-6);
+}
+
+.focus-visible\\\\:bg-graph-7:focus-visible {
+  background-color: var(--graph-7);
+}
+
+.focus-visible\\\\:bg-graph-8:focus-visible {
+  background-color: var(--graph-8);
+}
+
+.focus-visible\\\\:bg-graph-9:focus-visible {
+  background-color: var(--graph-9);
+}
+
+.focus-visible\\\\:bg-graph-disabled:focus-visible {
+  background-color: var(--graph-disabled);
+}
+
+.focus-visible\\\\:bg-ground-floor:focus-visible {
+  background-color: var(--ground-floor);
+}
+
+.focus-visible\\\\:bg-high:focus-visible {
+  background-color: var(--high);
+}
+
+.focus-visible\\\\:bg-informational:focus-visible {
+  background-color: var(--informational);
+}
+
+.focus-visible\\\\:bg-lines-dark:focus-visible {
+  background-color: var(--lines-dark);
+}
+
+.focus-visible\\\\:bg-lines-light:focus-visible {
+  background-color: var(--lines-light);
+}
+
+.focus-visible\\\\:bg-low:focus-visible {
+  background-color: var(--low);
+}
+
+.focus-visible\\\\:bg-medium:focus-visible {
+  background-color: var(--medium);
+}
+
+.focus-visible\\\\:bg-mezzanine:focus-visible {
+  background-color: var(--mezzanine);
+}
+
+.focus-visible\\\\:bg-nav-text-and-icons:focus-visible {
+  background-color: var(--nav-text-and-icons);
+}
+
+.focus-visible\\\\:bg-nav-text-secondary:focus-visible {
+  background-color: var(--nav-text-secondary);
+}
+
+.focus-visible\\\\:bg-network-operations:focus-visible {
+  background-color: var(--network-operations);
+}
+
+.focus-visible\\\\:bg-normal-hover:focus-visible {
+  background-color: var(--normal-hover);
+}
+
+.focus-visible\\\\:bg-normal-idle:focus-visible {
+  background-color: var(--normal-idle);
+}
+
+.focus-visible\\\\:bg-normal-pressed:focus-visible {
+  background-color: var(--normal-pressed);
+}
+
+.focus-visible\\\\:bg-overlay-0\\\\.5:focus-visible {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.focus-visible\\\\:bg-overlay-1:focus-visible {
+  background-color: var(--overlay-1);
+}
+
+.focus-visible\\\\:bg-overlay-2:focus-visible {
+  background-color: var(--overlay-2);
+}
+
+.focus-visible\\\\:bg-positive:focus-visible {
+  background-color: var(--positive);
+}
+
+.focus-visible\\\\:bg-primary-hover:focus-visible {
+  background-color: var(--primary-hover);
+}
+
+.focus-visible\\\\:bg-primary-idle:focus-visible {
+  background-color: var(--primary-idle);
+}
+
+.focus-visible\\\\:bg-primary-pressed:focus-visible {
+  background-color: var(--primary-pressed);
+}
+
+.focus-visible\\\\:bg-process-operations:focus-visible {
+  background-color: var(--process-operations);
+}
+
+.focus-visible\\\\:bg-purple:focus-visible {
+  background-color: var(--purple);
+}
+
+.focus-visible\\\\:bg-registry-operations:focus-visible {
+  background-color: var(--registry-operations);
+}
+
+.focus-visible\\\\:bg-selected:focus-visible {
+  background-color: var(--selected);
+}
+
+.focus-visible\\\\:bg-surface-2xl:focus-visible {
+  background-color: var(--surface-2xl);
+}
+
+.focus-visible\\\\:bg-surface-base:focus-visible {
+  background-color: var(--surface-base);
+}
+
+.focus-visible\\\\:bg-surface-inner:focus-visible {
+  background-color: var(--surface-inner);
+}
+
+.focus-visible\\\\:bg-surface-lg:focus-visible {
+  background-color: var(--surface-lg);
+}
+
+.focus-visible\\\\:bg-surface-md:focus-visible {
+  background-color: var(--surface-md);
+}
+
+.focus-visible\\\\:bg-surface-xl:focus-visible {
+  background-color: var(--surface-xl);
+}
+
+.focus-visible\\\\:bg-text-and-icons:focus-visible {
+  background-color: var(--text-and-icons);
+}
+
+.focus-visible\\\\:bg-titles-and-attributes:focus-visible {
+  background-color: var(--titles-and-attributes);
+}
+
+.active\\\\:bg-current:active {
+  background-color: currentColor;
+}
+
+.active\\\\:bg-transparent:active {
+  background-color: transparent;
+}
+
+.active\\\\:bg-falcon:active {
+  background-color: var(--falcon);
+}
+
+.active\\\\:bg-basement:active {
+  background-color: var(--basement);
+}
+
+.active\\\\:bg-blue:active {
+  background-color: var(--blue);
+}
+
+.active\\\\:bg-body-and-labels:active {
+  background-color: var(--body-and-labels);
+}
+
+.active\\\\:bg-brand:active {
+  background-color: var(--brand);
+}
+
+.active\\\\:bg-code-base-64:active {
+  background-color: var(--code-base-64);
+}
+
+.active\\\\:bg-code-bg:active {
+  background-color: var(--code-bg);
+}
+
+.active\\\\:bg-code-outline:active {
+  background-color: var(--code-outline);
+}
+
+.active\\\\:bg-code-text:active {
+  background-color: var(--code-text);
+}
+
+.active\\\\:bg-critical:active {
+  background-color: var(--critical);
+}
+
+.active\\\\:bg-destructive-hover:active {
+  background-color: var(--destructive-hover);
+}
+
+.active\\\\:bg-destructive-idle:active {
+  background-color: var(--destructive-idle);
+}
+
+.active\\\\:bg-destructive-pressed:active {
+  background-color: var(--destructive-pressed);
+}
+
+.active\\\\:bg-disabled:active {
+  background-color: var(--disabled);
+}
+
+.active\\\\:bg-disc-operations:active {
+  background-color: var(--disc-operations);
+}
+
+.active\\\\:bg-dns-requests:active {
+  background-color: var(--dns-requests);
+}
+
+.active\\\\:bg-focus:active {
+  background-color: var(--focus);
+}
+
+.active\\\\:bg-graph-1:active {
+  background-color: var(--graph-1);
+}
+
+.active\\\\:bg-graph-10:active {
+  background-color: var(--graph-10);
+}
+
+.active\\\\:bg-graph-11:active {
+  background-color: var(--graph-11);
+}
+
+.active\\\\:bg-graph-2:active {
+  background-color: var(--graph-2);
+}
+
+.active\\\\:bg-graph-3:active {
+  background-color: var(--graph-3);
+}
+
+.active\\\\:bg-graph-4:active {
+  background-color: var(--graph-4);
+}
+
+.active\\\\:bg-graph-5:active {
+  background-color: var(--graph-5);
+}
+
+.active\\\\:bg-graph-6:active {
+  background-color: var(--graph-6);
+}
+
+.active\\\\:bg-graph-7:active {
+  background-color: var(--graph-7);
+}
+
+.active\\\\:bg-graph-8:active {
+  background-color: var(--graph-8);
+}
+
+.active\\\\:bg-graph-9:active {
+  background-color: var(--graph-9);
+}
+
+.active\\\\:bg-graph-disabled:active {
+  background-color: var(--graph-disabled);
+}
+
+.active\\\\:bg-ground-floor:active {
+  background-color: var(--ground-floor);
+}
+
+.active\\\\:bg-high:active {
+  background-color: var(--high);
+}
+
+.active\\\\:bg-informational:active {
+  background-color: var(--informational);
+}
+
+.active\\\\:bg-lines-dark:active {
+  background-color: var(--lines-dark);
+}
+
+.active\\\\:bg-lines-light:active {
+  background-color: var(--lines-light);
+}
+
+.active\\\\:bg-low:active {
+  background-color: var(--low);
+}
+
+.active\\\\:bg-medium:active {
+  background-color: var(--medium);
+}
+
+.active\\\\:bg-mezzanine:active {
+  background-color: var(--mezzanine);
+}
+
+.active\\\\:bg-nav-text-and-icons:active {
+  background-color: var(--nav-text-and-icons);
+}
+
+.active\\\\:bg-nav-text-secondary:active {
+  background-color: var(--nav-text-secondary);
+}
+
+.active\\\\:bg-network-operations:active {
+  background-color: var(--network-operations);
+}
+
+.active\\\\:bg-normal-hover:active {
+  background-color: var(--normal-hover);
+}
+
+.active\\\\:bg-normal-idle:active {
+  background-color: var(--normal-idle);
+}
+
+.active\\\\:bg-normal-pressed:active {
+  background-color: var(--normal-pressed);
+}
+
+.active\\\\:bg-overlay-0\\\\.5:active {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.active\\\\:bg-overlay-1:active {
+  background-color: var(--overlay-1);
+}
+
+.active\\\\:bg-overlay-2:active {
+  background-color: var(--overlay-2);
+}
+
+.active\\\\:bg-positive:active {
+  background-color: var(--positive);
+}
+
+.active\\\\:bg-primary-hover:active {
+  background-color: var(--primary-hover);
+}
+
+.active\\\\:bg-primary-idle:active {
+  background-color: var(--primary-idle);
+}
+
+.active\\\\:bg-primary-pressed:active {
+  background-color: var(--primary-pressed);
+}
+
+.active\\\\:bg-process-operations:active {
+  background-color: var(--process-operations);
+}
+
+.active\\\\:bg-purple:active {
+  background-color: var(--purple);
+}
+
+.active\\\\:bg-registry-operations:active {
+  background-color: var(--registry-operations);
+}
+
+.active\\\\:bg-selected:active {
+  background-color: var(--selected);
+}
+
+.active\\\\:bg-surface-2xl:active {
+  background-color: var(--surface-2xl);
+}
+
+.active\\\\:bg-surface-base:active {
+  background-color: var(--surface-base);
+}
+
+.active\\\\:bg-surface-inner:active {
+  background-color: var(--surface-inner);
+}
+
+.active\\\\:bg-surface-lg:active {
+  background-color: var(--surface-lg);
+}
+
+.active\\\\:bg-surface-md:active {
+  background-color: var(--surface-md);
+}
+
+.active\\\\:bg-surface-xl:active {
+  background-color: var(--surface-xl);
+}
+
+.active\\\\:bg-text-and-icons:active {
+  background-color: var(--text-and-icons);
+}
+
+.active\\\\:bg-titles-and-attributes:active {
+  background-color: var(--titles-and-attributes);
+}
+
+.disabled\\\\:bg-current:disabled {
+  background-color: currentColor;
+}
+
+.disabled\\\\:bg-transparent:disabled {
+  background-color: transparent;
+}
+
+.disabled\\\\:bg-falcon:disabled {
+  background-color: var(--falcon);
+}
+
+.disabled\\\\:bg-basement:disabled {
+  background-color: var(--basement);
+}
+
+.disabled\\\\:bg-blue:disabled {
+  background-color: var(--blue);
+}
+
+.disabled\\\\:bg-body-and-labels:disabled {
+  background-color: var(--body-and-labels);
+}
+
+.disabled\\\\:bg-brand:disabled {
+  background-color: var(--brand);
+}
+
+.disabled\\\\:bg-code-base-64:disabled {
+  background-color: var(--code-base-64);
+}
+
+.disabled\\\\:bg-code-bg:disabled {
+  background-color: var(--code-bg);
+}
+
+.disabled\\\\:bg-code-outline:disabled {
+  background-color: var(--code-outline);
+}
+
+.disabled\\\\:bg-code-text:disabled {
+  background-color: var(--code-text);
+}
+
+.disabled\\\\:bg-critical:disabled {
+  background-color: var(--critical);
+}
+
+.disabled\\\\:bg-destructive-hover:disabled {
+  background-color: var(--destructive-hover);
+}
+
+.disabled\\\\:bg-destructive-idle:disabled {
+  background-color: var(--destructive-idle);
+}
+
+.disabled\\\\:bg-destructive-pressed:disabled {
+  background-color: var(--destructive-pressed);
+}
+
+.disabled\\\\:bg-disabled:disabled {
+  background-color: var(--disabled);
+}
+
+.disabled\\\\:bg-disc-operations:disabled {
+  background-color: var(--disc-operations);
+}
+
+.disabled\\\\:bg-dns-requests:disabled {
+  background-color: var(--dns-requests);
+}
+
+.disabled\\\\:bg-focus:disabled {
+  background-color: var(--focus);
+}
+
+.disabled\\\\:bg-graph-1:disabled {
+  background-color: var(--graph-1);
+}
+
+.disabled\\\\:bg-graph-10:disabled {
+  background-color: var(--graph-10);
+}
+
+.disabled\\\\:bg-graph-11:disabled {
+  background-color: var(--graph-11);
+}
+
+.disabled\\\\:bg-graph-2:disabled {
+  background-color: var(--graph-2);
+}
+
+.disabled\\\\:bg-graph-3:disabled {
+  background-color: var(--graph-3);
+}
+
+.disabled\\\\:bg-graph-4:disabled {
+  background-color: var(--graph-4);
+}
+
+.disabled\\\\:bg-graph-5:disabled {
+  background-color: var(--graph-5);
+}
+
+.disabled\\\\:bg-graph-6:disabled {
+  background-color: var(--graph-6);
+}
+
+.disabled\\\\:bg-graph-7:disabled {
+  background-color: var(--graph-7);
+}
+
+.disabled\\\\:bg-graph-8:disabled {
+  background-color: var(--graph-8);
+}
+
+.disabled\\\\:bg-graph-9:disabled {
+  background-color: var(--graph-9);
+}
+
+.disabled\\\\:bg-graph-disabled:disabled {
+  background-color: var(--graph-disabled);
+}
+
+.disabled\\\\:bg-ground-floor:disabled {
+  background-color: var(--ground-floor);
+}
+
+.disabled\\\\:bg-high:disabled {
+  background-color: var(--high);
+}
+
+.disabled\\\\:bg-informational:disabled {
+  background-color: var(--informational);
+}
+
+.disabled\\\\:bg-lines-dark:disabled {
+  background-color: var(--lines-dark);
+}
+
+.disabled\\\\:bg-lines-light:disabled {
+  background-color: var(--lines-light);
+}
+
+.disabled\\\\:bg-low:disabled {
+  background-color: var(--low);
+}
+
+.disabled\\\\:bg-medium:disabled {
+  background-color: var(--medium);
+}
+
+.disabled\\\\:bg-mezzanine:disabled {
+  background-color: var(--mezzanine);
+}
+
+.disabled\\\\:bg-nav-text-and-icons:disabled {
+  background-color: var(--nav-text-and-icons);
+}
+
+.disabled\\\\:bg-nav-text-secondary:disabled {
+  background-color: var(--nav-text-secondary);
+}
+
+.disabled\\\\:bg-network-operations:disabled {
+  background-color: var(--network-operations);
+}
+
+.disabled\\\\:bg-normal-hover:disabled {
+  background-color: var(--normal-hover);
+}
+
+.disabled\\\\:bg-normal-idle:disabled {
+  background-color: var(--normal-idle);
+}
+
+.disabled\\\\:bg-normal-pressed:disabled {
+  background-color: var(--normal-pressed);
+}
+
+.disabled\\\\:bg-overlay-0\\\\.5:disabled {
+  background-color: var(--overlay-0\\\\.5);
+}
+
+.disabled\\\\:bg-overlay-1:disabled {
+  background-color: var(--overlay-1);
+}
+
+.disabled\\\\:bg-overlay-2:disabled {
+  background-color: var(--overlay-2);
+}
+
+.disabled\\\\:bg-positive:disabled {
+  background-color: var(--positive);
+}
+
+.disabled\\\\:bg-primary-hover:disabled {
+  background-color: var(--primary-hover);
+}
+
+.disabled\\\\:bg-primary-idle:disabled {
+  background-color: var(--primary-idle);
+}
+
+.disabled\\\\:bg-primary-pressed:disabled {
+  background-color: var(--primary-pressed);
+}
+
+.disabled\\\\:bg-process-operations:disabled {
+  background-color: var(--process-operations);
+}
+
+.disabled\\\\:bg-purple:disabled {
+  background-color: var(--purple);
+}
+
+.disabled\\\\:bg-registry-operations:disabled {
+  background-color: var(--registry-operations);
+}
+
+.disabled\\\\:bg-selected:disabled {
+  background-color: var(--selected);
+}
+
+.disabled\\\\:bg-surface-2xl:disabled {
+  background-color: var(--surface-2xl);
+}
+
+.disabled\\\\:bg-surface-base:disabled {
+  background-color: var(--surface-base);
+}
+
+.disabled\\\\:bg-surface-inner:disabled {
+  background-color: var(--surface-inner);
+}
+
+.disabled\\\\:bg-surface-lg:disabled {
+  background-color: var(--surface-lg);
+}
+
+.disabled\\\\:bg-surface-md:disabled {
+  background-color: var(--surface-md);
+}
+
+.disabled\\\\:bg-surface-xl:disabled {
+  background-color: var(--surface-xl);
+}
+
+.disabled\\\\:bg-text-and-icons:disabled {
+  background-color: var(--text-and-icons);
+}
+
+.disabled\\\\:bg-titles-and-attributes:disabled {
+  background-color: var(--titles-and-attributes);
+}
+
+.bg-opacity-0 {
+  --tw-bg-opacity: 0;
+}
+
+.bg-opacity-5 {
+  --tw-bg-opacity: 0.05;
+}
+
+.bg-opacity-10 {
+  --tw-bg-opacity: 0.1;
+}
+
+.bg-opacity-20 {
+  --tw-bg-opacity: 0.2;
+}
+
+.bg-opacity-25 {
+  --tw-bg-opacity: 0.25;
+}
+
+.bg-opacity-30 {
+  --tw-bg-opacity: 0.3;
+}
+
+.bg-opacity-40 {
+  --tw-bg-opacity: 0.4;
+}
+
+.bg-opacity-50 {
+  --tw-bg-opacity: 0.5;
+}
+
+.bg-opacity-60 {
+  --tw-bg-opacity: 0.6;
+}
+
+.bg-opacity-70 {
+  --tw-bg-opacity: 0.7;
+}
+
+.bg-opacity-75 {
+  --tw-bg-opacity: 0.75;
+}
+
+.bg-opacity-80 {
+  --tw-bg-opacity: 0.8;
+}
+
+.bg-opacity-90 {
+  --tw-bg-opacity: 0.9;
+}
+
+.bg-opacity-95 {
+  --tw-bg-opacity: 0.95;
+}
+
+.bg-opacity-100 {
+  --tw-bg-opacity: 1;
+}
+
+.hover\\\\:bg-opacity-0:hover {
+  --tw-bg-opacity: 0;
+}
+
+.hover\\\\:bg-opacity-5:hover {
+  --tw-bg-opacity: 0.05;
+}
+
+.hover\\\\:bg-opacity-10:hover {
+  --tw-bg-opacity: 0.1;
+}
+
+.hover\\\\:bg-opacity-20:hover {
+  --tw-bg-opacity: 0.2;
+}
+
+.hover\\\\:bg-opacity-25:hover {
+  --tw-bg-opacity: 0.25;
+}
+
+.hover\\\\:bg-opacity-30:hover {
+  --tw-bg-opacity: 0.3;
+}
+
+.hover\\\\:bg-opacity-40:hover {
+  --tw-bg-opacity: 0.4;
+}
+
+.hover\\\\:bg-opacity-50:hover {
+  --tw-bg-opacity: 0.5;
+}
+
+.hover\\\\:bg-opacity-60:hover {
+  --tw-bg-opacity: 0.6;
+}
+
+.hover\\\\:bg-opacity-70:hover {
+  --tw-bg-opacity: 0.7;
+}
+
+.hover\\\\:bg-opacity-75:hover {
+  --tw-bg-opacity: 0.75;
+}
+
+.hover\\\\:bg-opacity-80:hover {
+  --tw-bg-opacity: 0.8;
+}
+
+.hover\\\\:bg-opacity-90:hover {
+  --tw-bg-opacity: 0.9;
+}
+
+.hover\\\\:bg-opacity-95:hover {
+  --tw-bg-opacity: 0.95;
+}
+
+.hover\\\\:bg-opacity-100:hover {
+  --tw-bg-opacity: 1;
+}
+
+.focus\\\\:bg-opacity-0:focus {
+  --tw-bg-opacity: 0;
+}
+
+.focus\\\\:bg-opacity-5:focus {
+  --tw-bg-opacity: 0.05;
+}
+
+.focus\\\\:bg-opacity-10:focus {
+  --tw-bg-opacity: 0.1;
+}
+
+.focus\\\\:bg-opacity-20:focus {
+  --tw-bg-opacity: 0.2;
+}
+
+.focus\\\\:bg-opacity-25:focus {
+  --tw-bg-opacity: 0.25;
+}
+
+.focus\\\\:bg-opacity-30:focus {
+  --tw-bg-opacity: 0.3;
+}
+
+.focus\\\\:bg-opacity-40:focus {
+  --tw-bg-opacity: 0.4;
+}
+
+.focus\\\\:bg-opacity-50:focus {
+  --tw-bg-opacity: 0.5;
+}
+
+.focus\\\\:bg-opacity-60:focus {
+  --tw-bg-opacity: 0.6;
+}
+
+.focus\\\\:bg-opacity-70:focus {
+  --tw-bg-opacity: 0.7;
+}
+
+.focus\\\\:bg-opacity-75:focus {
+  --tw-bg-opacity: 0.75;
+}
+
+.focus\\\\:bg-opacity-80:focus {
+  --tw-bg-opacity: 0.8;
+}
+
+.focus\\\\:bg-opacity-90:focus {
+  --tw-bg-opacity: 0.9;
+}
+
+.focus\\\\:bg-opacity-95:focus {
+  --tw-bg-opacity: 0.95;
+}
+
+.focus\\\\:bg-opacity-100:focus {
+  --tw-bg-opacity: 1;
+}
+
+.bg-none {
+  background-image: none;
+}
+
+.bg-gradient-to-t {
+  background-image: linear-gradient(to top, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-tr {
+  background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-r {
+  background-image: linear-gradient(to right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-br {
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-b {
+  background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-bl {
+  background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-l {
+  background-image: linear-gradient(to left, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-tl {
+  background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+}
+
+.from-current {
+  --tw-gradient-from: currentColor;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-transparent {
+  --tw-gradient-from: transparent;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.from-falcon {
+  --tw-gradient-from: var(--falcon);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-basement {
+  --tw-gradient-from: var(--basement);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-blue {
+  --tw-gradient-from: var(--blue);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-body-and-labels {
+  --tw-gradient-from: var(--body-and-labels);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-brand {
+  --tw-gradient-from: var(--brand);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-code-base-64 {
+  --tw-gradient-from: var(--code-base-64);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-code-bg {
+  --tw-gradient-from: var(--code-bg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-code-outline {
+  --tw-gradient-from: var(--code-outline);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-code-text {
+  --tw-gradient-from: var(--code-text);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-critical {
+  --tw-gradient-from: var(--critical);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-destructive-hover {
+  --tw-gradient-from: var(--destructive-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-destructive-idle {
+  --tw-gradient-from: var(--destructive-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-destructive-pressed {
+  --tw-gradient-from: var(--destructive-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-disabled {
+  --tw-gradient-from: var(--disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-disc-operations {
+  --tw-gradient-from: var(--disc-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-dns-requests {
+  --tw-gradient-from: var(--dns-requests);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-focus {
+  --tw-gradient-from: var(--focus);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-1 {
+  --tw-gradient-from: var(--graph-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-10 {
+  --tw-gradient-from: var(--graph-10);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-11 {
+  --tw-gradient-from: var(--graph-11);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-2 {
+  --tw-gradient-from: var(--graph-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-3 {
+  --tw-gradient-from: var(--graph-3);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-4 {
+  --tw-gradient-from: var(--graph-4);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-5 {
+  --tw-gradient-from: var(--graph-5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-6 {
+  --tw-gradient-from: var(--graph-6);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-7 {
+  --tw-gradient-from: var(--graph-7);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-8 {
+  --tw-gradient-from: var(--graph-8);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-9 {
+  --tw-gradient-from: var(--graph-9);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-graph-disabled {
+  --tw-gradient-from: var(--graph-disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-ground-floor {
+  --tw-gradient-from: var(--ground-floor);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-high {
+  --tw-gradient-from: var(--high);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-informational {
+  --tw-gradient-from: var(--informational);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-lines-dark {
+  --tw-gradient-from: var(--lines-dark);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-lines-light {
+  --tw-gradient-from: var(--lines-light);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-low {
+  --tw-gradient-from: var(--low);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-medium {
+  --tw-gradient-from: var(--medium);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-mezzanine {
+  --tw-gradient-from: var(--mezzanine);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-nav-text-and-icons {
+  --tw-gradient-from: var(--nav-text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-nav-text-secondary {
+  --tw-gradient-from: var(--nav-text-secondary);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-network-operations {
+  --tw-gradient-from: var(--network-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-normal-hover {
+  --tw-gradient-from: var(--normal-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-normal-idle {
+  --tw-gradient-from: var(--normal-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-normal-pressed {
+  --tw-gradient-from: var(--normal-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-overlay-0\\\\.5 {
+  --tw-gradient-from: var(--overlay-0\\\\.5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-overlay-1 {
+  --tw-gradient-from: var(--overlay-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-overlay-2 {
+  --tw-gradient-from: var(--overlay-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-positive {
+  --tw-gradient-from: var(--positive);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-primary-hover {
+  --tw-gradient-from: var(--primary-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-primary-idle {
+  --tw-gradient-from: var(--primary-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-primary-pressed {
+  --tw-gradient-from: var(--primary-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-process-operations {
+  --tw-gradient-from: var(--process-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-purple {
+  --tw-gradient-from: var(--purple);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-registry-operations {
+  --tw-gradient-from: var(--registry-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-selected {
+  --tw-gradient-from: var(--selected);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-2xl {
+  --tw-gradient-from: var(--surface-2xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-base {
+  --tw-gradient-from: var(--surface-base);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-inner {
+  --tw-gradient-from: var(--surface-inner);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-lg {
+  --tw-gradient-from: var(--surface-lg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-md {
+  --tw-gradient-from: var(--surface-md);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-surface-xl {
+  --tw-gradient-from: var(--surface-xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-text-and-icons {
+  --tw-gradient-from: var(--text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.from-titles-and-attributes {
+  --tw-gradient-from: var(--titles-and-attributes);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-current:hover {
+  --tw-gradient-from: currentColor;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-transparent:hover {
+  --tw-gradient-from: transparent;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.hover\\\\:from-falcon:hover {
+  --tw-gradient-from: var(--falcon);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-basement:hover {
+  --tw-gradient-from: var(--basement);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-blue:hover {
+  --tw-gradient-from: var(--blue);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-body-and-labels:hover {
+  --tw-gradient-from: var(--body-and-labels);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-brand:hover {
+  --tw-gradient-from: var(--brand);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-code-base-64:hover {
+  --tw-gradient-from: var(--code-base-64);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-code-bg:hover {
+  --tw-gradient-from: var(--code-bg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-code-outline:hover {
+  --tw-gradient-from: var(--code-outline);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-code-text:hover {
+  --tw-gradient-from: var(--code-text);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-critical:hover {
+  --tw-gradient-from: var(--critical);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-destructive-hover:hover {
+  --tw-gradient-from: var(--destructive-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-destructive-idle:hover {
+  --tw-gradient-from: var(--destructive-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-destructive-pressed:hover {
+  --tw-gradient-from: var(--destructive-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-disabled:hover {
+  --tw-gradient-from: var(--disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-disc-operations:hover {
+  --tw-gradient-from: var(--disc-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-dns-requests:hover {
+  --tw-gradient-from: var(--dns-requests);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-focus:hover {
+  --tw-gradient-from: var(--focus);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-1:hover {
+  --tw-gradient-from: var(--graph-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-10:hover {
+  --tw-gradient-from: var(--graph-10);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-11:hover {
+  --tw-gradient-from: var(--graph-11);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-2:hover {
+  --tw-gradient-from: var(--graph-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-3:hover {
+  --tw-gradient-from: var(--graph-3);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-4:hover {
+  --tw-gradient-from: var(--graph-4);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-5:hover {
+  --tw-gradient-from: var(--graph-5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-6:hover {
+  --tw-gradient-from: var(--graph-6);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-7:hover {
+  --tw-gradient-from: var(--graph-7);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-8:hover {
+  --tw-gradient-from: var(--graph-8);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-9:hover {
+  --tw-gradient-from: var(--graph-9);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-graph-disabled:hover {
+  --tw-gradient-from: var(--graph-disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-ground-floor:hover {
+  --tw-gradient-from: var(--ground-floor);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-high:hover {
+  --tw-gradient-from: var(--high);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-informational:hover {
+  --tw-gradient-from: var(--informational);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-lines-dark:hover {
+  --tw-gradient-from: var(--lines-dark);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-lines-light:hover {
+  --tw-gradient-from: var(--lines-light);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-low:hover {
+  --tw-gradient-from: var(--low);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-medium:hover {
+  --tw-gradient-from: var(--medium);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-mezzanine:hover {
+  --tw-gradient-from: var(--mezzanine);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-nav-text-and-icons:hover {
+  --tw-gradient-from: var(--nav-text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-nav-text-secondary:hover {
+  --tw-gradient-from: var(--nav-text-secondary);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-network-operations:hover {
+  --tw-gradient-from: var(--network-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-normal-hover:hover {
+  --tw-gradient-from: var(--normal-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-normal-idle:hover {
+  --tw-gradient-from: var(--normal-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-normal-pressed:hover {
+  --tw-gradient-from: var(--normal-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-overlay-0\\\\.5:hover {
+  --tw-gradient-from: var(--overlay-0\\\\.5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-overlay-1:hover {
+  --tw-gradient-from: var(--overlay-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-overlay-2:hover {
+  --tw-gradient-from: var(--overlay-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-positive:hover {
+  --tw-gradient-from: var(--positive);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-primary-hover:hover {
+  --tw-gradient-from: var(--primary-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-primary-idle:hover {
+  --tw-gradient-from: var(--primary-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-primary-pressed:hover {
+  --tw-gradient-from: var(--primary-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-process-operations:hover {
+  --tw-gradient-from: var(--process-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-purple:hover {
+  --tw-gradient-from: var(--purple);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-registry-operations:hover {
+  --tw-gradient-from: var(--registry-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-selected:hover {
+  --tw-gradient-from: var(--selected);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-2xl:hover {
+  --tw-gradient-from: var(--surface-2xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-base:hover {
+  --tw-gradient-from: var(--surface-base);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-inner:hover {
+  --tw-gradient-from: var(--surface-inner);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-lg:hover {
+  --tw-gradient-from: var(--surface-lg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-md:hover {
+  --tw-gradient-from: var(--surface-md);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-surface-xl:hover {
+  --tw-gradient-from: var(--surface-xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-text-and-icons:hover {
+  --tw-gradient-from: var(--text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:from-titles-and-attributes:hover {
+  --tw-gradient-from: var(--titles-and-attributes);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-current:focus {
+  --tw-gradient-from: currentColor;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-transparent:focus {
+  --tw-gradient-from: transparent;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.focus\\\\:from-falcon:focus {
+  --tw-gradient-from: var(--falcon);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-basement:focus {
+  --tw-gradient-from: var(--basement);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-blue:focus {
+  --tw-gradient-from: var(--blue);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-body-and-labels:focus {
+  --tw-gradient-from: var(--body-and-labels);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-brand:focus {
+  --tw-gradient-from: var(--brand);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-code-base-64:focus {
+  --tw-gradient-from: var(--code-base-64);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-code-bg:focus {
+  --tw-gradient-from: var(--code-bg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-code-outline:focus {
+  --tw-gradient-from: var(--code-outline);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-code-text:focus {
+  --tw-gradient-from: var(--code-text);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-critical:focus {
+  --tw-gradient-from: var(--critical);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-destructive-hover:focus {
+  --tw-gradient-from: var(--destructive-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-destructive-idle:focus {
+  --tw-gradient-from: var(--destructive-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-destructive-pressed:focus {
+  --tw-gradient-from: var(--destructive-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-disabled:focus {
+  --tw-gradient-from: var(--disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-disc-operations:focus {
+  --tw-gradient-from: var(--disc-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-dns-requests:focus {
+  --tw-gradient-from: var(--dns-requests);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-focus:focus {
+  --tw-gradient-from: var(--focus);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-1:focus {
+  --tw-gradient-from: var(--graph-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-10:focus {
+  --tw-gradient-from: var(--graph-10);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-11:focus {
+  --tw-gradient-from: var(--graph-11);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-2:focus {
+  --tw-gradient-from: var(--graph-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-3:focus {
+  --tw-gradient-from: var(--graph-3);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-4:focus {
+  --tw-gradient-from: var(--graph-4);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-5:focus {
+  --tw-gradient-from: var(--graph-5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-6:focus {
+  --tw-gradient-from: var(--graph-6);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-7:focus {
+  --tw-gradient-from: var(--graph-7);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-8:focus {
+  --tw-gradient-from: var(--graph-8);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-9:focus {
+  --tw-gradient-from: var(--graph-9);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-graph-disabled:focus {
+  --tw-gradient-from: var(--graph-disabled);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-ground-floor:focus {
+  --tw-gradient-from: var(--ground-floor);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-high:focus {
+  --tw-gradient-from: var(--high);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-informational:focus {
+  --tw-gradient-from: var(--informational);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-lines-dark:focus {
+  --tw-gradient-from: var(--lines-dark);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-lines-light:focus {
+  --tw-gradient-from: var(--lines-light);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-low:focus {
+  --tw-gradient-from: var(--low);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-medium:focus {
+  --tw-gradient-from: var(--medium);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-mezzanine:focus {
+  --tw-gradient-from: var(--mezzanine);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-nav-text-and-icons:focus {
+  --tw-gradient-from: var(--nav-text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-nav-text-secondary:focus {
+  --tw-gradient-from: var(--nav-text-secondary);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-network-operations:focus {
+  --tw-gradient-from: var(--network-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-normal-hover:focus {
+  --tw-gradient-from: var(--normal-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-normal-idle:focus {
+  --tw-gradient-from: var(--normal-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-normal-pressed:focus {
+  --tw-gradient-from: var(--normal-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-overlay-0\\\\.5:focus {
+  --tw-gradient-from: var(--overlay-0\\\\.5);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-overlay-1:focus {
+  --tw-gradient-from: var(--overlay-1);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-overlay-2:focus {
+  --tw-gradient-from: var(--overlay-2);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-positive:focus {
+  --tw-gradient-from: var(--positive);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-primary-hover:focus {
+  --tw-gradient-from: var(--primary-hover);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-primary-idle:focus {
+  --tw-gradient-from: var(--primary-idle);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-primary-pressed:focus {
+  --tw-gradient-from: var(--primary-pressed);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-process-operations:focus {
+  --tw-gradient-from: var(--process-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-purple:focus {
+  --tw-gradient-from: var(--purple);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-registry-operations:focus {
+  --tw-gradient-from: var(--registry-operations);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-selected:focus {
+  --tw-gradient-from: var(--selected);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-2xl:focus {
+  --tw-gradient-from: var(--surface-2xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-base:focus {
+  --tw-gradient-from: var(--surface-base);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-inner:focus {
+  --tw-gradient-from: var(--surface-inner);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-lg:focus {
+  --tw-gradient-from: var(--surface-lg);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-md:focus {
+  --tw-gradient-from: var(--surface-md);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-surface-xl:focus {
+  --tw-gradient-from: var(--surface-xl);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-text-and-icons:focus {
+  --tw-gradient-from: var(--text-and-icons);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:from-titles-and-attributes:focus {
+  --tw-gradient-from: var(--titles-and-attributes);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-current {
+  --tw-gradient-stops: var(--tw-gradient-from), currentColor, var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-transparent {
+  --tw-gradient-stops: var(--tw-gradient-from), transparent, var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.via-falcon {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--falcon), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-basement {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--basement), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-blue {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--blue), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-body-and-labels {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--body-and-labels), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-brand {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--brand), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-code-base-64 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-base-64), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-code-bg {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-bg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-code-outline {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-outline), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-code-text {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-text), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-critical {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--critical), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-destructive-hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-destructive-idle {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-destructive-pressed {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-disabled {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-disc-operations {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disc-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-dns-requests {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--dns-requests), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--focus), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-1 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-10 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-10), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-11 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-11), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-2 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-3 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-3), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-4 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-4), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-5 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-6 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-6), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-7 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-7), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-8 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-8), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-9 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-9), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-graph-disabled {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-ground-floor {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--ground-floor), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-high {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--high), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-informational {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--informational), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-lines-dark {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-dark), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-lines-light {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-light), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-low {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--low), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-medium {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--medium), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-mezzanine {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--mezzanine), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-nav-text-and-icons {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-nav-text-secondary {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-secondary), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-network-operations {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--network-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-normal-hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-normal-idle {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-normal-pressed {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-overlay-0\\\\.5 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-0\\\\.5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-overlay-1 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-overlay-2 {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-positive {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--positive), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-primary-hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-primary-idle {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-primary-pressed {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-process-operations {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--process-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-purple {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--purple), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-registry-operations {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--registry-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-selected {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--selected), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-2xl {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-2xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-base {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-base), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-inner {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-inner), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-lg {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-lg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-md {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-md), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-surface-xl {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-text-and-icons {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.via-titles-and-attributes {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--titles-and-attributes), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-current:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), currentColor, var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-transparent:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), transparent, var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.hover\\\\:via-falcon:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--falcon), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-basement:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--basement), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-blue:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--blue), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-body-and-labels:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--body-and-labels), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-brand:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--brand), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-code-base-64:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-base-64), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-code-bg:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-bg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-code-outline:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-outline), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-code-text:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-text), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-critical:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--critical), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-destructive-hover:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-destructive-idle:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-destructive-pressed:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-disabled:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-disc-operations:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disc-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-dns-requests:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--dns-requests), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-focus:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--focus), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-1:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-10:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-10), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-11:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-11), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-2:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-3:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-3), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-4:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-4), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-5:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-6:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-6), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-7:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-7), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-8:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-8), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-9:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-9), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-graph-disabled:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-ground-floor:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--ground-floor), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-high:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--high), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-informational:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--informational), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-lines-dark:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-dark), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-lines-light:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-light), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-low:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--low), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-medium:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--medium), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-mezzanine:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--mezzanine), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-nav-text-and-icons:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-nav-text-secondary:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-secondary), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-network-operations:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--network-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-normal-hover:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-normal-idle:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-normal-pressed:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-overlay-0\\\\.5:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-0\\\\.5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-overlay-1:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-overlay-2:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-positive:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--positive), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-primary-hover:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-primary-idle:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-primary-pressed:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-process-operations:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--process-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-purple:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--purple), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-registry-operations:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--registry-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-selected:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--selected), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-2xl:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-2xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-base:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-base), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-inner:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-inner), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-lg:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-lg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-md:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-md), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-surface-xl:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-text-and-icons:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.hover\\\\:via-titles-and-attributes:hover {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--titles-and-attributes), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-current:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), currentColor, var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-transparent:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), transparent, var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.focus\\\\:via-falcon:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--falcon), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-basement:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--basement), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-blue:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--blue), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-body-and-labels:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--body-and-labels), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-brand:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--brand), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-code-base-64:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-base-64), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-code-bg:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-bg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-code-outline:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-outline), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-code-text:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--code-text), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-critical:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--critical), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-destructive-hover:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-destructive-idle:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-destructive-pressed:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--destructive-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-disabled:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-disc-operations:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--disc-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-dns-requests:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--dns-requests), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-focus:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--focus), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-1:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-10:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-10), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-11:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-11), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-2:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-3:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-3), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-4:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-4), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-5:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-6:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-6), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-7:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-7), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-8:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-8), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-9:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-9), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-graph-disabled:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--graph-disabled), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-ground-floor:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--ground-floor), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-high:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--high), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-informational:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--informational), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-lines-dark:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-dark), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-lines-light:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--lines-light), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-low:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--low), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-medium:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--medium), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-mezzanine:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--mezzanine), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-nav-text-and-icons:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-nav-text-secondary:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--nav-text-secondary), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-network-operations:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--network-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-normal-hover:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-normal-idle:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-normal-pressed:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--normal-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-overlay-0\\\\.5:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-0\\\\.5), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-overlay-1:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-1), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-overlay-2:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--overlay-2), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-positive:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--positive), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-primary-hover:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-hover), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-primary-idle:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-idle), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-primary-pressed:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--primary-pressed), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-process-operations:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--process-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-purple:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--purple), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-registry-operations:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--registry-operations), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-selected:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--selected), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-2xl:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-2xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-base:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-base), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-inner:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-inner), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-lg:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-lg), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-md:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-md), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-surface-xl:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--surface-xl), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-text-and-icons:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--text-and-icons), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.focus\\\\:via-titles-and-attributes:focus {
+  --tw-gradient-stops: var(--tw-gradient-from), var(--titles-and-attributes), var(--tw-gradient-to, rgba(255, 255, 255, 0));
+}
+
+.to-current {
+  --tw-gradient-to: currentColor;
+}
+
+.to-transparent {
+  --tw-gradient-to: transparent;
+}
+
+.to-falcon {
+  --tw-gradient-to: var(--falcon);
+}
+
+.to-basement {
+  --tw-gradient-to: var(--basement);
+}
+
+.to-blue {
+  --tw-gradient-to: var(--blue);
+}
+
+.to-body-and-labels {
+  --tw-gradient-to: var(--body-and-labels);
+}
+
+.to-brand {
+  --tw-gradient-to: var(--brand);
+}
+
+.to-code-base-64 {
+  --tw-gradient-to: var(--code-base-64);
+}
+
+.to-code-bg {
+  --tw-gradient-to: var(--code-bg);
+}
+
+.to-code-outline {
+  --tw-gradient-to: var(--code-outline);
+}
+
+.to-code-text {
+  --tw-gradient-to: var(--code-text);
+}
+
+.to-critical {
+  --tw-gradient-to: var(--critical);
+}
+
+.to-destructive-hover {
+  --tw-gradient-to: var(--destructive-hover);
+}
+
+.to-destructive-idle {
+  --tw-gradient-to: var(--destructive-idle);
+}
+
+.to-destructive-pressed {
+  --tw-gradient-to: var(--destructive-pressed);
+}
+
+.to-disabled {
+  --tw-gradient-to: var(--disabled);
+}
+
+.to-disc-operations {
+  --tw-gradient-to: var(--disc-operations);
+}
+
+.to-dns-requests {
+  --tw-gradient-to: var(--dns-requests);
+}
+
+.to-focus {
+  --tw-gradient-to: var(--focus);
+}
+
+.to-graph-1 {
+  --tw-gradient-to: var(--graph-1);
+}
+
+.to-graph-10 {
+  --tw-gradient-to: var(--graph-10);
+}
+
+.to-graph-11 {
+  --tw-gradient-to: var(--graph-11);
+}
+
+.to-graph-2 {
+  --tw-gradient-to: var(--graph-2);
+}
+
+.to-graph-3 {
+  --tw-gradient-to: var(--graph-3);
+}
+
+.to-graph-4 {
+  --tw-gradient-to: var(--graph-4);
+}
+
+.to-graph-5 {
+  --tw-gradient-to: var(--graph-5);
+}
+
+.to-graph-6 {
+  --tw-gradient-to: var(--graph-6);
+}
+
+.to-graph-7 {
+  --tw-gradient-to: var(--graph-7);
+}
+
+.to-graph-8 {
+  --tw-gradient-to: var(--graph-8);
+}
+
+.to-graph-9 {
+  --tw-gradient-to: var(--graph-9);
+}
+
+.to-graph-disabled {
+  --tw-gradient-to: var(--graph-disabled);
+}
+
+.to-ground-floor {
+  --tw-gradient-to: var(--ground-floor);
+}
+
+.to-high {
+  --tw-gradient-to: var(--high);
+}
+
+.to-informational {
+  --tw-gradient-to: var(--informational);
+}
+
+.to-lines-dark {
+  --tw-gradient-to: var(--lines-dark);
+}
+
+.to-lines-light {
+  --tw-gradient-to: var(--lines-light);
+}
+
+.to-low {
+  --tw-gradient-to: var(--low);
+}
+
+.to-medium {
+  --tw-gradient-to: var(--medium);
+}
+
+.to-mezzanine {
+  --tw-gradient-to: var(--mezzanine);
+}
+
+.to-nav-text-and-icons {
+  --tw-gradient-to: var(--nav-text-and-icons);
+}
+
+.to-nav-text-secondary {
+  --tw-gradient-to: var(--nav-text-secondary);
+}
+
+.to-network-operations {
+  --tw-gradient-to: var(--network-operations);
+}
+
+.to-normal-hover {
+  --tw-gradient-to: var(--normal-hover);
+}
+
+.to-normal-idle {
+  --tw-gradient-to: var(--normal-idle);
+}
+
+.to-normal-pressed {
+  --tw-gradient-to: var(--normal-pressed);
+}
+
+.to-overlay-0\\\\.5 {
+  --tw-gradient-to: var(--overlay-0\\\\.5);
+}
+
+.to-overlay-1 {
+  --tw-gradient-to: var(--overlay-1);
+}
+
+.to-overlay-2 {
+  --tw-gradient-to: var(--overlay-2);
+}
+
+.to-positive {
+  --tw-gradient-to: var(--positive);
+}
+
+.to-primary-hover {
+  --tw-gradient-to: var(--primary-hover);
+}
+
+.to-primary-idle {
+  --tw-gradient-to: var(--primary-idle);
+}
+
+.to-primary-pressed {
+  --tw-gradient-to: var(--primary-pressed);
+}
+
+.to-process-operations {
+  --tw-gradient-to: var(--process-operations);
+}
+
+.to-purple {
+  --tw-gradient-to: var(--purple);
+}
+
+.to-registry-operations {
+  --tw-gradient-to: var(--registry-operations);
+}
+
+.to-selected {
+  --tw-gradient-to: var(--selected);
+}
+
+.to-surface-2xl {
+  --tw-gradient-to: var(--surface-2xl);
+}
+
+.to-surface-base {
+  --tw-gradient-to: var(--surface-base);
+}
+
+.to-surface-inner {
+  --tw-gradient-to: var(--surface-inner);
+}
+
+.to-surface-lg {
+  --tw-gradient-to: var(--surface-lg);
+}
+
+.to-surface-md {
+  --tw-gradient-to: var(--surface-md);
+}
+
+.to-surface-xl {
+  --tw-gradient-to: var(--surface-xl);
+}
+
+.to-text-and-icons {
+  --tw-gradient-to: var(--text-and-icons);
+}
+
+.to-titles-and-attributes {
+  --tw-gradient-to: var(--titles-and-attributes);
+}
+
+.hover\\\\:to-current:hover {
+  --tw-gradient-to: currentColor;
+}
+
+.hover\\\\:to-transparent:hover {
+  --tw-gradient-to: transparent;
+}
+
+.hover\\\\:to-falcon:hover {
+  --tw-gradient-to: var(--falcon);
+}
+
+.hover\\\\:to-basement:hover {
+  --tw-gradient-to: var(--basement);
+}
+
+.hover\\\\:to-blue:hover {
+  --tw-gradient-to: var(--blue);
+}
+
+.hover\\\\:to-body-and-labels:hover {
+  --tw-gradient-to: var(--body-and-labels);
+}
+
+.hover\\\\:to-brand:hover {
+  --tw-gradient-to: var(--brand);
+}
+
+.hover\\\\:to-code-base-64:hover {
+  --tw-gradient-to: var(--code-base-64);
+}
+
+.hover\\\\:to-code-bg:hover {
+  --tw-gradient-to: var(--code-bg);
+}
+
+.hover\\\\:to-code-outline:hover {
+  --tw-gradient-to: var(--code-outline);
+}
+
+.hover\\\\:to-code-text:hover {
+  --tw-gradient-to: var(--code-text);
+}
+
+.hover\\\\:to-critical:hover {
+  --tw-gradient-to: var(--critical);
+}
+
+.hover\\\\:to-destructive-hover:hover {
+  --tw-gradient-to: var(--destructive-hover);
+}
+
+.hover\\\\:to-destructive-idle:hover {
+  --tw-gradient-to: var(--destructive-idle);
+}
+
+.hover\\\\:to-destructive-pressed:hover {
+  --tw-gradient-to: var(--destructive-pressed);
+}
+
+.hover\\\\:to-disabled:hover {
+  --tw-gradient-to: var(--disabled);
+}
+
+.hover\\\\:to-disc-operations:hover {
+  --tw-gradient-to: var(--disc-operations);
+}
+
+.hover\\\\:to-dns-requests:hover {
+  --tw-gradient-to: var(--dns-requests);
+}
+
+.hover\\\\:to-focus:hover {
+  --tw-gradient-to: var(--focus);
+}
+
+.hover\\\\:to-graph-1:hover {
+  --tw-gradient-to: var(--graph-1);
+}
+
+.hover\\\\:to-graph-10:hover {
+  --tw-gradient-to: var(--graph-10);
+}
+
+.hover\\\\:to-graph-11:hover {
+  --tw-gradient-to: var(--graph-11);
+}
+
+.hover\\\\:to-graph-2:hover {
+  --tw-gradient-to: var(--graph-2);
+}
+
+.hover\\\\:to-graph-3:hover {
+  --tw-gradient-to: var(--graph-3);
+}
+
+.hover\\\\:to-graph-4:hover {
+  --tw-gradient-to: var(--graph-4);
+}
+
+.hover\\\\:to-graph-5:hover {
+  --tw-gradient-to: var(--graph-5);
+}
+
+.hover\\\\:to-graph-6:hover {
+  --tw-gradient-to: var(--graph-6);
+}
+
+.hover\\\\:to-graph-7:hover {
+  --tw-gradient-to: var(--graph-7);
+}
+
+.hover\\\\:to-graph-8:hover {
+  --tw-gradient-to: var(--graph-8);
+}
+
+.hover\\\\:to-graph-9:hover {
+  --tw-gradient-to: var(--graph-9);
+}
+
+.hover\\\\:to-graph-disabled:hover {
+  --tw-gradient-to: var(--graph-disabled);
+}
+
+.hover\\\\:to-ground-floor:hover {
+  --tw-gradient-to: var(--ground-floor);
+}
+
+.hover\\\\:to-high:hover {
+  --tw-gradient-to: var(--high);
+}
+
+.hover\\\\:to-informational:hover {
+  --tw-gradient-to: var(--informational);
+}
+
+.hover\\\\:to-lines-dark:hover {
+  --tw-gradient-to: var(--lines-dark);
+}
+
+.hover\\\\:to-lines-light:hover {
+  --tw-gradient-to: var(--lines-light);
+}
+
+.hover\\\\:to-low:hover {
+  --tw-gradient-to: var(--low);
+}
+
+.hover\\\\:to-medium:hover {
+  --tw-gradient-to: var(--medium);
+}
+
+.hover\\\\:to-mezzanine:hover {
+  --tw-gradient-to: var(--mezzanine);
+}
+
+.hover\\\\:to-nav-text-and-icons:hover {
+  --tw-gradient-to: var(--nav-text-and-icons);
+}
+
+.hover\\\\:to-nav-text-secondary:hover {
+  --tw-gradient-to: var(--nav-text-secondary);
+}
+
+.hover\\\\:to-network-operations:hover {
+  --tw-gradient-to: var(--network-operations);
+}
+
+.hover\\\\:to-normal-hover:hover {
+  --tw-gradient-to: var(--normal-hover);
+}
+
+.hover\\\\:to-normal-idle:hover {
+  --tw-gradient-to: var(--normal-idle);
+}
+
+.hover\\\\:to-normal-pressed:hover {
+  --tw-gradient-to: var(--normal-pressed);
+}
+
+.hover\\\\:to-overlay-0\\\\.5:hover {
+  --tw-gradient-to: var(--overlay-0\\\\.5);
+}
+
+.hover\\\\:to-overlay-1:hover {
+  --tw-gradient-to: var(--overlay-1);
+}
+
+.hover\\\\:to-overlay-2:hover {
+  --tw-gradient-to: var(--overlay-2);
+}
+
+.hover\\\\:to-positive:hover {
+  --tw-gradient-to: var(--positive);
+}
+
+.hover\\\\:to-primary-hover:hover {
+  --tw-gradient-to: var(--primary-hover);
+}
+
+.hover\\\\:to-primary-idle:hover {
+  --tw-gradient-to: var(--primary-idle);
+}
+
+.hover\\\\:to-primary-pressed:hover {
+  --tw-gradient-to: var(--primary-pressed);
+}
+
+.hover\\\\:to-process-operations:hover {
+  --tw-gradient-to: var(--process-operations);
+}
+
+.hover\\\\:to-purple:hover {
+  --tw-gradient-to: var(--purple);
+}
+
+.hover\\\\:to-registry-operations:hover {
+  --tw-gradient-to: var(--registry-operations);
+}
+
+.hover\\\\:to-selected:hover {
+  --tw-gradient-to: var(--selected);
+}
+
+.hover\\\\:to-surface-2xl:hover {
+  --tw-gradient-to: var(--surface-2xl);
+}
+
+.hover\\\\:to-surface-base:hover {
+  --tw-gradient-to: var(--surface-base);
+}
+
+.hover\\\\:to-surface-inner:hover {
+  --tw-gradient-to: var(--surface-inner);
+}
+
+.hover\\\\:to-surface-lg:hover {
+  --tw-gradient-to: var(--surface-lg);
+}
+
+.hover\\\\:to-surface-md:hover {
+  --tw-gradient-to: var(--surface-md);
+}
+
+.hover\\\\:to-surface-xl:hover {
+  --tw-gradient-to: var(--surface-xl);
+}
+
+.hover\\\\:to-text-and-icons:hover {
+  --tw-gradient-to: var(--text-and-icons);
+}
+
+.hover\\\\:to-titles-and-attributes:hover {
+  --tw-gradient-to: var(--titles-and-attributes);
+}
+
+.focus\\\\:to-current:focus {
+  --tw-gradient-to: currentColor;
+}
+
+.focus\\\\:to-transparent:focus {
+  --tw-gradient-to: transparent;
+}
+
+.focus\\\\:to-falcon:focus {
+  --tw-gradient-to: var(--falcon);
+}
+
+.focus\\\\:to-basement:focus {
+  --tw-gradient-to: var(--basement);
+}
+
+.focus\\\\:to-blue:focus {
+  --tw-gradient-to: var(--blue);
+}
+
+.focus\\\\:to-body-and-labels:focus {
+  --tw-gradient-to: var(--body-and-labels);
+}
+
+.focus\\\\:to-brand:focus {
+  --tw-gradient-to: var(--brand);
+}
+
+.focus\\\\:to-code-base-64:focus {
+  --tw-gradient-to: var(--code-base-64);
+}
+
+.focus\\\\:to-code-bg:focus {
+  --tw-gradient-to: var(--code-bg);
+}
+
+.focus\\\\:to-code-outline:focus {
+  --tw-gradient-to: var(--code-outline);
+}
+
+.focus\\\\:to-code-text:focus {
+  --tw-gradient-to: var(--code-text);
+}
+
+.focus\\\\:to-critical:focus {
+  --tw-gradient-to: var(--critical);
+}
+
+.focus\\\\:to-destructive-hover:focus {
+  --tw-gradient-to: var(--destructive-hover);
+}
+
+.focus\\\\:to-destructive-idle:focus {
+  --tw-gradient-to: var(--destructive-idle);
+}
+
+.focus\\\\:to-destructive-pressed:focus {
+  --tw-gradient-to: var(--destructive-pressed);
+}
+
+.focus\\\\:to-disabled:focus {
+  --tw-gradient-to: var(--disabled);
+}
+
+.focus\\\\:to-disc-operations:focus {
+  --tw-gradient-to: var(--disc-operations);
+}
+
+.focus\\\\:to-dns-requests:focus {
+  --tw-gradient-to: var(--dns-requests);
+}
+
+.focus\\\\:to-focus:focus {
+  --tw-gradient-to: var(--focus);
+}
+
+.focus\\\\:to-graph-1:focus {
+  --tw-gradient-to: var(--graph-1);
+}
+
+.focus\\\\:to-graph-10:focus {
+  --tw-gradient-to: var(--graph-10);
+}
+
+.focus\\\\:to-graph-11:focus {
+  --tw-gradient-to: var(--graph-11);
+}
+
+.focus\\\\:to-graph-2:focus {
+  --tw-gradient-to: var(--graph-2);
+}
+
+.focus\\\\:to-graph-3:focus {
+  --tw-gradient-to: var(--graph-3);
+}
+
+.focus\\\\:to-graph-4:focus {
+  --tw-gradient-to: var(--graph-4);
+}
+
+.focus\\\\:to-graph-5:focus {
+  --tw-gradient-to: var(--graph-5);
+}
+
+.focus\\\\:to-graph-6:focus {
+  --tw-gradient-to: var(--graph-6);
+}
+
+.focus\\\\:to-graph-7:focus {
+  --tw-gradient-to: var(--graph-7);
+}
+
+.focus\\\\:to-graph-8:focus {
+  --tw-gradient-to: var(--graph-8);
+}
+
+.focus\\\\:to-graph-9:focus {
+  --tw-gradient-to: var(--graph-9);
+}
+
+.focus\\\\:to-graph-disabled:focus {
+  --tw-gradient-to: var(--graph-disabled);
+}
+
+.focus\\\\:to-ground-floor:focus {
+  --tw-gradient-to: var(--ground-floor);
+}
+
+.focus\\\\:to-high:focus {
+  --tw-gradient-to: var(--high);
+}
+
+.focus\\\\:to-informational:focus {
+  --tw-gradient-to: var(--informational);
+}
+
+.focus\\\\:to-lines-dark:focus {
+  --tw-gradient-to: var(--lines-dark);
+}
+
+.focus\\\\:to-lines-light:focus {
+  --tw-gradient-to: var(--lines-light);
+}
+
+.focus\\\\:to-low:focus {
+  --tw-gradient-to: var(--low);
+}
+
+.focus\\\\:to-medium:focus {
+  --tw-gradient-to: var(--medium);
+}
+
+.focus\\\\:to-mezzanine:focus {
+  --tw-gradient-to: var(--mezzanine);
+}
+
+.focus\\\\:to-nav-text-and-icons:focus {
+  --tw-gradient-to: var(--nav-text-and-icons);
+}
+
+.focus\\\\:to-nav-text-secondary:focus {
+  --tw-gradient-to: var(--nav-text-secondary);
+}
+
+.focus\\\\:to-network-operations:focus {
+  --tw-gradient-to: var(--network-operations);
+}
+
+.focus\\\\:to-normal-hover:focus {
+  --tw-gradient-to: var(--normal-hover);
+}
+
+.focus\\\\:to-normal-idle:focus {
+  --tw-gradient-to: var(--normal-idle);
+}
+
+.focus\\\\:to-normal-pressed:focus {
+  --tw-gradient-to: var(--normal-pressed);
+}
+
+.focus\\\\:to-overlay-0\\\\.5:focus {
+  --tw-gradient-to: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:to-overlay-1:focus {
+  --tw-gradient-to: var(--overlay-1);
+}
+
+.focus\\\\:to-overlay-2:focus {
+  --tw-gradient-to: var(--overlay-2);
+}
+
+.focus\\\\:to-positive:focus {
+  --tw-gradient-to: var(--positive);
+}
+
+.focus\\\\:to-primary-hover:focus {
+  --tw-gradient-to: var(--primary-hover);
+}
+
+.focus\\\\:to-primary-idle:focus {
+  --tw-gradient-to: var(--primary-idle);
+}
+
+.focus\\\\:to-primary-pressed:focus {
+  --tw-gradient-to: var(--primary-pressed);
+}
+
+.focus\\\\:to-process-operations:focus {
+  --tw-gradient-to: var(--process-operations);
+}
+
+.focus\\\\:to-purple:focus {
+  --tw-gradient-to: var(--purple);
+}
+
+.focus\\\\:to-registry-operations:focus {
+  --tw-gradient-to: var(--registry-operations);
+}
+
+.focus\\\\:to-selected:focus {
+  --tw-gradient-to: var(--selected);
+}
+
+.focus\\\\:to-surface-2xl:focus {
+  --tw-gradient-to: var(--surface-2xl);
+}
+
+.focus\\\\:to-surface-base:focus {
+  --tw-gradient-to: var(--surface-base);
+}
+
+.focus\\\\:to-surface-inner:focus {
+  --tw-gradient-to: var(--surface-inner);
+}
+
+.focus\\\\:to-surface-lg:focus {
+  --tw-gradient-to: var(--surface-lg);
+}
+
+.focus\\\\:to-surface-md:focus {
+  --tw-gradient-to: var(--surface-md);
+}
+
+.focus\\\\:to-surface-xl:focus {
+  --tw-gradient-to: var(--surface-xl);
+}
+
+.focus\\\\:to-text-and-icons:focus {
+  --tw-gradient-to: var(--text-and-icons);
+}
+
+.focus\\\\:to-titles-and-attributes:focus {
+  --tw-gradient-to: var(--titles-and-attributes);
+}
+
+.decoration-slice {
+  -webkit-box-decoration-break: slice;
+          box-decoration-break: slice;
+}
+
+.decoration-clone {
+  -webkit-box-decoration-break: clone;
+          box-decoration-break: clone;
+}
+
+.bg-auto {
+  background-size: auto;
+}
+
+.bg-cover {
+  background-size: cover;
+}
+
+.bg-contain {
+  background-size: contain;
+}
+
+.bg-fixed {
+  background-attachment: fixed;
+}
+
+.bg-local {
+  background-attachment: local;
+}
+
+.bg-scroll {
+  background-attachment: scroll;
+}
+
+.bg-clip-border {
+  background-clip: border-box;
+}
+
+.bg-clip-padding {
+  background-clip: padding-box;
+}
+
+.bg-clip-content {
+  background-clip: content-box;
+}
+
+.bg-clip-text {
+  -webkit-background-clip: text;
+          background-clip: text;
+}
+
+.bg-bottom {
+  background-position: bottom;
+}
+
+.bg-center {
+  background-position: center;
+}
+
+.bg-left {
+  background-position: left;
+}
+
+.bg-left-bottom {
+  background-position: left bottom;
+}
+
+.bg-left-top {
+  background-position: left top;
+}
+
+.bg-right {
+  background-position: right;
+}
+
+.bg-right-bottom {
+  background-position: right bottom;
+}
+
+.bg-right-top {
+  background-position: right top;
+}
+
+.bg-top {
+  background-position: top;
+}
+
+.bg-repeat {
+  background-repeat: repeat;
+}
+
+.bg-no-repeat {
+  background-repeat: no-repeat;
+}
+
+.bg-repeat-x {
+  background-repeat: repeat-x;
+}
+
+.bg-repeat-y {
+  background-repeat: repeat-y;
+}
+
+.bg-repeat-round {
+  background-repeat: round;
+}
+
+.bg-repeat-space {
+  background-repeat: space;
+}
+
+.bg-origin-border {
+  background-origin: border-box;
+}
+
+.bg-origin-padding {
+  background-origin: padding-box;
+}
+
+.bg-origin-content {
+  background-origin: content-box;
+}
+
+.fill-current {
+  fill: currentColor;
+}
+
+.stroke-current {
+  stroke: currentColor;
+}
+
+.stroke-0 {
+  stroke-width: 0;
+}
+
+.stroke-1 {
+  stroke-width: 1;
+}
+
+.stroke-2 {
+  stroke-width: 2;
+}
+
+.object-contain {
+  -o-object-fit: contain;
+     object-fit: contain;
+}
+
+.object-cover {
+  -o-object-fit: cover;
+     object-fit: cover;
+}
+
+.object-fill {
+  -o-object-fit: fill;
+     object-fit: fill;
+}
+
+.object-none {
+  -o-object-fit: none;
+     object-fit: none;
+}
+
+.object-scale-down {
+  -o-object-fit: scale-down;
+     object-fit: scale-down;
+}
+
+.object-bottom {
+  -o-object-position: bottom;
+     object-position: bottom;
+}
+
+.object-center {
+  -o-object-position: center;
+     object-position: center;
+}
+
+.object-left {
+  -o-object-position: left;
+     object-position: left;
+}
+
+.object-left-bottom {
+  -o-object-position: left bottom;
+     object-position: left bottom;
+}
+
+.object-left-top {
+  -o-object-position: left top;
+     object-position: left top;
+}
+
+.object-right {
+  -o-object-position: right;
+     object-position: right;
+}
+
+.object-right-bottom {
+  -o-object-position: right bottom;
+     object-position: right bottom;
+}
+
+.object-right-top {
+  -o-object-position: right top;
+     object-position: right top;
+}
+
+.object-top {
+  -o-object-position: top;
+     object-position: top;
+}
+
+.p-0 {
+  padding: 0px;
+}
+
+.p-1 {
+  padding: 0.25rem;
+}
+
+.p-2 {
+  padding: 0.5rem;
+}
+
+.p-3 {
+  padding: 0.75rem;
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.p-5 {
+  padding: 1.25rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
+}
+
+.p-7 {
+  padding: 1.75rem;
+}
+
+.p-8 {
+  padding: 2rem;
+}
+
+.p-9 {
+  padding: 2.25rem;
+}
+
+.p-10 {
+  padding: 2.5rem;
+}
+
+.p-11 {
+  padding: 2.75rem;
+}
+
+.p-12 {
+  padding: 3rem;
+}
+
+.p-14 {
+  padding: 3.5rem;
+}
+
+.p-16 {
+  padding: 4rem;
+}
+
+.p-20 {
+  padding: 5rem;
+}
+
+.p-24 {
+  padding: 6rem;
+}
+
+.p-28 {
+  padding: 7rem;
+}
+
+.p-32 {
+  padding: 8rem;
+}
+
+.p-36 {
+  padding: 9rem;
+}
+
+.p-40 {
+  padding: 10rem;
+}
+
+.p-44 {
+  padding: 11rem;
+}
+
+.p-48 {
+  padding: 12rem;
+}
+
+.p-52 {
+  padding: 13rem;
+}
+
+.p-56 {
+  padding: 14rem;
+}
+
+.p-60 {
+  padding: 15rem;
+}
+
+.p-64 {
+  padding: 16rem;
+}
+
+.p-72 {
+  padding: 18rem;
+}
+
+.p-80 {
+  padding: 20rem;
+}
+
+.p-96 {
+  padding: 24rem;
+}
+
+.p-px {
+  padding: 1px;
+}
+
+.p-0\\\\.5 {
+  padding: 0.125rem;
+}
+
+.p-1\\\\.5 {
+  padding: 0.375rem;
+}
+
+.p-2\\\\.5 {
+  padding: 0.625rem;
+}
+
+.p-3\\\\.5 {
+  padding: 0.875rem;
+}
+
+.p-0\\\\.25 {
+  padding: 0.063rem;
+}
+
+.p-property-tabs-top {
+  padding: var(--property-tabs-top);
+}
+
+.p-unset {
+  padding: unset;
+}
+
+.px-0 {
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.px-5 {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.px-7 {
+  padding-left: 1.75rem;
+  padding-right: 1.75rem;
+}
+
+.px-8 {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.px-9 {
+  padding-left: 2.25rem;
+  padding-right: 2.25rem;
+}
+
+.px-10 {
+  padding-left: 2.5rem;
+  padding-right: 2.5rem;
+}
+
+.px-11 {
+  padding-left: 2.75rem;
+  padding-right: 2.75rem;
+}
+
+.px-12 {
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.px-14 {
+  padding-left: 3.5rem;
+  padding-right: 3.5rem;
+}
+
+.px-16 {
+  padding-left: 4rem;
+  padding-right: 4rem;
+}
+
+.px-20 {
+  padding-left: 5rem;
+  padding-right: 5rem;
+}
+
+.px-24 {
+  padding-left: 6rem;
+  padding-right: 6rem;
+}
+
+.px-28 {
+  padding-left: 7rem;
+  padding-right: 7rem;
+}
+
+.px-32 {
+  padding-left: 8rem;
+  padding-right: 8rem;
+}
+
+.px-36 {
+  padding-left: 9rem;
+  padding-right: 9rem;
+}
+
+.px-40 {
+  padding-left: 10rem;
+  padding-right: 10rem;
+}
+
+.px-44 {
+  padding-left: 11rem;
+  padding-right: 11rem;
+}
+
+.px-48 {
+  padding-left: 12rem;
+  padding-right: 12rem;
+}
+
+.px-52 {
+  padding-left: 13rem;
+  padding-right: 13rem;
+}
+
+.px-56 {
+  padding-left: 14rem;
+  padding-right: 14rem;
+}
+
+.px-60 {
+  padding-left: 15rem;
+  padding-right: 15rem;
+}
+
+.px-64 {
+  padding-left: 16rem;
+  padding-right: 16rem;
+}
+
+.px-72 {
+  padding-left: 18rem;
+  padding-right: 18rem;
+}
+
+.px-80 {
+  padding-left: 20rem;
+  padding-right: 20rem;
+}
+
+.px-96 {
+  padding-left: 24rem;
+  padding-right: 24rem;
+}
+
+.px-px {
+  padding-left: 1px;
+  padding-right: 1px;
+}
+
+.px-0\\\\.5 {
+  padding-left: 0.125rem;
+  padding-right: 0.125rem;
+}
+
+.px-1\\\\.5 {
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+}
+
+.px-2\\\\.5 {
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+}
+
+.px-3\\\\.5 {
+  padding-left: 0.875rem;
+  padding-right: 0.875rem;
+}
+
+.px-0\\\\.25 {
+  padding-left: 0.063rem;
+  padding-right: 0.063rem;
+}
+
+.px-property-tabs-top {
+  padding-left: var(--property-tabs-top);
+  padding-right: var(--property-tabs-top);
+}
+
+.px-unset {
+  padding-left: unset;
+  padding-right: unset;
+}
+
+.py-0 {
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+}
+
+.py-6 {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.py-7 {
+  padding-top: 1.75rem;
+  padding-bottom: 1.75rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.py-9 {
+  padding-top: 2.25rem;
+  padding-bottom: 2.25rem;
+}
+
+.py-10 {
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
+}
+
+.py-11 {
+  padding-top: 2.75rem;
+  padding-bottom: 2.75rem;
+}
+
+.py-12 {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.py-14 {
+  padding-top: 3.5rem;
+  padding-bottom: 3.5rem;
+}
+
+.py-16 {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}
+
+.py-20 {
+  padding-top: 5rem;
+  padding-bottom: 5rem;
+}
+
+.py-24 {
+  padding-top: 6rem;
+  padding-bottom: 6rem;
+}
+
+.py-28 {
+  padding-top: 7rem;
+  padding-bottom: 7rem;
+}
+
+.py-32 {
+  padding-top: 8rem;
+  padding-bottom: 8rem;
+}
+
+.py-36 {
+  padding-top: 9rem;
+  padding-bottom: 9rem;
+}
+
+.py-40 {
+  padding-top: 10rem;
+  padding-bottom: 10rem;
+}
+
+.py-44 {
+  padding-top: 11rem;
+  padding-bottom: 11rem;
+}
+
+.py-48 {
+  padding-top: 12rem;
+  padding-bottom: 12rem;
+}
+
+.py-52 {
+  padding-top: 13rem;
+  padding-bottom: 13rem;
+}
+
+.py-56 {
+  padding-top: 14rem;
+  padding-bottom: 14rem;
+}
+
+.py-60 {
+  padding-top: 15rem;
+  padding-bottom: 15rem;
+}
+
+.py-64 {
+  padding-top: 16rem;
+  padding-bottom: 16rem;
+}
+
+.py-72 {
+  padding-top: 18rem;
+  padding-bottom: 18rem;
+}
+
+.py-80 {
+  padding-top: 20rem;
+  padding-bottom: 20rem;
+}
+
+.py-96 {
+  padding-top: 24rem;
+  padding-bottom: 24rem;
+}
+
+.py-px {
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+
+.py-0\\\\.5 {
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+}
+
+.py-1\\\\.5 {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+}
+
+.py-2\\\\.5 {
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+}
+
+.py-3\\\\.5 {
+  padding-top: 0.875rem;
+  padding-bottom: 0.875rem;
+}
+
+.py-0\\\\.25 {
+  padding-top: 0.063rem;
+  padding-bottom: 0.063rem;
+}
+
+.py-property-tabs-top {
+  padding-top: var(--property-tabs-top);
+  padding-bottom: var(--property-tabs-top);
+}
+
+.py-unset {
+  padding-top: unset;
+  padding-bottom: unset;
+}
+
+.pt-0 {
+  padding-top: 0px;
+}
+
+.pt-1 {
+  padding-top: 0.25rem;
+}
+
+.pt-2 {
+  padding-top: 0.5rem;
+}
+
+.pt-3 {
+  padding-top: 0.75rem;
+}
+
+.pt-4 {
+  padding-top: 1rem;
+}
+
+.pt-5 {
+  padding-top: 1.25rem;
+}
+
+.pt-6 {
+  padding-top: 1.5rem;
+}
+
+.pt-7 {
+  padding-top: 1.75rem;
+}
+
+.pt-8 {
+  padding-top: 2rem;
+}
+
+.pt-9 {
+  padding-top: 2.25rem;
+}
+
+.pt-10 {
+  padding-top: 2.5rem;
+}
+
+.pt-11 {
+  padding-top: 2.75rem;
+}
+
+.pt-12 {
+  padding-top: 3rem;
+}
+
+.pt-14 {
+  padding-top: 3.5rem;
+}
+
+.pt-16 {
+  padding-top: 4rem;
+}
+
+.pt-20 {
+  padding-top: 5rem;
+}
+
+.pt-24 {
+  padding-top: 6rem;
+}
+
+.pt-28 {
+  padding-top: 7rem;
+}
+
+.pt-32 {
+  padding-top: 8rem;
+}
+
+.pt-36 {
+  padding-top: 9rem;
+}
+
+.pt-40 {
+  padding-top: 10rem;
+}
+
+.pt-44 {
+  padding-top: 11rem;
+}
+
+.pt-48 {
+  padding-top: 12rem;
+}
+
+.pt-52 {
+  padding-top: 13rem;
+}
+
+.pt-56 {
+  padding-top: 14rem;
+}
+
+.pt-60 {
+  padding-top: 15rem;
+}
+
+.pt-64 {
+  padding-top: 16rem;
+}
+
+.pt-72 {
+  padding-top: 18rem;
+}
+
+.pt-80 {
+  padding-top: 20rem;
+}
+
+.pt-96 {
+  padding-top: 24rem;
+}
+
+.pt-px {
+  padding-top: 1px;
+}
+
+.pt-0\\\\.5 {
+  padding-top: 0.125rem;
+}
+
+.pt-1\\\\.5 {
+  padding-top: 0.375rem;
+}
+
+.pt-2\\\\.5 {
+  padding-top: 0.625rem;
+}
+
+.pt-3\\\\.5 {
+  padding-top: 0.875rem;
+}
+
+.pt-0\\\\.25 {
+  padding-top: 0.063rem;
+}
+
+.pt-property-tabs-top {
+  padding-top: var(--property-tabs-top);
+}
+
+.pt-unset {
+  padding-top: unset;
+}
+
+.pr-0 {
+  padding-right: 0px;
+}
+
+.pr-1 {
+  padding-right: 0.25rem;
+}
+
+.pr-2 {
+  padding-right: 0.5rem;
+}
+
+.pr-3 {
+  padding-right: 0.75rem;
+}
+
+.pr-4 {
+  padding-right: 1rem;
+}
+
+.pr-5 {
+  padding-right: 1.25rem;
+}
+
+.pr-6 {
+  padding-right: 1.5rem;
+}
+
+.pr-7 {
+  padding-right: 1.75rem;
+}
+
+.pr-8 {
+  padding-right: 2rem;
+}
+
+.pr-9 {
+  padding-right: 2.25rem;
+}
+
+.pr-10 {
+  padding-right: 2.5rem;
+}
+
+.pr-11 {
+  padding-right: 2.75rem;
+}
+
+.pr-12 {
+  padding-right: 3rem;
+}
+
+.pr-14 {
+  padding-right: 3.5rem;
+}
+
+.pr-16 {
+  padding-right: 4rem;
+}
+
+.pr-20 {
+  padding-right: 5rem;
+}
+
+.pr-24 {
+  padding-right: 6rem;
+}
+
+.pr-28 {
+  padding-right: 7rem;
+}
+
+.pr-32 {
+  padding-right: 8rem;
+}
+
+.pr-36 {
+  padding-right: 9rem;
+}
+
+.pr-40 {
+  padding-right: 10rem;
+}
+
+.pr-44 {
+  padding-right: 11rem;
+}
+
+.pr-48 {
+  padding-right: 12rem;
+}
+
+.pr-52 {
+  padding-right: 13rem;
+}
+
+.pr-56 {
+  padding-right: 14rem;
+}
+
+.pr-60 {
+  padding-right: 15rem;
+}
+
+.pr-64 {
+  padding-right: 16rem;
+}
+
+.pr-72 {
+  padding-right: 18rem;
+}
+
+.pr-80 {
+  padding-right: 20rem;
+}
+
+.pr-96 {
+  padding-right: 24rem;
+}
+
+.pr-px {
+  padding-right: 1px;
+}
+
+.pr-0\\\\.5 {
+  padding-right: 0.125rem;
+}
+
+.pr-1\\\\.5 {
+  padding-right: 0.375rem;
+}
+
+.pr-2\\\\.5 {
+  padding-right: 0.625rem;
+}
+
+.pr-3\\\\.5 {
+  padding-right: 0.875rem;
+}
+
+.pr-0\\\\.25 {
+  padding-right: 0.063rem;
+}
+
+.pr-property-tabs-top {
+  padding-right: var(--property-tabs-top);
+}
+
+.pr-unset {
+  padding-right: unset;
+}
+
+.pb-0 {
+  padding-bottom: 0px;
+}
+
+.pb-1 {
+  padding-bottom: 0.25rem;
+}
+
+.pb-2 {
+  padding-bottom: 0.5rem;
+}
+
+.pb-3 {
+  padding-bottom: 0.75rem;
+}
+
+.pb-4 {
+  padding-bottom: 1rem;
+}
+
+.pb-5 {
+  padding-bottom: 1.25rem;
+}
+
+.pb-6 {
+  padding-bottom: 1.5rem;
+}
+
+.pb-7 {
+  padding-bottom: 1.75rem;
+}
+
+.pb-8 {
+  padding-bottom: 2rem;
+}
+
+.pb-9 {
+  padding-bottom: 2.25rem;
+}
+
+.pb-10 {
+  padding-bottom: 2.5rem;
+}
+
+.pb-11 {
+  padding-bottom: 2.75rem;
+}
+
+.pb-12 {
+  padding-bottom: 3rem;
+}
+
+.pb-14 {
+  padding-bottom: 3.5rem;
+}
+
+.pb-16 {
+  padding-bottom: 4rem;
+}
+
+.pb-20 {
+  padding-bottom: 5rem;
+}
+
+.pb-24 {
+  padding-bottom: 6rem;
+}
+
+.pb-28 {
+  padding-bottom: 7rem;
+}
+
+.pb-32 {
+  padding-bottom: 8rem;
+}
+
+.pb-36 {
+  padding-bottom: 9rem;
+}
+
+.pb-40 {
+  padding-bottom: 10rem;
+}
+
+.pb-44 {
+  padding-bottom: 11rem;
+}
+
+.pb-48 {
+  padding-bottom: 12rem;
+}
+
+.pb-52 {
+  padding-bottom: 13rem;
+}
+
+.pb-56 {
+  padding-bottom: 14rem;
+}
+
+.pb-60 {
+  padding-bottom: 15rem;
+}
+
+.pb-64 {
+  padding-bottom: 16rem;
+}
+
+.pb-72 {
+  padding-bottom: 18rem;
+}
+
+.pb-80 {
+  padding-bottom: 20rem;
+}
+
+.pb-96 {
+  padding-bottom: 24rem;
+}
+
+.pb-px {
+  padding-bottom: 1px;
+}
+
+.pb-0\\\\.5 {
+  padding-bottom: 0.125rem;
+}
+
+.pb-1\\\\.5 {
+  padding-bottom: 0.375rem;
+}
+
+.pb-2\\\\.5 {
+  padding-bottom: 0.625rem;
+}
+
+.pb-3\\\\.5 {
+  padding-bottom: 0.875rem;
+}
+
+.pb-0\\\\.25 {
+  padding-bottom: 0.063rem;
+}
+
+.pb-property-tabs-top {
+  padding-bottom: var(--property-tabs-top);
+}
+
+.pb-unset {
+  padding-bottom: unset;
+}
+
+.pl-0 {
+  padding-left: 0px;
+}
+
+.pl-1 {
+  padding-left: 0.25rem;
+}
+
+.pl-2 {
+  padding-left: 0.5rem;
+}
+
+.pl-3 {
+  padding-left: 0.75rem;
+}
+
+.pl-4 {
+  padding-left: 1rem;
+}
+
+.pl-5 {
+  padding-left: 1.25rem;
+}
+
+.pl-6 {
+  padding-left: 1.5rem;
+}
+
+.pl-7 {
+  padding-left: 1.75rem;
+}
+
+.pl-8 {
+  padding-left: 2rem;
+}
+
+.pl-9 {
+  padding-left: 2.25rem;
+}
+
+.pl-10 {
+  padding-left: 2.5rem;
+}
+
+.pl-11 {
+  padding-left: 2.75rem;
+}
+
+.pl-12 {
+  padding-left: 3rem;
+}
+
+.pl-14 {
+  padding-left: 3.5rem;
+}
+
+.pl-16 {
+  padding-left: 4rem;
+}
+
+.pl-20 {
+  padding-left: 5rem;
+}
+
+.pl-24 {
+  padding-left: 6rem;
+}
+
+.pl-28 {
+  padding-left: 7rem;
+}
+
+.pl-32 {
+  padding-left: 8rem;
+}
+
+.pl-36 {
+  padding-left: 9rem;
+}
+
+.pl-40 {
+  padding-left: 10rem;
+}
+
+.pl-44 {
+  padding-left: 11rem;
+}
+
+.pl-48 {
+  padding-left: 12rem;
+}
+
+.pl-52 {
+  padding-left: 13rem;
+}
+
+.pl-56 {
+  padding-left: 14rem;
+}
+
+.pl-60 {
+  padding-left: 15rem;
+}
+
+.pl-64 {
+  padding-left: 16rem;
+}
+
+.pl-72 {
+  padding-left: 18rem;
+}
+
+.pl-80 {
+  padding-left: 20rem;
+}
+
+.pl-96 {
+  padding-left: 24rem;
+}
+
+.pl-px {
+  padding-left: 1px;
+}
+
+.pl-0\\\\.5 {
+  padding-left: 0.125rem;
+}
+
+.pl-1\\\\.5 {
+  padding-left: 0.375rem;
+}
+
+.pl-2\\\\.5 {
+  padding-left: 0.625rem;
+}
+
+.pl-3\\\\.5 {
+  padding-left: 0.875rem;
+}
+
+.pl-0\\\\.25 {
+  padding-left: 0.063rem;
+}
+
+.pl-property-tabs-top {
+  padding-left: var(--property-tabs-top);
+}
+
+.pl-unset {
+  padding-left: unset;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.text-justify {
+  text-align: justify;
+}
+
+.align-baseline {
+  vertical-align: baseline;
+}
+
+.align-top {
+  vertical-align: top;
+}
+
+.align-middle {
+  vertical-align: middle;
+}
+
+.align-bottom {
+  vertical-align: bottom;
+}
+
+.align-text-top {
+  vertical-align: text-top;
+}
+
+.align-text-bottom {
+  vertical-align: text-bottom;
+}
+
+.font-sans {
+  font-family: Calibre, sans-serif;
+}
+
+.font-mono {
+  font-family: Monaco, monospace;
+}
+
+.text-xxs {
+  font-size: .5625rem;
+  line-height: 1rem;
+}
+
+.text-xs {
+  font-size: .75rem;
+  line-height: 1.25rem;
+}
+
+.text-sm {
+  font-size: .875rem;
+  line-height: 1.5rem;
+}
+
+.text-md {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.text-lg {
+  font-size: 1.25rem;
+  line-height: 2rem;
+}
+
+.text-xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+.text-2xl {
+  font-size: 2rem;
+  line-height: 2.5rem;
+}
+
+.text-3xl {
+  font-size: 2.5rem;
+  line-height: 3rem;
+}
+
+.text-4xl {
+  font-size: 3rem;
+  line-height: 3.25rem;
+}
+
+.font-thin {
+  font-weight: 100;
+}
+
+.font-extralight {
+  font-weight: 200;
+}
+
+.font-light {
+  font-weight: 300;
+}
+
+.font-normal {
+  font-weight: 400;
+}
+
+.font-medium {
+  font-weight: 500;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-extrabold {
+  font-weight: 800;
+}
+
+.font-black {
+  font-weight: 900;
+}
+
+.hover\\\\:font-thin:hover {
+  font-weight: 100;
+}
+
+.hover\\\\:font-extralight:hover {
+  font-weight: 200;
+}
+
+.hover\\\\:font-light:hover {
+  font-weight: 300;
+}
+
+.hover\\\\:font-normal:hover {
+  font-weight: 400;
+}
+
+.hover\\\\:font-medium:hover {
+  font-weight: 500;
+}
+
+.hover\\\\:font-semibold:hover {
+  font-weight: 600;
+}
+
+.hover\\\\:font-bold:hover {
+  font-weight: 700;
+}
+
+.hover\\\\:font-extrabold:hover {
+  font-weight: 800;
+}
+
+.hover\\\\:font-black:hover {
+  font-weight: 900;
+}
+
+.focus\\\\:font-thin:focus {
+  font-weight: 100;
+}
+
+.focus\\\\:font-extralight:focus {
+  font-weight: 200;
+}
+
+.focus\\\\:font-light:focus {
+  font-weight: 300;
+}
+
+.focus\\\\:font-normal:focus {
+  font-weight: 400;
+}
+
+.focus\\\\:font-medium:focus {
+  font-weight: 500;
+}
+
+.focus\\\\:font-semibold:focus {
+  font-weight: 600;
+}
+
+.focus\\\\:font-bold:focus {
+  font-weight: 700;
+}
+
+.focus\\\\:font-extrabold:focus {
+  font-weight: 800;
+}
+
+.focus\\\\:font-black:focus {
+  font-weight: 900;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.lowercase {
+  text-transform: lowercase;
+}
+
+.capitalize {
+  text-transform: capitalize;
+}
+
+.normal-case {
+  text-transform: none;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.not-italic {
+  font-style: normal;
+}
+
+.ordinal, .slashed-zero, .lining-nums, .oldstyle-nums, .proportional-nums, .tabular-nums, .diagonal-fractions, .stacked-fractions {
+  --tw-ordinal: var(--tw-empty,/*!*/ /*!*/);
+  --tw-slashed-zero: var(--tw-empty,/*!*/ /*!*/);
+  --tw-numeric-figure: var(--tw-empty,/*!*/ /*!*/);
+  --tw-numeric-spacing: var(--tw-empty,/*!*/ /*!*/);
+  --tw-numeric-fraction: var(--tw-empty,/*!*/ /*!*/);
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
+}
+
+.normal-nums {
+  font-variant-numeric: normal;
+}
+
+.ordinal {
+  --tw-ordinal: ordinal;
+}
+
+.slashed-zero {
+  --tw-slashed-zero: slashed-zero;
+}
+
+.lining-nums {
+  --tw-numeric-figure: lining-nums;
+}
+
+.oldstyle-nums {
+  --tw-numeric-figure: oldstyle-nums;
+}
+
+.proportional-nums {
+  --tw-numeric-spacing: proportional-nums;
+}
+
+.tabular-nums {
+  --tw-numeric-spacing: tabular-nums;
+}
+
+.diagonal-fractions {
+  --tw-numeric-fraction: diagonal-fractions;
+}
+
+.stacked-fractions {
+  --tw-numeric-fraction: stacked-fractions;
+}
+
+.leading-3 {
+  line-height: .75rem;
+}
+
+.leading-4 {
+  line-height: 1rem;
+}
+
+.leading-5 {
+  line-height: 1.25rem;
+}
+
+.leading-6 {
+  line-height: 1.5rem;
+}
+
+.leading-7 {
+  line-height: 1.75rem;
+}
+
+.leading-8 {
+  line-height: 2rem;
+}
+
+.leading-9 {
+  line-height: 2.25rem;
+}
+
+.leading-10 {
+  line-height: 2.5rem;
+}
+
+.leading-12 {
+  line-height: 3rem;
+}
+
+.leading-13 {
+  line-height: 3.25rem;
+}
+
+.leading-none {
+  line-height: 1;
+}
+
+.leading-tight {
+  line-height: 1.25;
+}
+
+.leading-snug {
+  line-height: 1.375;
+}
+
+.leading-normal {
+  line-height: 1.5;
+}
+
+.leading-relaxed {
+  line-height: 1.625;
+}
+
+.leading-loose {
+  line-height: 2;
+}
+
+.tracking-tighter {
+  letter-spacing: -0.05em;
+}
+
+.tracking-tight {
+  letter-spacing: -0.025em;
+}
+
+.tracking-normal {
+  letter-spacing: 0em;
+}
+
+.tracking-wide {
+  letter-spacing: 0.025em;
+}
+
+.tracking-wider {
+  letter-spacing: 0.05em;
+}
+
+.tracking-widest {
+  letter-spacing: 0.1em;
+}
+
+.text-current {
+  color: currentColor;
+}
+
+.text-transparent {
+  color: transparent;
+}
+
+.text-falcon {
+  color: var(--falcon);
+}
+
+.text-basement {
+  color: var(--basement);
+}
+
+.text-blue {
+  color: var(--blue);
+}
+
+.text-body-and-labels {
+  color: var(--body-and-labels);
+}
+
+.text-brand {
+  color: var(--brand);
+}
+
+.text-code-base-64 {
+  color: var(--code-base-64);
+}
+
+.text-code-bg {
+  color: var(--code-bg);
+}
+
+.text-code-outline {
+  color: var(--code-outline);
+}
+
+.text-code-text {
+  color: var(--code-text);
+}
+
+.text-critical {
+  color: var(--critical);
+}
+
+.text-destructive-hover {
+  color: var(--destructive-hover);
+}
+
+.text-destructive-idle {
+  color: var(--destructive-idle);
+}
+
+.text-destructive-pressed {
+  color: var(--destructive-pressed);
+}
+
+.text-disabled {
+  color: var(--disabled);
+}
+
+.text-disc-operations {
+  color: var(--disc-operations);
+}
+
+.text-dns-requests {
+  color: var(--dns-requests);
+}
+
+.text-focus {
+  color: var(--focus);
+}
+
+.text-graph-1 {
+  color: var(--graph-1);
+}
+
+.text-graph-10 {
+  color: var(--graph-10);
+}
+
+.text-graph-11 {
+  color: var(--graph-11);
+}
+
+.text-graph-2 {
+  color: var(--graph-2);
+}
+
+.text-graph-3 {
+  color: var(--graph-3);
+}
+
+.text-graph-4 {
+  color: var(--graph-4);
+}
+
+.text-graph-5 {
+  color: var(--graph-5);
+}
+
+.text-graph-6 {
+  color: var(--graph-6);
+}
+
+.text-graph-7 {
+  color: var(--graph-7);
+}
+
+.text-graph-8 {
+  color: var(--graph-8);
+}
+
+.text-graph-9 {
+  color: var(--graph-9);
+}
+
+.text-graph-disabled {
+  color: var(--graph-disabled);
+}
+
+.text-ground-floor {
+  color: var(--ground-floor);
+}
+
+.text-high {
+  color: var(--high);
+}
+
+.text-informational {
+  color: var(--informational);
+}
+
+.text-lines-dark {
+  color: var(--lines-dark);
+}
+
+.text-lines-light {
+  color: var(--lines-light);
+}
+
+.text-low {
+  color: var(--low);
+}
+
+.text-medium {
+  color: var(--medium);
+}
+
+.text-mezzanine {
+  color: var(--mezzanine);
+}
+
+.text-nav-text-and-icons {
+  color: var(--nav-text-and-icons);
+}
+
+.text-nav-text-secondary {
+  color: var(--nav-text-secondary);
+}
+
+.text-network-operations {
+  color: var(--network-operations);
+}
+
+.text-normal-hover {
+  color: var(--normal-hover);
+}
+
+.text-normal-idle {
+  color: var(--normal-idle);
+}
+
+.text-normal-pressed {
+  color: var(--normal-pressed);
+}
+
+.text-overlay-0\\\\.5 {
+  color: var(--overlay-0\\\\.5);
+}
+
+.text-overlay-1 {
+  color: var(--overlay-1);
+}
+
+.text-overlay-2 {
+  color: var(--overlay-2);
+}
+
+.text-positive {
+  color: var(--positive);
+}
+
+.text-primary-hover {
+  color: var(--primary-hover);
+}
+
+.text-primary-idle {
+  color: var(--primary-idle);
+}
+
+.text-primary-pressed {
+  color: var(--primary-pressed);
+}
+
+.text-process-operations {
+  color: var(--process-operations);
+}
+
+.text-purple {
+  color: var(--purple);
+}
+
+.text-registry-operations {
+  color: var(--registry-operations);
+}
+
+.text-selected {
+  color: var(--selected);
+}
+
+.text-surface-2xl {
+  color: var(--surface-2xl);
+}
+
+.text-surface-base {
+  color: var(--surface-base);
+}
+
+.text-surface-inner {
+  color: var(--surface-inner);
+}
+
+.text-surface-lg {
+  color: var(--surface-lg);
+}
+
+.text-surface-md {
+  color: var(--surface-md);
+}
+
+.text-surface-xl {
+  color: var(--surface-xl);
+}
+
+.text-text-and-icons {
+  color: var(--text-and-icons);
+}
+
+.text-titles-and-attributes {
+  color: var(--titles-and-attributes);
+}
+
+.hover\\\\:text-current:hover {
+  color: currentColor;
+}
+
+.hover\\\\:text-transparent:hover {
+  color: transparent;
+}
+
+.hover\\\\:text-falcon:hover {
+  color: var(--falcon);
+}
+
+.hover\\\\:text-basement:hover {
+  color: var(--basement);
+}
+
+.hover\\\\:text-blue:hover {
+  color: var(--blue);
+}
+
+.hover\\\\:text-body-and-labels:hover {
+  color: var(--body-and-labels);
+}
+
+.hover\\\\:text-brand:hover {
+  color: var(--brand);
+}
+
+.hover\\\\:text-code-base-64:hover {
+  color: var(--code-base-64);
+}
+
+.hover\\\\:text-code-bg:hover {
+  color: var(--code-bg);
+}
+
+.hover\\\\:text-code-outline:hover {
+  color: var(--code-outline);
+}
+
+.hover\\\\:text-code-text:hover {
+  color: var(--code-text);
+}
+
+.hover\\\\:text-critical:hover {
+  color: var(--critical);
+}
+
+.hover\\\\:text-destructive-hover:hover {
+  color: var(--destructive-hover);
+}
+
+.hover\\\\:text-destructive-idle:hover {
+  color: var(--destructive-idle);
+}
+
+.hover\\\\:text-destructive-pressed:hover {
+  color: var(--destructive-pressed);
+}
+
+.hover\\\\:text-disabled:hover {
+  color: var(--disabled);
+}
+
+.hover\\\\:text-disc-operations:hover {
+  color: var(--disc-operations);
+}
+
+.hover\\\\:text-dns-requests:hover {
+  color: var(--dns-requests);
+}
+
+.hover\\\\:text-focus:hover {
+  color: var(--focus);
+}
+
+.hover\\\\:text-graph-1:hover {
+  color: var(--graph-1);
+}
+
+.hover\\\\:text-graph-10:hover {
+  color: var(--graph-10);
+}
+
+.hover\\\\:text-graph-11:hover {
+  color: var(--graph-11);
+}
+
+.hover\\\\:text-graph-2:hover {
+  color: var(--graph-2);
+}
+
+.hover\\\\:text-graph-3:hover {
+  color: var(--graph-3);
+}
+
+.hover\\\\:text-graph-4:hover {
+  color: var(--graph-4);
+}
+
+.hover\\\\:text-graph-5:hover {
+  color: var(--graph-5);
+}
+
+.hover\\\\:text-graph-6:hover {
+  color: var(--graph-6);
+}
+
+.hover\\\\:text-graph-7:hover {
+  color: var(--graph-7);
+}
+
+.hover\\\\:text-graph-8:hover {
+  color: var(--graph-8);
+}
+
+.hover\\\\:text-graph-9:hover {
+  color: var(--graph-9);
+}
+
+.hover\\\\:text-graph-disabled:hover {
+  color: var(--graph-disabled);
+}
+
+.hover\\\\:text-ground-floor:hover {
+  color: var(--ground-floor);
+}
+
+.hover\\\\:text-high:hover {
+  color: var(--high);
+}
+
+.hover\\\\:text-informational:hover {
+  color: var(--informational);
+}
+
+.hover\\\\:text-lines-dark:hover {
+  color: var(--lines-dark);
+}
+
+.hover\\\\:text-lines-light:hover {
+  color: var(--lines-light);
+}
+
+.hover\\\\:text-low:hover {
+  color: var(--low);
+}
+
+.hover\\\\:text-medium:hover {
+  color: var(--medium);
+}
+
+.hover\\\\:text-mezzanine:hover {
+  color: var(--mezzanine);
+}
+
+.hover\\\\:text-nav-text-and-icons:hover {
+  color: var(--nav-text-and-icons);
+}
+
+.hover\\\\:text-nav-text-secondary:hover {
+  color: var(--nav-text-secondary);
+}
+
+.hover\\\\:text-network-operations:hover {
+  color: var(--network-operations);
+}
+
+.hover\\\\:text-normal-hover:hover {
+  color: var(--normal-hover);
+}
+
+.hover\\\\:text-normal-idle:hover {
+  color: var(--normal-idle);
+}
+
+.hover\\\\:text-normal-pressed:hover {
+  color: var(--normal-pressed);
+}
+
+.hover\\\\:text-overlay-0\\\\.5:hover {
+  color: var(--overlay-0\\\\.5);
+}
+
+.hover\\\\:text-overlay-1:hover {
+  color: var(--overlay-1);
+}
+
+.hover\\\\:text-overlay-2:hover {
+  color: var(--overlay-2);
+}
+
+.hover\\\\:text-positive:hover {
+  color: var(--positive);
+}
+
+.hover\\\\:text-primary-hover:hover {
+  color: var(--primary-hover);
+}
+
+.hover\\\\:text-primary-idle:hover {
+  color: var(--primary-idle);
+}
+
+.hover\\\\:text-primary-pressed:hover {
+  color: var(--primary-pressed);
+}
+
+.hover\\\\:text-process-operations:hover {
+  color: var(--process-operations);
+}
+
+.hover\\\\:text-purple:hover {
+  color: var(--purple);
+}
+
+.hover\\\\:text-registry-operations:hover {
+  color: var(--registry-operations);
+}
+
+.hover\\\\:text-selected:hover {
+  color: var(--selected);
+}
+
+.hover\\\\:text-surface-2xl:hover {
+  color: var(--surface-2xl);
+}
+
+.hover\\\\:text-surface-base:hover {
+  color: var(--surface-base);
+}
+
+.hover\\\\:text-surface-inner:hover {
+  color: var(--surface-inner);
+}
+
+.hover\\\\:text-surface-lg:hover {
+  color: var(--surface-lg);
+}
+
+.hover\\\\:text-surface-md:hover {
+  color: var(--surface-md);
+}
+
+.hover\\\\:text-surface-xl:hover {
+  color: var(--surface-xl);
+}
+
+.hover\\\\:text-text-and-icons:hover {
+  color: var(--text-and-icons);
+}
+
+.hover\\\\:text-titles-and-attributes:hover {
+  color: var(--titles-and-attributes);
+}
+
+.focus\\\\:text-current:focus {
+  color: currentColor;
+}
+
+.focus\\\\:text-transparent:focus {
+  color: transparent;
+}
+
+.focus\\\\:text-falcon:focus {
+  color: var(--falcon);
+}
+
+.focus\\\\:text-basement:focus {
+  color: var(--basement);
+}
+
+.focus\\\\:text-blue:focus {
+  color: var(--blue);
+}
+
+.focus\\\\:text-body-and-labels:focus {
+  color: var(--body-and-labels);
+}
+
+.focus\\\\:text-brand:focus {
+  color: var(--brand);
+}
+
+.focus\\\\:text-code-base-64:focus {
+  color: var(--code-base-64);
+}
+
+.focus\\\\:text-code-bg:focus {
+  color: var(--code-bg);
+}
+
+.focus\\\\:text-code-outline:focus {
+  color: var(--code-outline);
+}
+
+.focus\\\\:text-code-text:focus {
+  color: var(--code-text);
+}
+
+.focus\\\\:text-critical:focus {
+  color: var(--critical);
+}
+
+.focus\\\\:text-destructive-hover:focus {
+  color: var(--destructive-hover);
+}
+
+.focus\\\\:text-destructive-idle:focus {
+  color: var(--destructive-idle);
+}
+
+.focus\\\\:text-destructive-pressed:focus {
+  color: var(--destructive-pressed);
+}
+
+.focus\\\\:text-disabled:focus {
+  color: var(--disabled);
+}
+
+.focus\\\\:text-disc-operations:focus {
+  color: var(--disc-operations);
+}
+
+.focus\\\\:text-dns-requests:focus {
+  color: var(--dns-requests);
+}
+
+.focus\\\\:text-focus:focus {
+  color: var(--focus);
+}
+
+.focus\\\\:text-graph-1:focus {
+  color: var(--graph-1);
+}
+
+.focus\\\\:text-graph-10:focus {
+  color: var(--graph-10);
+}
+
+.focus\\\\:text-graph-11:focus {
+  color: var(--graph-11);
+}
+
+.focus\\\\:text-graph-2:focus {
+  color: var(--graph-2);
+}
+
+.focus\\\\:text-graph-3:focus {
+  color: var(--graph-3);
+}
+
+.focus\\\\:text-graph-4:focus {
+  color: var(--graph-4);
+}
+
+.focus\\\\:text-graph-5:focus {
+  color: var(--graph-5);
+}
+
+.focus\\\\:text-graph-6:focus {
+  color: var(--graph-6);
+}
+
+.focus\\\\:text-graph-7:focus {
+  color: var(--graph-7);
+}
+
+.focus\\\\:text-graph-8:focus {
+  color: var(--graph-8);
+}
+
+.focus\\\\:text-graph-9:focus {
+  color: var(--graph-9);
+}
+
+.focus\\\\:text-graph-disabled:focus {
+  color: var(--graph-disabled);
+}
+
+.focus\\\\:text-ground-floor:focus {
+  color: var(--ground-floor);
+}
+
+.focus\\\\:text-high:focus {
+  color: var(--high);
+}
+
+.focus\\\\:text-informational:focus {
+  color: var(--informational);
+}
+
+.focus\\\\:text-lines-dark:focus {
+  color: var(--lines-dark);
+}
+
+.focus\\\\:text-lines-light:focus {
+  color: var(--lines-light);
+}
+
+.focus\\\\:text-low:focus {
+  color: var(--low);
+}
+
+.focus\\\\:text-medium:focus {
+  color: var(--medium);
+}
+
+.focus\\\\:text-mezzanine:focus {
+  color: var(--mezzanine);
+}
+
+.focus\\\\:text-nav-text-and-icons:focus {
+  color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:text-nav-text-secondary:focus {
+  color: var(--nav-text-secondary);
+}
+
+.focus\\\\:text-network-operations:focus {
+  color: var(--network-operations);
+}
+
+.focus\\\\:text-normal-hover:focus {
+  color: var(--normal-hover);
+}
+
+.focus\\\\:text-normal-idle:focus {
+  color: var(--normal-idle);
+}
+
+.focus\\\\:text-normal-pressed:focus {
+  color: var(--normal-pressed);
+}
+
+.focus\\\\:text-overlay-0\\\\.5:focus {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:text-overlay-1:focus {
+  color: var(--overlay-1);
+}
+
+.focus\\\\:text-overlay-2:focus {
+  color: var(--overlay-2);
+}
+
+.focus\\\\:text-positive:focus {
+  color: var(--positive);
+}
+
+.focus\\\\:text-primary-hover:focus {
+  color: var(--primary-hover);
+}
+
+.focus\\\\:text-primary-idle:focus {
+  color: var(--primary-idle);
+}
+
+.focus\\\\:text-primary-pressed:focus {
+  color: var(--primary-pressed);
+}
+
+.focus\\\\:text-process-operations:focus {
+  color: var(--process-operations);
+}
+
+.focus\\\\:text-purple:focus {
+  color: var(--purple);
+}
+
+.focus\\\\:text-registry-operations:focus {
+  color: var(--registry-operations);
+}
+
+.focus\\\\:text-selected:focus {
+  color: var(--selected);
+}
+
+.focus\\\\:text-surface-2xl:focus {
+  color: var(--surface-2xl);
+}
+
+.focus\\\\:text-surface-base:focus {
+  color: var(--surface-base);
+}
+
+.focus\\\\:text-surface-inner:focus {
+  color: var(--surface-inner);
+}
+
+.focus\\\\:text-surface-lg:focus {
+  color: var(--surface-lg);
+}
+
+.focus\\\\:text-surface-md:focus {
+  color: var(--surface-md);
+}
+
+.focus\\\\:text-surface-xl:focus {
+  color: var(--surface-xl);
+}
+
+.focus\\\\:text-text-and-icons:focus {
+  color: var(--text-and-icons);
+}
+
+.focus\\\\:text-titles-and-attributes:focus {
+  color: var(--titles-and-attributes);
+}
+
+.focus-visible\\\\:text-current:focus-visible {
+  color: currentColor;
+}
+
+.focus-visible\\\\:text-transparent:focus-visible {
+  color: transparent;
+}
+
+.focus-visible\\\\:text-falcon:focus-visible {
+  color: var(--falcon);
+}
+
+.focus-visible\\\\:text-basement:focus-visible {
+  color: var(--basement);
+}
+
+.focus-visible\\\\:text-blue:focus-visible {
+  color: var(--blue);
+}
+
+.focus-visible\\\\:text-body-and-labels:focus-visible {
+  color: var(--body-and-labels);
+}
+
+.focus-visible\\\\:text-brand:focus-visible {
+  color: var(--brand);
+}
+
+.focus-visible\\\\:text-code-base-64:focus-visible {
+  color: var(--code-base-64);
+}
+
+.focus-visible\\\\:text-code-bg:focus-visible {
+  color: var(--code-bg);
+}
+
+.focus-visible\\\\:text-code-outline:focus-visible {
+  color: var(--code-outline);
+}
+
+.focus-visible\\\\:text-code-text:focus-visible {
+  color: var(--code-text);
+}
+
+.focus-visible\\\\:text-critical:focus-visible {
+  color: var(--critical);
+}
+
+.focus-visible\\\\:text-destructive-hover:focus-visible {
+  color: var(--destructive-hover);
+}
+
+.focus-visible\\\\:text-destructive-idle:focus-visible {
+  color: var(--destructive-idle);
+}
+
+.focus-visible\\\\:text-destructive-pressed:focus-visible {
+  color: var(--destructive-pressed);
+}
+
+.focus-visible\\\\:text-disabled:focus-visible {
+  color: var(--disabled);
+}
+
+.focus-visible\\\\:text-disc-operations:focus-visible {
+  color: var(--disc-operations);
+}
+
+.focus-visible\\\\:text-dns-requests:focus-visible {
+  color: var(--dns-requests);
+}
+
+.focus-visible\\\\:text-focus:focus-visible {
+  color: var(--focus);
+}
+
+.focus-visible\\\\:text-graph-1:focus-visible {
+  color: var(--graph-1);
+}
+
+.focus-visible\\\\:text-graph-10:focus-visible {
+  color: var(--graph-10);
+}
+
+.focus-visible\\\\:text-graph-11:focus-visible {
+  color: var(--graph-11);
+}
+
+.focus-visible\\\\:text-graph-2:focus-visible {
+  color: var(--graph-2);
+}
+
+.focus-visible\\\\:text-graph-3:focus-visible {
+  color: var(--graph-3);
+}
+
+.focus-visible\\\\:text-graph-4:focus-visible {
+  color: var(--graph-4);
+}
+
+.focus-visible\\\\:text-graph-5:focus-visible {
+  color: var(--graph-5);
+}
+
+.focus-visible\\\\:text-graph-6:focus-visible {
+  color: var(--graph-6);
+}
+
+.focus-visible\\\\:text-graph-7:focus-visible {
+  color: var(--graph-7);
+}
+
+.focus-visible\\\\:text-graph-8:focus-visible {
+  color: var(--graph-8);
+}
+
+.focus-visible\\\\:text-graph-9:focus-visible {
+  color: var(--graph-9);
+}
+
+.focus-visible\\\\:text-graph-disabled:focus-visible {
+  color: var(--graph-disabled);
+}
+
+.focus-visible\\\\:text-ground-floor:focus-visible {
+  color: var(--ground-floor);
+}
+
+.focus-visible\\\\:text-high:focus-visible {
+  color: var(--high);
+}
+
+.focus-visible\\\\:text-informational:focus-visible {
+  color: var(--informational);
+}
+
+.focus-visible\\\\:text-lines-dark:focus-visible {
+  color: var(--lines-dark);
+}
+
+.focus-visible\\\\:text-lines-light:focus-visible {
+  color: var(--lines-light);
+}
+
+.focus-visible\\\\:text-low:focus-visible {
+  color: var(--low);
+}
+
+.focus-visible\\\\:text-medium:focus-visible {
+  color: var(--medium);
+}
+
+.focus-visible\\\\:text-mezzanine:focus-visible {
+  color: var(--mezzanine);
+}
+
+.focus-visible\\\\:text-nav-text-and-icons:focus-visible {
+  color: var(--nav-text-and-icons);
+}
+
+.focus-visible\\\\:text-nav-text-secondary:focus-visible {
+  color: var(--nav-text-secondary);
+}
+
+.focus-visible\\\\:text-network-operations:focus-visible {
+  color: var(--network-operations);
+}
+
+.focus-visible\\\\:text-normal-hover:focus-visible {
+  color: var(--normal-hover);
+}
+
+.focus-visible\\\\:text-normal-idle:focus-visible {
+  color: var(--normal-idle);
+}
+
+.focus-visible\\\\:text-normal-pressed:focus-visible {
+  color: var(--normal-pressed);
+}
+
+.focus-visible\\\\:text-overlay-0\\\\.5:focus-visible {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus-visible\\\\:text-overlay-1:focus-visible {
+  color: var(--overlay-1);
+}
+
+.focus-visible\\\\:text-overlay-2:focus-visible {
+  color: var(--overlay-2);
+}
+
+.focus-visible\\\\:text-positive:focus-visible {
+  color: var(--positive);
+}
+
+.focus-visible\\\\:text-primary-hover:focus-visible {
+  color: var(--primary-hover);
+}
+
+.focus-visible\\\\:text-primary-idle:focus-visible {
+  color: var(--primary-idle);
+}
+
+.focus-visible\\\\:text-primary-pressed:focus-visible {
+  color: var(--primary-pressed);
+}
+
+.focus-visible\\\\:text-process-operations:focus-visible {
+  color: var(--process-operations);
+}
+
+.focus-visible\\\\:text-purple:focus-visible {
+  color: var(--purple);
+}
+
+.focus-visible\\\\:text-registry-operations:focus-visible {
+  color: var(--registry-operations);
+}
+
+.focus-visible\\\\:text-selected:focus-visible {
+  color: var(--selected);
+}
+
+.focus-visible\\\\:text-surface-2xl:focus-visible {
+  color: var(--surface-2xl);
+}
+
+.focus-visible\\\\:text-surface-base:focus-visible {
+  color: var(--surface-base);
+}
+
+.focus-visible\\\\:text-surface-inner:focus-visible {
+  color: var(--surface-inner);
+}
+
+.focus-visible\\\\:text-surface-lg:focus-visible {
+  color: var(--surface-lg);
+}
+
+.focus-visible\\\\:text-surface-md:focus-visible {
+  color: var(--surface-md);
+}
+
+.focus-visible\\\\:text-surface-xl:focus-visible {
+  color: var(--surface-xl);
+}
+
+.focus-visible\\\\:text-text-and-icons:focus-visible {
+  color: var(--text-and-icons);
+}
+
+.focus-visible\\\\:text-titles-and-attributes:focus-visible {
+  color: var(--titles-and-attributes);
+}
+
+.group:hover .group-hover\\\\:text-current {
+  color: currentColor;
+}
+
+.group:hover .group-hover\\\\:text-transparent {
+  color: transparent;
+}
+
+.group:hover .group-hover\\\\:text-falcon {
+  color: var(--falcon);
+}
+
+.group:hover .group-hover\\\\:text-basement {
+  color: var(--basement);
+}
+
+.group:hover .group-hover\\\\:text-blue {
+  color: var(--blue);
+}
+
+.group:hover .group-hover\\\\:text-body-and-labels {
+  color: var(--body-and-labels);
+}
+
+.group:hover .group-hover\\\\:text-brand {
+  color: var(--brand);
+}
+
+.group:hover .group-hover\\\\:text-code-base-64 {
+  color: var(--code-base-64);
+}
+
+.group:hover .group-hover\\\\:text-code-bg {
+  color: var(--code-bg);
+}
+
+.group:hover .group-hover\\\\:text-code-outline {
+  color: var(--code-outline);
+}
+
+.group:hover .group-hover\\\\:text-code-text {
+  color: var(--code-text);
+}
+
+.group:hover .group-hover\\\\:text-critical {
+  color: var(--critical);
+}
+
+.group:hover .group-hover\\\\:text-destructive-hover {
+  color: var(--destructive-hover);
+}
+
+.group:hover .group-hover\\\\:text-destructive-idle {
+  color: var(--destructive-idle);
+}
+
+.group:hover .group-hover\\\\:text-destructive-pressed {
+  color: var(--destructive-pressed);
+}
+
+.group:hover .group-hover\\\\:text-disabled {
+  color: var(--disabled);
+}
+
+.group:hover .group-hover\\\\:text-disc-operations {
+  color: var(--disc-operations);
+}
+
+.group:hover .group-hover\\\\:text-dns-requests {
+  color: var(--dns-requests);
+}
+
+.group:hover .group-hover\\\\:text-focus {
+  color: var(--focus);
+}
+
+.group:hover .group-hover\\\\:text-graph-1 {
+  color: var(--graph-1);
+}
+
+.group:hover .group-hover\\\\:text-graph-10 {
+  color: var(--graph-10);
+}
+
+.group:hover .group-hover\\\\:text-graph-11 {
+  color: var(--graph-11);
+}
+
+.group:hover .group-hover\\\\:text-graph-2 {
+  color: var(--graph-2);
+}
+
+.group:hover .group-hover\\\\:text-graph-3 {
+  color: var(--graph-3);
+}
+
+.group:hover .group-hover\\\\:text-graph-4 {
+  color: var(--graph-4);
+}
+
+.group:hover .group-hover\\\\:text-graph-5 {
+  color: var(--graph-5);
+}
+
+.group:hover .group-hover\\\\:text-graph-6 {
+  color: var(--graph-6);
+}
+
+.group:hover .group-hover\\\\:text-graph-7 {
+  color: var(--graph-7);
+}
+
+.group:hover .group-hover\\\\:text-graph-8 {
+  color: var(--graph-8);
+}
+
+.group:hover .group-hover\\\\:text-graph-9 {
+  color: var(--graph-9);
+}
+
+.group:hover .group-hover\\\\:text-graph-disabled {
+  color: var(--graph-disabled);
+}
+
+.group:hover .group-hover\\\\:text-ground-floor {
+  color: var(--ground-floor);
+}
+
+.group:hover .group-hover\\\\:text-high {
+  color: var(--high);
+}
+
+.group:hover .group-hover\\\\:text-informational {
+  color: var(--informational);
+}
+
+.group:hover .group-hover\\\\:text-lines-dark {
+  color: var(--lines-dark);
+}
+
+.group:hover .group-hover\\\\:text-lines-light {
+  color: var(--lines-light);
+}
+
+.group:hover .group-hover\\\\:text-low {
+  color: var(--low);
+}
+
+.group:hover .group-hover\\\\:text-medium {
+  color: var(--medium);
+}
+
+.group:hover .group-hover\\\\:text-mezzanine {
+  color: var(--mezzanine);
+}
+
+.group:hover .group-hover\\\\:text-nav-text-and-icons {
+  color: var(--nav-text-and-icons);
+}
+
+.group:hover .group-hover\\\\:text-nav-text-secondary {
+  color: var(--nav-text-secondary);
+}
+
+.group:hover .group-hover\\\\:text-network-operations {
+  color: var(--network-operations);
+}
+
+.group:hover .group-hover\\\\:text-normal-hover {
+  color: var(--normal-hover);
+}
+
+.group:hover .group-hover\\\\:text-normal-idle {
+  color: var(--normal-idle);
+}
+
+.group:hover .group-hover\\\\:text-normal-pressed {
+  color: var(--normal-pressed);
+}
+
+.group:hover .group-hover\\\\:text-overlay-0\\\\.5 {
+  color: var(--overlay-0\\\\.5);
+}
+
+.group:hover .group-hover\\\\:text-overlay-1 {
+  color: var(--overlay-1);
+}
+
+.group:hover .group-hover\\\\:text-overlay-2 {
+  color: var(--overlay-2);
+}
+
+.group:hover .group-hover\\\\:text-positive {
+  color: var(--positive);
+}
+
+.group:hover .group-hover\\\\:text-primary-hover {
+  color: var(--primary-hover);
+}
+
+.group:hover .group-hover\\\\:text-primary-idle {
+  color: var(--primary-idle);
+}
+
+.group:hover .group-hover\\\\:text-primary-pressed {
+  color: var(--primary-pressed);
+}
+
+.group:hover .group-hover\\\\:text-process-operations {
+  color: var(--process-operations);
+}
+
+.group:hover .group-hover\\\\:text-purple {
+  color: var(--purple);
+}
+
+.group:hover .group-hover\\\\:text-registry-operations {
+  color: var(--registry-operations);
+}
+
+.group:hover .group-hover\\\\:text-selected {
+  color: var(--selected);
+}
+
+.group:hover .group-hover\\\\:text-surface-2xl {
+  color: var(--surface-2xl);
+}
+
+.group:hover .group-hover\\\\:text-surface-base {
+  color: var(--surface-base);
+}
+
+.group:hover .group-hover\\\\:text-surface-inner {
+  color: var(--surface-inner);
+}
+
+.group:hover .group-hover\\\\:text-surface-lg {
+  color: var(--surface-lg);
+}
+
+.group:hover .group-hover\\\\:text-surface-md {
+  color: var(--surface-md);
+}
+
+.group:hover .group-hover\\\\:text-surface-xl {
+  color: var(--surface-xl);
+}
+
+.group:hover .group-hover\\\\:text-text-and-icons {
+  color: var(--text-and-icons);
+}
+
+.group:hover .group-hover\\\\:text-titles-and-attributes {
+  color: var(--titles-and-attributes);
+}
+
+.active\\\\:text-current:active {
+  color: currentColor;
+}
+
+.active\\\\:text-transparent:active {
+  color: transparent;
+}
+
+.active\\\\:text-falcon:active {
+  color: var(--falcon);
+}
+
+.active\\\\:text-basement:active {
+  color: var(--basement);
+}
+
+.active\\\\:text-blue:active {
+  color: var(--blue);
+}
+
+.active\\\\:text-body-and-labels:active {
+  color: var(--body-and-labels);
+}
+
+.active\\\\:text-brand:active {
+  color: var(--brand);
+}
+
+.active\\\\:text-code-base-64:active {
+  color: var(--code-base-64);
+}
+
+.active\\\\:text-code-bg:active {
+  color: var(--code-bg);
+}
+
+.active\\\\:text-code-outline:active {
+  color: var(--code-outline);
+}
+
+.active\\\\:text-code-text:active {
+  color: var(--code-text);
+}
+
+.active\\\\:text-critical:active {
+  color: var(--critical);
+}
+
+.active\\\\:text-destructive-hover:active {
+  color: var(--destructive-hover);
+}
+
+.active\\\\:text-destructive-idle:active {
+  color: var(--destructive-idle);
+}
+
+.active\\\\:text-destructive-pressed:active {
+  color: var(--destructive-pressed);
+}
+
+.active\\\\:text-disabled:active {
+  color: var(--disabled);
+}
+
+.active\\\\:text-disc-operations:active {
+  color: var(--disc-operations);
+}
+
+.active\\\\:text-dns-requests:active {
+  color: var(--dns-requests);
+}
+
+.active\\\\:text-focus:active {
+  color: var(--focus);
+}
+
+.active\\\\:text-graph-1:active {
+  color: var(--graph-1);
+}
+
+.active\\\\:text-graph-10:active {
+  color: var(--graph-10);
+}
+
+.active\\\\:text-graph-11:active {
+  color: var(--graph-11);
+}
+
+.active\\\\:text-graph-2:active {
+  color: var(--graph-2);
+}
+
+.active\\\\:text-graph-3:active {
+  color: var(--graph-3);
+}
+
+.active\\\\:text-graph-4:active {
+  color: var(--graph-4);
+}
+
+.active\\\\:text-graph-5:active {
+  color: var(--graph-5);
+}
+
+.active\\\\:text-graph-6:active {
+  color: var(--graph-6);
+}
+
+.active\\\\:text-graph-7:active {
+  color: var(--graph-7);
+}
+
+.active\\\\:text-graph-8:active {
+  color: var(--graph-8);
+}
+
+.active\\\\:text-graph-9:active {
+  color: var(--graph-9);
+}
+
+.active\\\\:text-graph-disabled:active {
+  color: var(--graph-disabled);
+}
+
+.active\\\\:text-ground-floor:active {
+  color: var(--ground-floor);
+}
+
+.active\\\\:text-high:active {
+  color: var(--high);
+}
+
+.active\\\\:text-informational:active {
+  color: var(--informational);
+}
+
+.active\\\\:text-lines-dark:active {
+  color: var(--lines-dark);
+}
+
+.active\\\\:text-lines-light:active {
+  color: var(--lines-light);
+}
+
+.active\\\\:text-low:active {
+  color: var(--low);
+}
+
+.active\\\\:text-medium:active {
+  color: var(--medium);
+}
+
+.active\\\\:text-mezzanine:active {
+  color: var(--mezzanine);
+}
+
+.active\\\\:text-nav-text-and-icons:active {
+  color: var(--nav-text-and-icons);
+}
+
+.active\\\\:text-nav-text-secondary:active {
+  color: var(--nav-text-secondary);
+}
+
+.active\\\\:text-network-operations:active {
+  color: var(--network-operations);
+}
+
+.active\\\\:text-normal-hover:active {
+  color: var(--normal-hover);
+}
+
+.active\\\\:text-normal-idle:active {
+  color: var(--normal-idle);
+}
+
+.active\\\\:text-normal-pressed:active {
+  color: var(--normal-pressed);
+}
+
+.active\\\\:text-overlay-0\\\\.5:active {
+  color: var(--overlay-0\\\\.5);
+}
+
+.active\\\\:text-overlay-1:active {
+  color: var(--overlay-1);
+}
+
+.active\\\\:text-overlay-2:active {
+  color: var(--overlay-2);
+}
+
+.active\\\\:text-positive:active {
+  color: var(--positive);
+}
+
+.active\\\\:text-primary-hover:active {
+  color: var(--primary-hover);
+}
+
+.active\\\\:text-primary-idle:active {
+  color: var(--primary-idle);
+}
+
+.active\\\\:text-primary-pressed:active {
+  color: var(--primary-pressed);
+}
+
+.active\\\\:text-process-operations:active {
+  color: var(--process-operations);
+}
+
+.active\\\\:text-purple:active {
+  color: var(--purple);
+}
+
+.active\\\\:text-registry-operations:active {
+  color: var(--registry-operations);
+}
+
+.active\\\\:text-selected:active {
+  color: var(--selected);
+}
+
+.active\\\\:text-surface-2xl:active {
+  color: var(--surface-2xl);
+}
+
+.active\\\\:text-surface-base:active {
+  color: var(--surface-base);
+}
+
+.active\\\\:text-surface-inner:active {
+  color: var(--surface-inner);
+}
+
+.active\\\\:text-surface-lg:active {
+  color: var(--surface-lg);
+}
+
+.active\\\\:text-surface-md:active {
+  color: var(--surface-md);
+}
+
+.active\\\\:text-surface-xl:active {
+  color: var(--surface-xl);
+}
+
+.active\\\\:text-text-and-icons:active {
+  color: var(--text-and-icons);
+}
+
+.active\\\\:text-titles-and-attributes:active {
+  color: var(--titles-and-attributes);
+}
+
+.disabled\\\\:text-current:disabled {
+  color: currentColor;
+}
+
+.disabled\\\\:text-transparent:disabled {
+  color: transparent;
+}
+
+.disabled\\\\:text-falcon:disabled {
+  color: var(--falcon);
+}
+
+.disabled\\\\:text-basement:disabled {
+  color: var(--basement);
+}
+
+.disabled\\\\:text-blue:disabled {
+  color: var(--blue);
+}
+
+.disabled\\\\:text-body-and-labels:disabled {
+  color: var(--body-and-labels);
+}
+
+.disabled\\\\:text-brand:disabled {
+  color: var(--brand);
+}
+
+.disabled\\\\:text-code-base-64:disabled {
+  color: var(--code-base-64);
+}
+
+.disabled\\\\:text-code-bg:disabled {
+  color: var(--code-bg);
+}
+
+.disabled\\\\:text-code-outline:disabled {
+  color: var(--code-outline);
+}
+
+.disabled\\\\:text-code-text:disabled {
+  color: var(--code-text);
+}
+
+.disabled\\\\:text-critical:disabled {
+  color: var(--critical);
+}
+
+.disabled\\\\:text-destructive-hover:disabled {
+  color: var(--destructive-hover);
+}
+
+.disabled\\\\:text-destructive-idle:disabled {
+  color: var(--destructive-idle);
+}
+
+.disabled\\\\:text-destructive-pressed:disabled {
+  color: var(--destructive-pressed);
+}
+
+.disabled\\\\:text-disabled:disabled {
+  color: var(--disabled);
+}
+
+.disabled\\\\:text-disc-operations:disabled {
+  color: var(--disc-operations);
+}
+
+.disabled\\\\:text-dns-requests:disabled {
+  color: var(--dns-requests);
+}
+
+.disabled\\\\:text-focus:disabled {
+  color: var(--focus);
+}
+
+.disabled\\\\:text-graph-1:disabled {
+  color: var(--graph-1);
+}
+
+.disabled\\\\:text-graph-10:disabled {
+  color: var(--graph-10);
+}
+
+.disabled\\\\:text-graph-11:disabled {
+  color: var(--graph-11);
+}
+
+.disabled\\\\:text-graph-2:disabled {
+  color: var(--graph-2);
+}
+
+.disabled\\\\:text-graph-3:disabled {
+  color: var(--graph-3);
+}
+
+.disabled\\\\:text-graph-4:disabled {
+  color: var(--graph-4);
+}
+
+.disabled\\\\:text-graph-5:disabled {
+  color: var(--graph-5);
+}
+
+.disabled\\\\:text-graph-6:disabled {
+  color: var(--graph-6);
+}
+
+.disabled\\\\:text-graph-7:disabled {
+  color: var(--graph-7);
+}
+
+.disabled\\\\:text-graph-8:disabled {
+  color: var(--graph-8);
+}
+
+.disabled\\\\:text-graph-9:disabled {
+  color: var(--graph-9);
+}
+
+.disabled\\\\:text-graph-disabled:disabled {
+  color: var(--graph-disabled);
+}
+
+.disabled\\\\:text-ground-floor:disabled {
+  color: var(--ground-floor);
+}
+
+.disabled\\\\:text-high:disabled {
+  color: var(--high);
+}
+
+.disabled\\\\:text-informational:disabled {
+  color: var(--informational);
+}
+
+.disabled\\\\:text-lines-dark:disabled {
+  color: var(--lines-dark);
+}
+
+.disabled\\\\:text-lines-light:disabled {
+  color: var(--lines-light);
+}
+
+.disabled\\\\:text-low:disabled {
+  color: var(--low);
+}
+
+.disabled\\\\:text-medium:disabled {
+  color: var(--medium);
+}
+
+.disabled\\\\:text-mezzanine:disabled {
+  color: var(--mezzanine);
+}
+
+.disabled\\\\:text-nav-text-and-icons:disabled {
+  color: var(--nav-text-and-icons);
+}
+
+.disabled\\\\:text-nav-text-secondary:disabled {
+  color: var(--nav-text-secondary);
+}
+
+.disabled\\\\:text-network-operations:disabled {
+  color: var(--network-operations);
+}
+
+.disabled\\\\:text-normal-hover:disabled {
+  color: var(--normal-hover);
+}
+
+.disabled\\\\:text-normal-idle:disabled {
+  color: var(--normal-idle);
+}
+
+.disabled\\\\:text-normal-pressed:disabled {
+  color: var(--normal-pressed);
+}
+
+.disabled\\\\:text-overlay-0\\\\.5:disabled {
+  color: var(--overlay-0\\\\.5);
+}
+
+.disabled\\\\:text-overlay-1:disabled {
+  color: var(--overlay-1);
+}
+
+.disabled\\\\:text-overlay-2:disabled {
+  color: var(--overlay-2);
+}
+
+.disabled\\\\:text-positive:disabled {
+  color: var(--positive);
+}
+
+.disabled\\\\:text-primary-hover:disabled {
+  color: var(--primary-hover);
+}
+
+.disabled\\\\:text-primary-idle:disabled {
+  color: var(--primary-idle);
+}
+
+.disabled\\\\:text-primary-pressed:disabled {
+  color: var(--primary-pressed);
+}
+
+.disabled\\\\:text-process-operations:disabled {
+  color: var(--process-operations);
+}
+
+.disabled\\\\:text-purple:disabled {
+  color: var(--purple);
+}
+
+.disabled\\\\:text-registry-operations:disabled {
+  color: var(--registry-operations);
+}
+
+.disabled\\\\:text-selected:disabled {
+  color: var(--selected);
+}
+
+.disabled\\\\:text-surface-2xl:disabled {
+  color: var(--surface-2xl);
+}
+
+.disabled\\\\:text-surface-base:disabled {
+  color: var(--surface-base);
+}
+
+.disabled\\\\:text-surface-inner:disabled {
+  color: var(--surface-inner);
+}
+
+.disabled\\\\:text-surface-lg:disabled {
+  color: var(--surface-lg);
+}
+
+.disabled\\\\:text-surface-md:disabled {
+  color: var(--surface-md);
+}
+
+.disabled\\\\:text-surface-xl:disabled {
+  color: var(--surface-xl);
+}
+
+.disabled\\\\:text-text-and-icons:disabled {
+  color: var(--text-and-icons);
+}
+
+.disabled\\\\:text-titles-and-attributes:disabled {
+  color: var(--titles-and-attributes);
+}
+
+.text-opacity-0 {
+  --tw-text-opacity: 0;
+}
+
+.text-opacity-5 {
+  --tw-text-opacity: 0.05;
+}
+
+.text-opacity-10 {
+  --tw-text-opacity: 0.1;
+}
+
+.text-opacity-20 {
+  --tw-text-opacity: 0.2;
+}
+
+.text-opacity-25 {
+  --tw-text-opacity: 0.25;
+}
+
+.text-opacity-30 {
+  --tw-text-opacity: 0.3;
+}
+
+.text-opacity-40 {
+  --tw-text-opacity: 0.4;
+}
+
+.text-opacity-50 {
+  --tw-text-opacity: 0.5;
+}
+
+.text-opacity-60 {
+  --tw-text-opacity: 0.6;
+}
+
+.text-opacity-70 {
+  --tw-text-opacity: 0.7;
+}
+
+.text-opacity-75 {
+  --tw-text-opacity: 0.75;
+}
+
+.text-opacity-80 {
+  --tw-text-opacity: 0.8;
+}
+
+.text-opacity-90 {
+  --tw-text-opacity: 0.9;
+}
+
+.text-opacity-95 {
+  --tw-text-opacity: 0.95;
+}
+
+.text-opacity-100 {
+  --tw-text-opacity: 1;
+}
+
+.hover\\\\:text-opacity-0:hover {
+  --tw-text-opacity: 0;
+}
+
+.hover\\\\:text-opacity-5:hover {
+  --tw-text-opacity: 0.05;
+}
+
+.hover\\\\:text-opacity-10:hover {
+  --tw-text-opacity: 0.1;
+}
+
+.hover\\\\:text-opacity-20:hover {
+  --tw-text-opacity: 0.2;
+}
+
+.hover\\\\:text-opacity-25:hover {
+  --tw-text-opacity: 0.25;
+}
+
+.hover\\\\:text-opacity-30:hover {
+  --tw-text-opacity: 0.3;
+}
+
+.hover\\\\:text-opacity-40:hover {
+  --tw-text-opacity: 0.4;
+}
+
+.hover\\\\:text-opacity-50:hover {
+  --tw-text-opacity: 0.5;
+}
+
+.hover\\\\:text-opacity-60:hover {
+  --tw-text-opacity: 0.6;
+}
+
+.hover\\\\:text-opacity-70:hover {
+  --tw-text-opacity: 0.7;
+}
+
+.hover\\\\:text-opacity-75:hover {
+  --tw-text-opacity: 0.75;
+}
+
+.hover\\\\:text-opacity-80:hover {
+  --tw-text-opacity: 0.8;
+}
+
+.hover\\\\:text-opacity-90:hover {
+  --tw-text-opacity: 0.9;
+}
+
+.hover\\\\:text-opacity-95:hover {
+  --tw-text-opacity: 0.95;
+}
+
+.hover\\\\:text-opacity-100:hover {
+  --tw-text-opacity: 1;
+}
+
+.focus\\\\:text-opacity-0:focus {
+  --tw-text-opacity: 0;
+}
+
+.focus\\\\:text-opacity-5:focus {
+  --tw-text-opacity: 0.05;
+}
+
+.focus\\\\:text-opacity-10:focus {
+  --tw-text-opacity: 0.1;
+}
+
+.focus\\\\:text-opacity-20:focus {
+  --tw-text-opacity: 0.2;
+}
+
+.focus\\\\:text-opacity-25:focus {
+  --tw-text-opacity: 0.25;
+}
+
+.focus\\\\:text-opacity-30:focus {
+  --tw-text-opacity: 0.3;
+}
+
+.focus\\\\:text-opacity-40:focus {
+  --tw-text-opacity: 0.4;
+}
+
+.focus\\\\:text-opacity-50:focus {
+  --tw-text-opacity: 0.5;
+}
+
+.focus\\\\:text-opacity-60:focus {
+  --tw-text-opacity: 0.6;
+}
+
+.focus\\\\:text-opacity-70:focus {
+  --tw-text-opacity: 0.7;
+}
+
+.focus\\\\:text-opacity-75:focus {
+  --tw-text-opacity: 0.75;
+}
+
+.focus\\\\:text-opacity-80:focus {
+  --tw-text-opacity: 0.8;
+}
+
+.focus\\\\:text-opacity-90:focus {
+  --tw-text-opacity: 0.9;
+}
+
+.focus\\\\:text-opacity-95:focus {
+  --tw-text-opacity: 0.95;
+}
+
+.focus\\\\:text-opacity-100:focus {
+  --tw-text-opacity: 1;
+}
+
+.underline {
+  text-decoration: underline;
+}
+
+.line-through {
+  text-decoration: line-through;
+}
+
+.no-underline {
+  text-decoration: none;
+}
+
+.hover\\\\:underline:hover {
+  text-decoration: underline;
+}
+
+.hover\\\\:line-through:hover {
+  text-decoration: line-through;
+}
+
+.hover\\\\:no-underline:hover {
+  text-decoration: none;
+}
+
+.focus\\\\:underline:focus {
+  text-decoration: underline;
+}
+
+.focus\\\\:line-through:focus {
+  text-decoration: line-through;
+}
+
+.focus\\\\:no-underline:focus {
+  text-decoration: none;
+}
+
+.antialiased {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.subpixel-antialiased {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+}
+
+.placeholder-current::-moz-placeholder {
+  color: currentColor;
+}
+
+.placeholder-current:-ms-input-placeholder {
+  color: currentColor;
+}
+
+.placeholder-current::placeholder {
+  color: currentColor;
+}
+
+.placeholder-transparent::-moz-placeholder {
+  color: transparent;
+}
+
+.placeholder-transparent:-ms-input-placeholder {
+  color: transparent;
+}
+
+.placeholder-transparent::placeholder {
+  color: transparent;
+}
+
+.placeholder-falcon::-moz-placeholder {
+  color: var(--falcon);
+}
+
+.placeholder-falcon:-ms-input-placeholder {
+  color: var(--falcon);
+}
+
+.placeholder-falcon::placeholder {
+  color: var(--falcon);
+}
+
+.placeholder-basement::-moz-placeholder {
+  color: var(--basement);
+}
+
+.placeholder-basement:-ms-input-placeholder {
+  color: var(--basement);
+}
+
+.placeholder-basement::placeholder {
+  color: var(--basement);
+}
+
+.placeholder-blue::-moz-placeholder {
+  color: var(--blue);
+}
+
+.placeholder-blue:-ms-input-placeholder {
+  color: var(--blue);
+}
+
+.placeholder-blue::placeholder {
+  color: var(--blue);
+}
+
+.placeholder-body-and-labels::-moz-placeholder {
+  color: var(--body-and-labels);
+}
+
+.placeholder-body-and-labels:-ms-input-placeholder {
+  color: var(--body-and-labels);
+}
+
+.placeholder-body-and-labels::placeholder {
+  color: var(--body-and-labels);
+}
+
+.placeholder-brand::-moz-placeholder {
+  color: var(--brand);
+}
+
+.placeholder-brand:-ms-input-placeholder {
+  color: var(--brand);
+}
+
+.placeholder-brand::placeholder {
+  color: var(--brand);
+}
+
+.placeholder-code-base-64::-moz-placeholder {
+  color: var(--code-base-64);
+}
+
+.placeholder-code-base-64:-ms-input-placeholder {
+  color: var(--code-base-64);
+}
+
+.placeholder-code-base-64::placeholder {
+  color: var(--code-base-64);
+}
+
+.placeholder-code-bg::-moz-placeholder {
+  color: var(--code-bg);
+}
+
+.placeholder-code-bg:-ms-input-placeholder {
+  color: var(--code-bg);
+}
+
+.placeholder-code-bg::placeholder {
+  color: var(--code-bg);
+}
+
+.placeholder-code-outline::-moz-placeholder {
+  color: var(--code-outline);
+}
+
+.placeholder-code-outline:-ms-input-placeholder {
+  color: var(--code-outline);
+}
+
+.placeholder-code-outline::placeholder {
+  color: var(--code-outline);
+}
+
+.placeholder-code-text::-moz-placeholder {
+  color: var(--code-text);
+}
+
+.placeholder-code-text:-ms-input-placeholder {
+  color: var(--code-text);
+}
+
+.placeholder-code-text::placeholder {
+  color: var(--code-text);
+}
+
+.placeholder-critical::-moz-placeholder {
+  color: var(--critical);
+}
+
+.placeholder-critical:-ms-input-placeholder {
+  color: var(--critical);
+}
+
+.placeholder-critical::placeholder {
+  color: var(--critical);
+}
+
+.placeholder-destructive-hover::-moz-placeholder {
+  color: var(--destructive-hover);
+}
+
+.placeholder-destructive-hover:-ms-input-placeholder {
+  color: var(--destructive-hover);
+}
+
+.placeholder-destructive-hover::placeholder {
+  color: var(--destructive-hover);
+}
+
+.placeholder-destructive-idle::-moz-placeholder {
+  color: var(--destructive-idle);
+}
+
+.placeholder-destructive-idle:-ms-input-placeholder {
+  color: var(--destructive-idle);
+}
+
+.placeholder-destructive-idle::placeholder {
+  color: var(--destructive-idle);
+}
+
+.placeholder-destructive-pressed::-moz-placeholder {
+  color: var(--destructive-pressed);
+}
+
+.placeholder-destructive-pressed:-ms-input-placeholder {
+  color: var(--destructive-pressed);
+}
+
+.placeholder-destructive-pressed::placeholder {
+  color: var(--destructive-pressed);
+}
+
+.placeholder-disabled::-moz-placeholder {
+  color: var(--disabled);
+}
+
+.placeholder-disabled:-ms-input-placeholder {
+  color: var(--disabled);
+}
+
+.placeholder-disabled::placeholder {
+  color: var(--disabled);
+}
+
+.placeholder-disc-operations::-moz-placeholder {
+  color: var(--disc-operations);
+}
+
+.placeholder-disc-operations:-ms-input-placeholder {
+  color: var(--disc-operations);
+}
+
+.placeholder-disc-operations::placeholder {
+  color: var(--disc-operations);
+}
+
+.placeholder-dns-requests::-moz-placeholder {
+  color: var(--dns-requests);
+}
+
+.placeholder-dns-requests:-ms-input-placeholder {
+  color: var(--dns-requests);
+}
+
+.placeholder-dns-requests::placeholder {
+  color: var(--dns-requests);
+}
+
+.placeholder-focus::-moz-placeholder {
+  color: var(--focus);
+}
+
+.placeholder-focus:-ms-input-placeholder {
+  color: var(--focus);
+}
+
+.placeholder-focus::placeholder {
+  color: var(--focus);
+}
+
+.placeholder-graph-1::-moz-placeholder {
+  color: var(--graph-1);
+}
+
+.placeholder-graph-1:-ms-input-placeholder {
+  color: var(--graph-1);
+}
+
+.placeholder-graph-1::placeholder {
+  color: var(--graph-1);
+}
+
+.placeholder-graph-10::-moz-placeholder {
+  color: var(--graph-10);
+}
+
+.placeholder-graph-10:-ms-input-placeholder {
+  color: var(--graph-10);
+}
+
+.placeholder-graph-10::placeholder {
+  color: var(--graph-10);
+}
+
+.placeholder-graph-11::-moz-placeholder {
+  color: var(--graph-11);
+}
+
+.placeholder-graph-11:-ms-input-placeholder {
+  color: var(--graph-11);
+}
+
+.placeholder-graph-11::placeholder {
+  color: var(--graph-11);
+}
+
+.placeholder-graph-2::-moz-placeholder {
+  color: var(--graph-2);
+}
+
+.placeholder-graph-2:-ms-input-placeholder {
+  color: var(--graph-2);
+}
+
+.placeholder-graph-2::placeholder {
+  color: var(--graph-2);
+}
+
+.placeholder-graph-3::-moz-placeholder {
+  color: var(--graph-3);
+}
+
+.placeholder-graph-3:-ms-input-placeholder {
+  color: var(--graph-3);
+}
+
+.placeholder-graph-3::placeholder {
+  color: var(--graph-3);
+}
+
+.placeholder-graph-4::-moz-placeholder {
+  color: var(--graph-4);
+}
+
+.placeholder-graph-4:-ms-input-placeholder {
+  color: var(--graph-4);
+}
+
+.placeholder-graph-4::placeholder {
+  color: var(--graph-4);
+}
+
+.placeholder-graph-5::-moz-placeholder {
+  color: var(--graph-5);
+}
+
+.placeholder-graph-5:-ms-input-placeholder {
+  color: var(--graph-5);
+}
+
+.placeholder-graph-5::placeholder {
+  color: var(--graph-5);
+}
+
+.placeholder-graph-6::-moz-placeholder {
+  color: var(--graph-6);
+}
+
+.placeholder-graph-6:-ms-input-placeholder {
+  color: var(--graph-6);
+}
+
+.placeholder-graph-6::placeholder {
+  color: var(--graph-6);
+}
+
+.placeholder-graph-7::-moz-placeholder {
+  color: var(--graph-7);
+}
+
+.placeholder-graph-7:-ms-input-placeholder {
+  color: var(--graph-7);
+}
+
+.placeholder-graph-7::placeholder {
+  color: var(--graph-7);
+}
+
+.placeholder-graph-8::-moz-placeholder {
+  color: var(--graph-8);
+}
+
+.placeholder-graph-8:-ms-input-placeholder {
+  color: var(--graph-8);
+}
+
+.placeholder-graph-8::placeholder {
+  color: var(--graph-8);
+}
+
+.placeholder-graph-9::-moz-placeholder {
+  color: var(--graph-9);
+}
+
+.placeholder-graph-9:-ms-input-placeholder {
+  color: var(--graph-9);
+}
+
+.placeholder-graph-9::placeholder {
+  color: var(--graph-9);
+}
+
+.placeholder-graph-disabled::-moz-placeholder {
+  color: var(--graph-disabled);
+}
+
+.placeholder-graph-disabled:-ms-input-placeholder {
+  color: var(--graph-disabled);
+}
+
+.placeholder-graph-disabled::placeholder {
+  color: var(--graph-disabled);
+}
+
+.placeholder-ground-floor::-moz-placeholder {
+  color: var(--ground-floor);
+}
+
+.placeholder-ground-floor:-ms-input-placeholder {
+  color: var(--ground-floor);
+}
+
+.placeholder-ground-floor::placeholder {
+  color: var(--ground-floor);
+}
+
+.placeholder-high::-moz-placeholder {
+  color: var(--high);
+}
+
+.placeholder-high:-ms-input-placeholder {
+  color: var(--high);
+}
+
+.placeholder-high::placeholder {
+  color: var(--high);
+}
+
+.placeholder-informational::-moz-placeholder {
+  color: var(--informational);
+}
+
+.placeholder-informational:-ms-input-placeholder {
+  color: var(--informational);
+}
+
+.placeholder-informational::placeholder {
+  color: var(--informational);
+}
+
+.placeholder-lines-dark::-moz-placeholder {
+  color: var(--lines-dark);
+}
+
+.placeholder-lines-dark:-ms-input-placeholder {
+  color: var(--lines-dark);
+}
+
+.placeholder-lines-dark::placeholder {
+  color: var(--lines-dark);
+}
+
+.placeholder-lines-light::-moz-placeholder {
+  color: var(--lines-light);
+}
+
+.placeholder-lines-light:-ms-input-placeholder {
+  color: var(--lines-light);
+}
+
+.placeholder-lines-light::placeholder {
+  color: var(--lines-light);
+}
+
+.placeholder-low::-moz-placeholder {
+  color: var(--low);
+}
+
+.placeholder-low:-ms-input-placeholder {
+  color: var(--low);
+}
+
+.placeholder-low::placeholder {
+  color: var(--low);
+}
+
+.placeholder-medium::-moz-placeholder {
+  color: var(--medium);
+}
+
+.placeholder-medium:-ms-input-placeholder {
+  color: var(--medium);
+}
+
+.placeholder-medium::placeholder {
+  color: var(--medium);
+}
+
+.placeholder-mezzanine::-moz-placeholder {
+  color: var(--mezzanine);
+}
+
+.placeholder-mezzanine:-ms-input-placeholder {
+  color: var(--mezzanine);
+}
+
+.placeholder-mezzanine::placeholder {
+  color: var(--mezzanine);
+}
+
+.placeholder-nav-text-and-icons::-moz-placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.placeholder-nav-text-and-icons:-ms-input-placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.placeholder-nav-text-and-icons::placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.placeholder-nav-text-secondary::-moz-placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.placeholder-nav-text-secondary:-ms-input-placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.placeholder-nav-text-secondary::placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.placeholder-network-operations::-moz-placeholder {
+  color: var(--network-operations);
+}
+
+.placeholder-network-operations:-ms-input-placeholder {
+  color: var(--network-operations);
+}
+
+.placeholder-network-operations::placeholder {
+  color: var(--network-operations);
+}
+
+.placeholder-normal-hover::-moz-placeholder {
+  color: var(--normal-hover);
+}
+
+.placeholder-normal-hover:-ms-input-placeholder {
+  color: var(--normal-hover);
+}
+
+.placeholder-normal-hover::placeholder {
+  color: var(--normal-hover);
+}
+
+.placeholder-normal-idle::-moz-placeholder {
+  color: var(--normal-idle);
+}
+
+.placeholder-normal-idle:-ms-input-placeholder {
+  color: var(--normal-idle);
+}
+
+.placeholder-normal-idle::placeholder {
+  color: var(--normal-idle);
+}
+
+.placeholder-normal-pressed::-moz-placeholder {
+  color: var(--normal-pressed);
+}
+
+.placeholder-normal-pressed:-ms-input-placeholder {
+  color: var(--normal-pressed);
+}
+
+.placeholder-normal-pressed::placeholder {
+  color: var(--normal-pressed);
+}
+
+.placeholder-overlay-0\\\\.5::-moz-placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.placeholder-overlay-0\\\\.5:-ms-input-placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.placeholder-overlay-0\\\\.5::placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.placeholder-overlay-1::-moz-placeholder {
+  color: var(--overlay-1);
+}
+
+.placeholder-overlay-1:-ms-input-placeholder {
+  color: var(--overlay-1);
+}
+
+.placeholder-overlay-1::placeholder {
+  color: var(--overlay-1);
+}
+
+.placeholder-overlay-2::-moz-placeholder {
+  color: var(--overlay-2);
+}
+
+.placeholder-overlay-2:-ms-input-placeholder {
+  color: var(--overlay-2);
+}
+
+.placeholder-overlay-2::placeholder {
+  color: var(--overlay-2);
+}
+
+.placeholder-positive::-moz-placeholder {
+  color: var(--positive);
+}
+
+.placeholder-positive:-ms-input-placeholder {
+  color: var(--positive);
+}
+
+.placeholder-positive::placeholder {
+  color: var(--positive);
+}
+
+.placeholder-primary-hover::-moz-placeholder {
+  color: var(--primary-hover);
+}
+
+.placeholder-primary-hover:-ms-input-placeholder {
+  color: var(--primary-hover);
+}
+
+.placeholder-primary-hover::placeholder {
+  color: var(--primary-hover);
+}
+
+.placeholder-primary-idle::-moz-placeholder {
+  color: var(--primary-idle);
+}
+
+.placeholder-primary-idle:-ms-input-placeholder {
+  color: var(--primary-idle);
+}
+
+.placeholder-primary-idle::placeholder {
+  color: var(--primary-idle);
+}
+
+.placeholder-primary-pressed::-moz-placeholder {
+  color: var(--primary-pressed);
+}
+
+.placeholder-primary-pressed:-ms-input-placeholder {
+  color: var(--primary-pressed);
+}
+
+.placeholder-primary-pressed::placeholder {
+  color: var(--primary-pressed);
+}
+
+.placeholder-process-operations::-moz-placeholder {
+  color: var(--process-operations);
+}
+
+.placeholder-process-operations:-ms-input-placeholder {
+  color: var(--process-operations);
+}
+
+.placeholder-process-operations::placeholder {
+  color: var(--process-operations);
+}
+
+.placeholder-purple::-moz-placeholder {
+  color: var(--purple);
+}
+
+.placeholder-purple:-ms-input-placeholder {
+  color: var(--purple);
+}
+
+.placeholder-purple::placeholder {
+  color: var(--purple);
+}
+
+.placeholder-registry-operations::-moz-placeholder {
+  color: var(--registry-operations);
+}
+
+.placeholder-registry-operations:-ms-input-placeholder {
+  color: var(--registry-operations);
+}
+
+.placeholder-registry-operations::placeholder {
+  color: var(--registry-operations);
+}
+
+.placeholder-selected::-moz-placeholder {
+  color: var(--selected);
+}
+
+.placeholder-selected:-ms-input-placeholder {
+  color: var(--selected);
+}
+
+.placeholder-selected::placeholder {
+  color: var(--selected);
+}
+
+.placeholder-surface-2xl::-moz-placeholder {
+  color: var(--surface-2xl);
+}
+
+.placeholder-surface-2xl:-ms-input-placeholder {
+  color: var(--surface-2xl);
+}
+
+.placeholder-surface-2xl::placeholder {
+  color: var(--surface-2xl);
+}
+
+.placeholder-surface-base::-moz-placeholder {
+  color: var(--surface-base);
+}
+
+.placeholder-surface-base:-ms-input-placeholder {
+  color: var(--surface-base);
+}
+
+.placeholder-surface-base::placeholder {
+  color: var(--surface-base);
+}
+
+.placeholder-surface-inner::-moz-placeholder {
+  color: var(--surface-inner);
+}
+
+.placeholder-surface-inner:-ms-input-placeholder {
+  color: var(--surface-inner);
+}
+
+.placeholder-surface-inner::placeholder {
+  color: var(--surface-inner);
+}
+
+.placeholder-surface-lg::-moz-placeholder {
+  color: var(--surface-lg);
+}
+
+.placeholder-surface-lg:-ms-input-placeholder {
+  color: var(--surface-lg);
+}
+
+.placeholder-surface-lg::placeholder {
+  color: var(--surface-lg);
+}
+
+.placeholder-surface-md::-moz-placeholder {
+  color: var(--surface-md);
+}
+
+.placeholder-surface-md:-ms-input-placeholder {
+  color: var(--surface-md);
+}
+
+.placeholder-surface-md::placeholder {
+  color: var(--surface-md);
+}
+
+.placeholder-surface-xl::-moz-placeholder {
+  color: var(--surface-xl);
+}
+
+.placeholder-surface-xl:-ms-input-placeholder {
+  color: var(--surface-xl);
+}
+
+.placeholder-surface-xl::placeholder {
+  color: var(--surface-xl);
+}
+
+.placeholder-text-and-icons::-moz-placeholder {
+  color: var(--text-and-icons);
+}
+
+.placeholder-text-and-icons:-ms-input-placeholder {
+  color: var(--text-and-icons);
+}
+
+.placeholder-text-and-icons::placeholder {
+  color: var(--text-and-icons);
+}
+
+.placeholder-titles-and-attributes::-moz-placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.placeholder-titles-and-attributes:-ms-input-placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.placeholder-titles-and-attributes::placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.focus\\\\:placeholder-current:focus::-moz-placeholder {
+  color: currentColor;
+}
+
+.focus\\\\:placeholder-current:focus:-ms-input-placeholder {
+  color: currentColor;
+}
+
+.focus\\\\:placeholder-current:focus::placeholder {
+  color: currentColor;
+}
+
+.focus\\\\:placeholder-transparent:focus::-moz-placeholder {
+  color: transparent;
+}
+
+.focus\\\\:placeholder-transparent:focus:-ms-input-placeholder {
+  color: transparent;
+}
+
+.focus\\\\:placeholder-transparent:focus::placeholder {
+  color: transparent;
+}
+
+.focus\\\\:placeholder-falcon:focus::-moz-placeholder {
+  color: var(--falcon);
+}
+
+.focus\\\\:placeholder-falcon:focus:-ms-input-placeholder {
+  color: var(--falcon);
+}
+
+.focus\\\\:placeholder-falcon:focus::placeholder {
+  color: var(--falcon);
+}
+
+.focus\\\\:placeholder-basement:focus::-moz-placeholder {
+  color: var(--basement);
+}
+
+.focus\\\\:placeholder-basement:focus:-ms-input-placeholder {
+  color: var(--basement);
+}
+
+.focus\\\\:placeholder-basement:focus::placeholder {
+  color: var(--basement);
+}
+
+.focus\\\\:placeholder-blue:focus::-moz-placeholder {
+  color: var(--blue);
+}
+
+.focus\\\\:placeholder-blue:focus:-ms-input-placeholder {
+  color: var(--blue);
+}
+
+.focus\\\\:placeholder-blue:focus::placeholder {
+  color: var(--blue);
+}
+
+.focus\\\\:placeholder-body-and-labels:focus::-moz-placeholder {
+  color: var(--body-and-labels);
+}
+
+.focus\\\\:placeholder-body-and-labels:focus:-ms-input-placeholder {
+  color: var(--body-and-labels);
+}
+
+.focus\\\\:placeholder-body-and-labels:focus::placeholder {
+  color: var(--body-and-labels);
+}
+
+.focus\\\\:placeholder-brand:focus::-moz-placeholder {
+  color: var(--brand);
+}
+
+.focus\\\\:placeholder-brand:focus:-ms-input-placeholder {
+  color: var(--brand);
+}
+
+.focus\\\\:placeholder-brand:focus::placeholder {
+  color: var(--brand);
+}
+
+.focus\\\\:placeholder-code-base-64:focus::-moz-placeholder {
+  color: var(--code-base-64);
+}
+
+.focus\\\\:placeholder-code-base-64:focus:-ms-input-placeholder {
+  color: var(--code-base-64);
+}
+
+.focus\\\\:placeholder-code-base-64:focus::placeholder {
+  color: var(--code-base-64);
+}
+
+.focus\\\\:placeholder-code-bg:focus::-moz-placeholder {
+  color: var(--code-bg);
+}
+
+.focus\\\\:placeholder-code-bg:focus:-ms-input-placeholder {
+  color: var(--code-bg);
+}
+
+.focus\\\\:placeholder-code-bg:focus::placeholder {
+  color: var(--code-bg);
+}
+
+.focus\\\\:placeholder-code-outline:focus::-moz-placeholder {
+  color: var(--code-outline);
+}
+
+.focus\\\\:placeholder-code-outline:focus:-ms-input-placeholder {
+  color: var(--code-outline);
+}
+
+.focus\\\\:placeholder-code-outline:focus::placeholder {
+  color: var(--code-outline);
+}
+
+.focus\\\\:placeholder-code-text:focus::-moz-placeholder {
+  color: var(--code-text);
+}
+
+.focus\\\\:placeholder-code-text:focus:-ms-input-placeholder {
+  color: var(--code-text);
+}
+
+.focus\\\\:placeholder-code-text:focus::placeholder {
+  color: var(--code-text);
+}
+
+.focus\\\\:placeholder-critical:focus::-moz-placeholder {
+  color: var(--critical);
+}
+
+.focus\\\\:placeholder-critical:focus:-ms-input-placeholder {
+  color: var(--critical);
+}
+
+.focus\\\\:placeholder-critical:focus::placeholder {
+  color: var(--critical);
+}
+
+.focus\\\\:placeholder-destructive-hover:focus::-moz-placeholder {
+  color: var(--destructive-hover);
+}
+
+.focus\\\\:placeholder-destructive-hover:focus:-ms-input-placeholder {
+  color: var(--destructive-hover);
+}
+
+.focus\\\\:placeholder-destructive-hover:focus::placeholder {
+  color: var(--destructive-hover);
+}
+
+.focus\\\\:placeholder-destructive-idle:focus::-moz-placeholder {
+  color: var(--destructive-idle);
+}
+
+.focus\\\\:placeholder-destructive-idle:focus:-ms-input-placeholder {
+  color: var(--destructive-idle);
+}
+
+.focus\\\\:placeholder-destructive-idle:focus::placeholder {
+  color: var(--destructive-idle);
+}
+
+.focus\\\\:placeholder-destructive-pressed:focus::-moz-placeholder {
+  color: var(--destructive-pressed);
+}
+
+.focus\\\\:placeholder-destructive-pressed:focus:-ms-input-placeholder {
+  color: var(--destructive-pressed);
+}
+
+.focus\\\\:placeholder-destructive-pressed:focus::placeholder {
+  color: var(--destructive-pressed);
+}
+
+.focus\\\\:placeholder-disabled:focus::-moz-placeholder {
+  color: var(--disabled);
+}
+
+.focus\\\\:placeholder-disabled:focus:-ms-input-placeholder {
+  color: var(--disabled);
+}
+
+.focus\\\\:placeholder-disabled:focus::placeholder {
+  color: var(--disabled);
+}
+
+.focus\\\\:placeholder-disc-operations:focus::-moz-placeholder {
+  color: var(--disc-operations);
+}
+
+.focus\\\\:placeholder-disc-operations:focus:-ms-input-placeholder {
+  color: var(--disc-operations);
+}
+
+.focus\\\\:placeholder-disc-operations:focus::placeholder {
+  color: var(--disc-operations);
+}
+
+.focus\\\\:placeholder-dns-requests:focus::-moz-placeholder {
+  color: var(--dns-requests);
+}
+
+.focus\\\\:placeholder-dns-requests:focus:-ms-input-placeholder {
+  color: var(--dns-requests);
+}
+
+.focus\\\\:placeholder-dns-requests:focus::placeholder {
+  color: var(--dns-requests);
+}
+
+.focus\\\\:placeholder-focus:focus::-moz-placeholder {
+  color: var(--focus);
+}
+
+.focus\\\\:placeholder-focus:focus:-ms-input-placeholder {
+  color: var(--focus);
+}
+
+.focus\\\\:placeholder-focus:focus::placeholder {
+  color: var(--focus);
+}
+
+.focus\\\\:placeholder-graph-1:focus::-moz-placeholder {
+  color: var(--graph-1);
+}
+
+.focus\\\\:placeholder-graph-1:focus:-ms-input-placeholder {
+  color: var(--graph-1);
+}
+
+.focus\\\\:placeholder-graph-1:focus::placeholder {
+  color: var(--graph-1);
+}
+
+.focus\\\\:placeholder-graph-10:focus::-moz-placeholder {
+  color: var(--graph-10);
+}
+
+.focus\\\\:placeholder-graph-10:focus:-ms-input-placeholder {
+  color: var(--graph-10);
+}
+
+.focus\\\\:placeholder-graph-10:focus::placeholder {
+  color: var(--graph-10);
+}
+
+.focus\\\\:placeholder-graph-11:focus::-moz-placeholder {
+  color: var(--graph-11);
+}
+
+.focus\\\\:placeholder-graph-11:focus:-ms-input-placeholder {
+  color: var(--graph-11);
+}
+
+.focus\\\\:placeholder-graph-11:focus::placeholder {
+  color: var(--graph-11);
+}
+
+.focus\\\\:placeholder-graph-2:focus::-moz-placeholder {
+  color: var(--graph-2);
+}
+
+.focus\\\\:placeholder-graph-2:focus:-ms-input-placeholder {
+  color: var(--graph-2);
+}
+
+.focus\\\\:placeholder-graph-2:focus::placeholder {
+  color: var(--graph-2);
+}
+
+.focus\\\\:placeholder-graph-3:focus::-moz-placeholder {
+  color: var(--graph-3);
+}
+
+.focus\\\\:placeholder-graph-3:focus:-ms-input-placeholder {
+  color: var(--graph-3);
+}
+
+.focus\\\\:placeholder-graph-3:focus::placeholder {
+  color: var(--graph-3);
+}
+
+.focus\\\\:placeholder-graph-4:focus::-moz-placeholder {
+  color: var(--graph-4);
+}
+
+.focus\\\\:placeholder-graph-4:focus:-ms-input-placeholder {
+  color: var(--graph-4);
+}
+
+.focus\\\\:placeholder-graph-4:focus::placeholder {
+  color: var(--graph-4);
+}
+
+.focus\\\\:placeholder-graph-5:focus::-moz-placeholder {
+  color: var(--graph-5);
+}
+
+.focus\\\\:placeholder-graph-5:focus:-ms-input-placeholder {
+  color: var(--graph-5);
+}
+
+.focus\\\\:placeholder-graph-5:focus::placeholder {
+  color: var(--graph-5);
+}
+
+.focus\\\\:placeholder-graph-6:focus::-moz-placeholder {
+  color: var(--graph-6);
+}
+
+.focus\\\\:placeholder-graph-6:focus:-ms-input-placeholder {
+  color: var(--graph-6);
+}
+
+.focus\\\\:placeholder-graph-6:focus::placeholder {
+  color: var(--graph-6);
+}
+
+.focus\\\\:placeholder-graph-7:focus::-moz-placeholder {
+  color: var(--graph-7);
+}
+
+.focus\\\\:placeholder-graph-7:focus:-ms-input-placeholder {
+  color: var(--graph-7);
+}
+
+.focus\\\\:placeholder-graph-7:focus::placeholder {
+  color: var(--graph-7);
+}
+
+.focus\\\\:placeholder-graph-8:focus::-moz-placeholder {
+  color: var(--graph-8);
+}
+
+.focus\\\\:placeholder-graph-8:focus:-ms-input-placeholder {
+  color: var(--graph-8);
+}
+
+.focus\\\\:placeholder-graph-8:focus::placeholder {
+  color: var(--graph-8);
+}
+
+.focus\\\\:placeholder-graph-9:focus::-moz-placeholder {
+  color: var(--graph-9);
+}
+
+.focus\\\\:placeholder-graph-9:focus:-ms-input-placeholder {
+  color: var(--graph-9);
+}
+
+.focus\\\\:placeholder-graph-9:focus::placeholder {
+  color: var(--graph-9);
+}
+
+.focus\\\\:placeholder-graph-disabled:focus::-moz-placeholder {
+  color: var(--graph-disabled);
+}
+
+.focus\\\\:placeholder-graph-disabled:focus:-ms-input-placeholder {
+  color: var(--graph-disabled);
+}
+
+.focus\\\\:placeholder-graph-disabled:focus::placeholder {
+  color: var(--graph-disabled);
+}
+
+.focus\\\\:placeholder-ground-floor:focus::-moz-placeholder {
+  color: var(--ground-floor);
+}
+
+.focus\\\\:placeholder-ground-floor:focus:-ms-input-placeholder {
+  color: var(--ground-floor);
+}
+
+.focus\\\\:placeholder-ground-floor:focus::placeholder {
+  color: var(--ground-floor);
+}
+
+.focus\\\\:placeholder-high:focus::-moz-placeholder {
+  color: var(--high);
+}
+
+.focus\\\\:placeholder-high:focus:-ms-input-placeholder {
+  color: var(--high);
+}
+
+.focus\\\\:placeholder-high:focus::placeholder {
+  color: var(--high);
+}
+
+.focus\\\\:placeholder-informational:focus::-moz-placeholder {
+  color: var(--informational);
+}
+
+.focus\\\\:placeholder-informational:focus:-ms-input-placeholder {
+  color: var(--informational);
+}
+
+.focus\\\\:placeholder-informational:focus::placeholder {
+  color: var(--informational);
+}
+
+.focus\\\\:placeholder-lines-dark:focus::-moz-placeholder {
+  color: var(--lines-dark);
+}
+
+.focus\\\\:placeholder-lines-dark:focus:-ms-input-placeholder {
+  color: var(--lines-dark);
+}
+
+.focus\\\\:placeholder-lines-dark:focus::placeholder {
+  color: var(--lines-dark);
+}
+
+.focus\\\\:placeholder-lines-light:focus::-moz-placeholder {
+  color: var(--lines-light);
+}
+
+.focus\\\\:placeholder-lines-light:focus:-ms-input-placeholder {
+  color: var(--lines-light);
+}
+
+.focus\\\\:placeholder-lines-light:focus::placeholder {
+  color: var(--lines-light);
+}
+
+.focus\\\\:placeholder-low:focus::-moz-placeholder {
+  color: var(--low);
+}
+
+.focus\\\\:placeholder-low:focus:-ms-input-placeholder {
+  color: var(--low);
+}
+
+.focus\\\\:placeholder-low:focus::placeholder {
+  color: var(--low);
+}
+
+.focus\\\\:placeholder-medium:focus::-moz-placeholder {
+  color: var(--medium);
+}
+
+.focus\\\\:placeholder-medium:focus:-ms-input-placeholder {
+  color: var(--medium);
+}
+
+.focus\\\\:placeholder-medium:focus::placeholder {
+  color: var(--medium);
+}
+
+.focus\\\\:placeholder-mezzanine:focus::-moz-placeholder {
+  color: var(--mezzanine);
+}
+
+.focus\\\\:placeholder-mezzanine:focus:-ms-input-placeholder {
+  color: var(--mezzanine);
+}
+
+.focus\\\\:placeholder-mezzanine:focus::placeholder {
+  color: var(--mezzanine);
+}
+
+.focus\\\\:placeholder-nav-text-and-icons:focus::-moz-placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:placeholder-nav-text-and-icons:focus:-ms-input-placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:placeholder-nav-text-and-icons:focus::placeholder {
+  color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:placeholder-nav-text-secondary:focus::-moz-placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.focus\\\\:placeholder-nav-text-secondary:focus:-ms-input-placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.focus\\\\:placeholder-nav-text-secondary:focus::placeholder {
+  color: var(--nav-text-secondary);
+}
+
+.focus\\\\:placeholder-network-operations:focus::-moz-placeholder {
+  color: var(--network-operations);
+}
+
+.focus\\\\:placeholder-network-operations:focus:-ms-input-placeholder {
+  color: var(--network-operations);
+}
+
+.focus\\\\:placeholder-network-operations:focus::placeholder {
+  color: var(--network-operations);
+}
+
+.focus\\\\:placeholder-normal-hover:focus::-moz-placeholder {
+  color: var(--normal-hover);
+}
+
+.focus\\\\:placeholder-normal-hover:focus:-ms-input-placeholder {
+  color: var(--normal-hover);
+}
+
+.focus\\\\:placeholder-normal-hover:focus::placeholder {
+  color: var(--normal-hover);
+}
+
+.focus\\\\:placeholder-normal-idle:focus::-moz-placeholder {
+  color: var(--normal-idle);
+}
+
+.focus\\\\:placeholder-normal-idle:focus:-ms-input-placeholder {
+  color: var(--normal-idle);
+}
+
+.focus\\\\:placeholder-normal-idle:focus::placeholder {
+  color: var(--normal-idle);
+}
+
+.focus\\\\:placeholder-normal-pressed:focus::-moz-placeholder {
+  color: var(--normal-pressed);
+}
+
+.focus\\\\:placeholder-normal-pressed:focus:-ms-input-placeholder {
+  color: var(--normal-pressed);
+}
+
+.focus\\\\:placeholder-normal-pressed:focus::placeholder {
+  color: var(--normal-pressed);
+}
+
+.focus\\\\:placeholder-overlay-0\\\\.5:focus::-moz-placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:placeholder-overlay-0\\\\.5:focus:-ms-input-placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:placeholder-overlay-0\\\\.5:focus::placeholder {
+  color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:placeholder-overlay-1:focus::-moz-placeholder {
+  color: var(--overlay-1);
+}
+
+.focus\\\\:placeholder-overlay-1:focus:-ms-input-placeholder {
+  color: var(--overlay-1);
+}
+
+.focus\\\\:placeholder-overlay-1:focus::placeholder {
+  color: var(--overlay-1);
+}
+
+.focus\\\\:placeholder-overlay-2:focus::-moz-placeholder {
+  color: var(--overlay-2);
+}
+
+.focus\\\\:placeholder-overlay-2:focus:-ms-input-placeholder {
+  color: var(--overlay-2);
+}
+
+.focus\\\\:placeholder-overlay-2:focus::placeholder {
+  color: var(--overlay-2);
+}
+
+.focus\\\\:placeholder-positive:focus::-moz-placeholder {
+  color: var(--positive);
+}
+
+.focus\\\\:placeholder-positive:focus:-ms-input-placeholder {
+  color: var(--positive);
+}
+
+.focus\\\\:placeholder-positive:focus::placeholder {
+  color: var(--positive);
+}
+
+.focus\\\\:placeholder-primary-hover:focus::-moz-placeholder {
+  color: var(--primary-hover);
+}
+
+.focus\\\\:placeholder-primary-hover:focus:-ms-input-placeholder {
+  color: var(--primary-hover);
+}
+
+.focus\\\\:placeholder-primary-hover:focus::placeholder {
+  color: var(--primary-hover);
+}
+
+.focus\\\\:placeholder-primary-idle:focus::-moz-placeholder {
+  color: var(--primary-idle);
+}
+
+.focus\\\\:placeholder-primary-idle:focus:-ms-input-placeholder {
+  color: var(--primary-idle);
+}
+
+.focus\\\\:placeholder-primary-idle:focus::placeholder {
+  color: var(--primary-idle);
+}
+
+.focus\\\\:placeholder-primary-pressed:focus::-moz-placeholder {
+  color: var(--primary-pressed);
+}
+
+.focus\\\\:placeholder-primary-pressed:focus:-ms-input-placeholder {
+  color: var(--primary-pressed);
+}
+
+.focus\\\\:placeholder-primary-pressed:focus::placeholder {
+  color: var(--primary-pressed);
+}
+
+.focus\\\\:placeholder-process-operations:focus::-moz-placeholder {
+  color: var(--process-operations);
+}
+
+.focus\\\\:placeholder-process-operations:focus:-ms-input-placeholder {
+  color: var(--process-operations);
+}
+
+.focus\\\\:placeholder-process-operations:focus::placeholder {
+  color: var(--process-operations);
+}
+
+.focus\\\\:placeholder-purple:focus::-moz-placeholder {
+  color: var(--purple);
+}
+
+.focus\\\\:placeholder-purple:focus:-ms-input-placeholder {
+  color: var(--purple);
+}
+
+.focus\\\\:placeholder-purple:focus::placeholder {
+  color: var(--purple);
+}
+
+.focus\\\\:placeholder-registry-operations:focus::-moz-placeholder {
+  color: var(--registry-operations);
+}
+
+.focus\\\\:placeholder-registry-operations:focus:-ms-input-placeholder {
+  color: var(--registry-operations);
+}
+
+.focus\\\\:placeholder-registry-operations:focus::placeholder {
+  color: var(--registry-operations);
+}
+
+.focus\\\\:placeholder-selected:focus::-moz-placeholder {
+  color: var(--selected);
+}
+
+.focus\\\\:placeholder-selected:focus:-ms-input-placeholder {
+  color: var(--selected);
+}
+
+.focus\\\\:placeholder-selected:focus::placeholder {
+  color: var(--selected);
+}
+
+.focus\\\\:placeholder-surface-2xl:focus::-moz-placeholder {
+  color: var(--surface-2xl);
+}
+
+.focus\\\\:placeholder-surface-2xl:focus:-ms-input-placeholder {
+  color: var(--surface-2xl);
+}
+
+.focus\\\\:placeholder-surface-2xl:focus::placeholder {
+  color: var(--surface-2xl);
+}
+
+.focus\\\\:placeholder-surface-base:focus::-moz-placeholder {
+  color: var(--surface-base);
+}
+
+.focus\\\\:placeholder-surface-base:focus:-ms-input-placeholder {
+  color: var(--surface-base);
+}
+
+.focus\\\\:placeholder-surface-base:focus::placeholder {
+  color: var(--surface-base);
+}
+
+.focus\\\\:placeholder-surface-inner:focus::-moz-placeholder {
+  color: var(--surface-inner);
+}
+
+.focus\\\\:placeholder-surface-inner:focus:-ms-input-placeholder {
+  color: var(--surface-inner);
+}
+
+.focus\\\\:placeholder-surface-inner:focus::placeholder {
+  color: var(--surface-inner);
+}
+
+.focus\\\\:placeholder-surface-lg:focus::-moz-placeholder {
+  color: var(--surface-lg);
+}
+
+.focus\\\\:placeholder-surface-lg:focus:-ms-input-placeholder {
+  color: var(--surface-lg);
+}
+
+.focus\\\\:placeholder-surface-lg:focus::placeholder {
+  color: var(--surface-lg);
+}
+
+.focus\\\\:placeholder-surface-md:focus::-moz-placeholder {
+  color: var(--surface-md);
+}
+
+.focus\\\\:placeholder-surface-md:focus:-ms-input-placeholder {
+  color: var(--surface-md);
+}
+
+.focus\\\\:placeholder-surface-md:focus::placeholder {
+  color: var(--surface-md);
+}
+
+.focus\\\\:placeholder-surface-xl:focus::-moz-placeholder {
+  color: var(--surface-xl);
+}
+
+.focus\\\\:placeholder-surface-xl:focus:-ms-input-placeholder {
+  color: var(--surface-xl);
+}
+
+.focus\\\\:placeholder-surface-xl:focus::placeholder {
+  color: var(--surface-xl);
+}
+
+.focus\\\\:placeholder-text-and-icons:focus::-moz-placeholder {
+  color: var(--text-and-icons);
+}
+
+.focus\\\\:placeholder-text-and-icons:focus:-ms-input-placeholder {
+  color: var(--text-and-icons);
+}
+
+.focus\\\\:placeholder-text-and-icons:focus::placeholder {
+  color: var(--text-and-icons);
+}
+
+.focus\\\\:placeholder-titles-and-attributes:focus::-moz-placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.focus\\\\:placeholder-titles-and-attributes:focus:-ms-input-placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.focus\\\\:placeholder-titles-and-attributes:focus::placeholder {
+  color: var(--titles-and-attributes);
+}
+
+.placeholder-opacity-0::-moz-placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.placeholder-opacity-0:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.placeholder-opacity-0::placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.placeholder-opacity-5::-moz-placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.placeholder-opacity-5:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.placeholder-opacity-5::placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.placeholder-opacity-10::-moz-placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.placeholder-opacity-10:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.placeholder-opacity-10::placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.placeholder-opacity-20::-moz-placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.placeholder-opacity-20:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.placeholder-opacity-20::placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.placeholder-opacity-25::-moz-placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.placeholder-opacity-25:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.placeholder-opacity-25::placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.placeholder-opacity-30::-moz-placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.placeholder-opacity-30:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.placeholder-opacity-30::placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.placeholder-opacity-40::-moz-placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.placeholder-opacity-40:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.placeholder-opacity-40::placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.placeholder-opacity-50::-moz-placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.placeholder-opacity-50:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.placeholder-opacity-50::placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.placeholder-opacity-60::-moz-placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.placeholder-opacity-60:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.placeholder-opacity-60::placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.placeholder-opacity-70::-moz-placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.placeholder-opacity-70:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.placeholder-opacity-70::placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.placeholder-opacity-75::-moz-placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.placeholder-opacity-75:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.placeholder-opacity-75::placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.placeholder-opacity-80::-moz-placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.placeholder-opacity-80:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.placeholder-opacity-80::placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.placeholder-opacity-90::-moz-placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.placeholder-opacity-90:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.placeholder-opacity-90::placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.placeholder-opacity-95::-moz-placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.placeholder-opacity-95:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.placeholder-opacity-95::placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.placeholder-opacity-100::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.placeholder-opacity-100:-ms-input-placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.placeholder-opacity-100::placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.focus\\\\:placeholder-opacity-0:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.focus\\\\:placeholder-opacity-0:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.focus\\\\:placeholder-opacity-0:focus::placeholder {
+  --tw-placeholder-opacity: 0;
+}
+
+.focus\\\\:placeholder-opacity-5:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.focus\\\\:placeholder-opacity-5:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.focus\\\\:placeholder-opacity-5:focus::placeholder {
+  --tw-placeholder-opacity: 0.05;
+}
+
+.focus\\\\:placeholder-opacity-10:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.focus\\\\:placeholder-opacity-10:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.focus\\\\:placeholder-opacity-10:focus::placeholder {
+  --tw-placeholder-opacity: 0.1;
+}
+
+.focus\\\\:placeholder-opacity-20:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.focus\\\\:placeholder-opacity-20:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.focus\\\\:placeholder-opacity-20:focus::placeholder {
+  --tw-placeholder-opacity: 0.2;
+}
+
+.focus\\\\:placeholder-opacity-25:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.focus\\\\:placeholder-opacity-25:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.focus\\\\:placeholder-opacity-25:focus::placeholder {
+  --tw-placeholder-opacity: 0.25;
+}
+
+.focus\\\\:placeholder-opacity-30:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.focus\\\\:placeholder-opacity-30:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.focus\\\\:placeholder-opacity-30:focus::placeholder {
+  --tw-placeholder-opacity: 0.3;
+}
+
+.focus\\\\:placeholder-opacity-40:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.focus\\\\:placeholder-opacity-40:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.focus\\\\:placeholder-opacity-40:focus::placeholder {
+  --tw-placeholder-opacity: 0.4;
+}
+
+.focus\\\\:placeholder-opacity-50:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.focus\\\\:placeholder-opacity-50:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.focus\\\\:placeholder-opacity-50:focus::placeholder {
+  --tw-placeholder-opacity: 0.5;
+}
+
+.focus\\\\:placeholder-opacity-60:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.focus\\\\:placeholder-opacity-60:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.focus\\\\:placeholder-opacity-60:focus::placeholder {
+  --tw-placeholder-opacity: 0.6;
+}
+
+.focus\\\\:placeholder-opacity-70:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.focus\\\\:placeholder-opacity-70:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.focus\\\\:placeholder-opacity-70:focus::placeholder {
+  --tw-placeholder-opacity: 0.7;
+}
+
+.focus\\\\:placeholder-opacity-75:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.focus\\\\:placeholder-opacity-75:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.focus\\\\:placeholder-opacity-75:focus::placeholder {
+  --tw-placeholder-opacity: 0.75;
+}
+
+.focus\\\\:placeholder-opacity-80:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.focus\\\\:placeholder-opacity-80:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.focus\\\\:placeholder-opacity-80:focus::placeholder {
+  --tw-placeholder-opacity: 0.8;
+}
+
+.focus\\\\:placeholder-opacity-90:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.focus\\\\:placeholder-opacity-90:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.focus\\\\:placeholder-opacity-90:focus::placeholder {
+  --tw-placeholder-opacity: 0.9;
+}
+
+.focus\\\\:placeholder-opacity-95:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.focus\\\\:placeholder-opacity-95:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.focus\\\\:placeholder-opacity-95:focus::placeholder {
+  --tw-placeholder-opacity: 0.95;
+}
+
+.focus\\\\:placeholder-opacity-100:focus::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.focus\\\\:placeholder-opacity-100:focus:-ms-input-placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.focus\\\\:placeholder-opacity-100:focus::placeholder {
+  --tw-placeholder-opacity: 1;
+}
+
+.caret-current {
+  caret-color: currentColor;
+}
+
+.caret-transparent {
+  caret-color: transparent;
+}
+
+.caret-falcon {
+  caret-color: var(--falcon);
+}
+
+.caret-basement {
+  caret-color: var(--basement);
+}
+
+.caret-blue {
+  caret-color: var(--blue);
+}
+
+.caret-body-and-labels {
+  caret-color: var(--body-and-labels);
+}
+
+.caret-brand {
+  caret-color: var(--brand);
+}
+
+.caret-code-base-64 {
+  caret-color: var(--code-base-64);
+}
+
+.caret-code-bg {
+  caret-color: var(--code-bg);
+}
+
+.caret-code-outline {
+  caret-color: var(--code-outline);
+}
+
+.caret-code-text {
+  caret-color: var(--code-text);
+}
+
+.caret-critical {
+  caret-color: var(--critical);
+}
+
+.caret-destructive-hover {
+  caret-color: var(--destructive-hover);
+}
+
+.caret-destructive-idle {
+  caret-color: var(--destructive-idle);
+}
+
+.caret-destructive-pressed {
+  caret-color: var(--destructive-pressed);
+}
+
+.caret-disabled {
+  caret-color: var(--disabled);
+}
+
+.caret-disc-operations {
+  caret-color: var(--disc-operations);
+}
+
+.caret-dns-requests {
+  caret-color: var(--dns-requests);
+}
+
+.caret-focus {
+  caret-color: var(--focus);
+}
+
+.caret-graph-1 {
+  caret-color: var(--graph-1);
+}
+
+.caret-graph-10 {
+  caret-color: var(--graph-10);
+}
+
+.caret-graph-11 {
+  caret-color: var(--graph-11);
+}
+
+.caret-graph-2 {
+  caret-color: var(--graph-2);
+}
+
+.caret-graph-3 {
+  caret-color: var(--graph-3);
+}
+
+.caret-graph-4 {
+  caret-color: var(--graph-4);
+}
+
+.caret-graph-5 {
+  caret-color: var(--graph-5);
+}
+
+.caret-graph-6 {
+  caret-color: var(--graph-6);
+}
+
+.caret-graph-7 {
+  caret-color: var(--graph-7);
+}
+
+.caret-graph-8 {
+  caret-color: var(--graph-8);
+}
+
+.caret-graph-9 {
+  caret-color: var(--graph-9);
+}
+
+.caret-graph-disabled {
+  caret-color: var(--graph-disabled);
+}
+
+.caret-ground-floor {
+  caret-color: var(--ground-floor);
+}
+
+.caret-high {
+  caret-color: var(--high);
+}
+
+.caret-informational {
+  caret-color: var(--informational);
+}
+
+.caret-lines-dark {
+  caret-color: var(--lines-dark);
+}
+
+.caret-lines-light {
+  caret-color: var(--lines-light);
+}
+
+.caret-low {
+  caret-color: var(--low);
+}
+
+.caret-medium {
+  caret-color: var(--medium);
+}
+
+.caret-mezzanine {
+  caret-color: var(--mezzanine);
+}
+
+.caret-nav-text-and-icons {
+  caret-color: var(--nav-text-and-icons);
+}
+
+.caret-nav-text-secondary {
+  caret-color: var(--nav-text-secondary);
+}
+
+.caret-network-operations {
+  caret-color: var(--network-operations);
+}
+
+.caret-normal-hover {
+  caret-color: var(--normal-hover);
+}
+
+.caret-normal-idle {
+  caret-color: var(--normal-idle);
+}
+
+.caret-normal-pressed {
+  caret-color: var(--normal-pressed);
+}
+
+.caret-overlay-0\\\\.5 {
+  caret-color: var(--overlay-0\\\\.5);
+}
+
+.caret-overlay-1 {
+  caret-color: var(--overlay-1);
+}
+
+.caret-overlay-2 {
+  caret-color: var(--overlay-2);
+}
+
+.caret-positive {
+  caret-color: var(--positive);
+}
+
+.caret-primary-hover {
+  caret-color: var(--primary-hover);
+}
+
+.caret-primary-idle {
+  caret-color: var(--primary-idle);
+}
+
+.caret-primary-pressed {
+  caret-color: var(--primary-pressed);
+}
+
+.caret-process-operations {
+  caret-color: var(--process-operations);
+}
+
+.caret-purple {
+  caret-color: var(--purple);
+}
+
+.caret-registry-operations {
+  caret-color: var(--registry-operations);
+}
+
+.caret-selected {
+  caret-color: var(--selected);
+}
+
+.caret-surface-2xl {
+  caret-color: var(--surface-2xl);
+}
+
+.caret-surface-base {
+  caret-color: var(--surface-base);
+}
+
+.caret-surface-inner {
+  caret-color: var(--surface-inner);
+}
+
+.caret-surface-lg {
+  caret-color: var(--surface-lg);
+}
+
+.caret-surface-md {
+  caret-color: var(--surface-md);
+}
+
+.caret-surface-xl {
+  caret-color: var(--surface-xl);
+}
+
+.caret-text-and-icons {
+  caret-color: var(--text-and-icons);
+}
+
+.caret-titles-and-attributes {
+  caret-color: var(--titles-and-attributes);
+}
+
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-5 {
+  opacity: 0.05;
+}
+
+.opacity-10 {
+  opacity: 0.1;
+}
+
+.opacity-20 {
+  opacity: 0.2;
+}
+
+.opacity-25 {
+  opacity: 0.25;
+}
+
+.opacity-30 {
+  opacity: 0.3;
+}
+
+.opacity-40 {
+  opacity: 0.4;
+}
+
+.opacity-50 {
+  opacity: 0.5;
+}
+
+.opacity-60 {
+  opacity: 0.6;
+}
+
+.opacity-70 {
+  opacity: 0.7;
+}
+
+.opacity-75 {
+  opacity: 0.75;
+}
+
+.opacity-80 {
+  opacity: 0.8;
+}
+
+.opacity-90 {
+  opacity: 0.9;
+}
+
+.opacity-95 {
+  opacity: 0.95;
+}
+
+.opacity-100 {
+  opacity: 1;
+}
+
+.hover\\\\:opacity-0:hover {
+  opacity: 0;
+}
+
+.hover\\\\:opacity-5:hover {
+  opacity: 0.05;
+}
+
+.hover\\\\:opacity-10:hover {
+  opacity: 0.1;
+}
+
+.hover\\\\:opacity-20:hover {
+  opacity: 0.2;
+}
+
+.hover\\\\:opacity-25:hover {
+  opacity: 0.25;
+}
+
+.hover\\\\:opacity-30:hover {
+  opacity: 0.3;
+}
+
+.hover\\\\:opacity-40:hover {
+  opacity: 0.4;
+}
+
+.hover\\\\:opacity-50:hover {
+  opacity: 0.5;
+}
+
+.hover\\\\:opacity-60:hover {
+  opacity: 0.6;
+}
+
+.hover\\\\:opacity-70:hover {
+  opacity: 0.7;
+}
+
+.hover\\\\:opacity-75:hover {
+  opacity: 0.75;
+}
+
+.hover\\\\:opacity-80:hover {
+  opacity: 0.8;
+}
+
+.hover\\\\:opacity-90:hover {
+  opacity: 0.9;
+}
+
+.hover\\\\:opacity-95:hover {
+  opacity: 0.95;
+}
+
+.hover\\\\:opacity-100:hover {
+  opacity: 1;
+}
+
+.focus\\\\:opacity-0:focus {
+  opacity: 0;
+}
+
+.focus\\\\:opacity-5:focus {
+  opacity: 0.05;
+}
+
+.focus\\\\:opacity-10:focus {
+  opacity: 0.1;
+}
+
+.focus\\\\:opacity-20:focus {
+  opacity: 0.2;
+}
+
+.focus\\\\:opacity-25:focus {
+  opacity: 0.25;
+}
+
+.focus\\\\:opacity-30:focus {
+  opacity: 0.3;
+}
+
+.focus\\\\:opacity-40:focus {
+  opacity: 0.4;
+}
+
+.focus\\\\:opacity-50:focus {
+  opacity: 0.5;
+}
+
+.focus\\\\:opacity-60:focus {
+  opacity: 0.6;
+}
+
+.focus\\\\:opacity-70:focus {
+  opacity: 0.7;
+}
+
+.focus\\\\:opacity-75:focus {
+  opacity: 0.75;
+}
+
+.focus\\\\:opacity-80:focus {
+  opacity: 0.8;
+}
+
+.focus\\\\:opacity-90:focus {
+  opacity: 0.9;
+}
+
+.focus\\\\:opacity-95:focus {
+  opacity: 0.95;
+}
+
+.focus\\\\:opacity-100:focus {
+  opacity: 1;
+}
+
+.group:hover .group-hover\\\\:opacity-0 {
+  opacity: 0;
+}
+
+.group:hover .group-hover\\\\:opacity-5 {
+  opacity: 0.05;
+}
+
+.group:hover .group-hover\\\\:opacity-10 {
+  opacity: 0.1;
+}
+
+.group:hover .group-hover\\\\:opacity-20 {
+  opacity: 0.2;
+}
+
+.group:hover .group-hover\\\\:opacity-25 {
+  opacity: 0.25;
+}
+
+.group:hover .group-hover\\\\:opacity-30 {
+  opacity: 0.3;
+}
+
+.group:hover .group-hover\\\\:opacity-40 {
+  opacity: 0.4;
+}
+
+.group:hover .group-hover\\\\:opacity-50 {
+  opacity: 0.5;
+}
+
+.group:hover .group-hover\\\\:opacity-60 {
+  opacity: 0.6;
+}
+
+.group:hover .group-hover\\\\:opacity-70 {
+  opacity: 0.7;
+}
+
+.group:hover .group-hover\\\\:opacity-75 {
+  opacity: 0.75;
+}
+
+.group:hover .group-hover\\\\:opacity-80 {
+  opacity: 0.8;
+}
+
+.group:hover .group-hover\\\\:opacity-90 {
+  opacity: 0.9;
+}
+
+.group:hover .group-hover\\\\:opacity-95 {
+  opacity: 0.95;
+}
+
+.group:hover .group-hover\\\\:opacity-100 {
+  opacity: 1;
+}
+
+.group:focus .group-focus\\\\:opacity-0 {
+  opacity: 0;
+}
+
+.group:focus .group-focus\\\\:opacity-5 {
+  opacity: 0.05;
+}
+
+.group:focus .group-focus\\\\:opacity-10 {
+  opacity: 0.1;
+}
+
+.group:focus .group-focus\\\\:opacity-20 {
+  opacity: 0.2;
+}
+
+.group:focus .group-focus\\\\:opacity-25 {
+  opacity: 0.25;
+}
+
+.group:focus .group-focus\\\\:opacity-30 {
+  opacity: 0.3;
+}
+
+.group:focus .group-focus\\\\:opacity-40 {
+  opacity: 0.4;
+}
+
+.group:focus .group-focus\\\\:opacity-50 {
+  opacity: 0.5;
+}
+
+.group:focus .group-focus\\\\:opacity-60 {
+  opacity: 0.6;
+}
+
+.group:focus .group-focus\\\\:opacity-70 {
+  opacity: 0.7;
+}
+
+.group:focus .group-focus\\\\:opacity-75 {
+  opacity: 0.75;
+}
+
+.group:focus .group-focus\\\\:opacity-80 {
+  opacity: 0.8;
+}
+
+.group:focus .group-focus\\\\:opacity-90 {
+  opacity: 0.9;
+}
+
+.group:focus .group-focus\\\\:opacity-95 {
+  opacity: 0.95;
+}
+
+.group:focus .group-focus\\\\:opacity-100 {
+  opacity: 1;
+}
+
+.bg-blend-normal {
+  background-blend-mode: normal;
+}
+
+.bg-blend-multiply {
+  background-blend-mode: multiply;
+}
+
+.bg-blend-screen {
+  background-blend-mode: screen;
+}
+
+.bg-blend-overlay {
+  background-blend-mode: overlay;
+}
+
+.bg-blend-darken {
+  background-blend-mode: darken;
+}
+
+.bg-blend-lighten {
+  background-blend-mode: lighten;
+}
+
+.bg-blend-color-dodge {
+  background-blend-mode: color-dodge;
+}
+
+.bg-blend-color-burn {
+  background-blend-mode: color-burn;
+}
+
+.bg-blend-hard-light {
+  background-blend-mode: hard-light;
+}
+
+.bg-blend-soft-light {
+  background-blend-mode: soft-light;
+}
+
+.bg-blend-difference {
+  background-blend-mode: difference;
+}
+
+.bg-blend-exclusion {
+  background-blend-mode: exclusion;
+}
+
+.bg-blend-hue {
+  background-blend-mode: hue;
+}
+
+.bg-blend-saturation {
+  background-blend-mode: saturation;
+}
+
+.bg-blend-color {
+  background-blend-mode: color;
+}
+
+.bg-blend-luminosity {
+  background-blend-mode: luminosity;
+}
+
+.mix-blend-normal {
+  mix-blend-mode: normal;
+}
+
+.mix-blend-multiply {
+  mix-blend-mode: multiply;
+}
+
+.mix-blend-screen {
+  mix-blend-mode: screen;
+}
+
+.mix-blend-overlay {
+  mix-blend-mode: overlay;
+}
+
+.mix-blend-darken {
+  mix-blend-mode: darken;
+}
+
+.mix-blend-lighten {
+  mix-blend-mode: lighten;
+}
+
+.mix-blend-color-dodge {
+  mix-blend-mode: color-dodge;
+}
+
+.mix-blend-color-burn {
+  mix-blend-mode: color-burn;
+}
+
+.mix-blend-hard-light {
+  mix-blend-mode: hard-light;
+}
+
+.mix-blend-soft-light {
+  mix-blend-mode: soft-light;
+}
+
+.mix-blend-difference {
+  mix-blend-mode: difference;
+}
+
+.mix-blend-exclusion {
+  mix-blend-mode: exclusion;
+}
+
+.mix-blend-hue {
+  mix-blend-mode: hue;
+}
+
+.mix-blend-saturation {
+  mix-blend-mode: saturation;
+}
+
+.mix-blend-color {
+  mix-blend-mode: color;
+}
+
+.mix-blend-luminosity {
+  mix-blend-mode: luminosity;
+}
+
+*, ::before, ::after {
+  --tw-shadow: 0 0 #0000;
+}
+
+.shadow-none {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-focusable-outline {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-focus-outline {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-error-outline {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-search-input {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-2xl {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-base {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-inner-lg {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-inner-md {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-lg {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-md {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-xl {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-none:hover {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-focusable-outline:hover {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-focus-outline:hover {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-error-outline:hover {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-search-input:hover {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-2xl:hover {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-base:hover {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-inner-lg:hover {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-inner-md:hover {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-lg:hover {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-md:hover {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-xl:hover {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-none {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-focusable-outline {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-focus-outline {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-error-outline {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-search-input {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-2xl {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-base {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-inner-lg {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-inner-md {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-lg {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-md {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.group:hover .group-hover\\\\:shadow-xl {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-none:focus {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-focusable-outline:focus {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-focus-outline:focus {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-error-outline:focus {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-search-input:focus {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-2xl:focus {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-base:focus {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-inner-lg:focus {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-inner-md:focus {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-lg:focus {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-md:focus {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-xl:focus {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-none:focus-within {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-focusable-outline:focus-within {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-focus-outline:focus-within {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-error-outline:focus-within {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-search-input:focus-within {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-2xl:focus-within {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-base:focus-within {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-inner-lg:focus-within {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-inner-md:focus-within {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-lg:focus-within {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-md:focus-within {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\\\\:shadow-xl:focus-within {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-none:focus-visible {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-focusable-outline:focus-visible {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-focus-outline:focus-visible {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-error-outline:focus-visible {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-search-input:focus-visible {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-2xl:focus-visible {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-base:focus-visible {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-inner-lg:focus-visible {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-inner-md:focus-visible {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-lg:focus-visible {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-md:focus-visible {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-xl:focus-visible {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-none:active {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-focusable-outline:active {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-focus-outline:active {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-error-outline:active {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-search-input:active {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-2xl:active {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-base:active {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-inner-lg:active {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-inner-md:active {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-lg:active {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-md:active {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.active\\\\:shadow-xl:active {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-none:disabled {
+  --tw-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-focusable-outline:disabled {
+  --tw-shadow: inset 0 0 0 1px var(--lines-dark), var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-focus-outline:disabled {
+  --tw-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-error-outline:disabled {
+  --tw-shadow: inset 0 0 0 2px var(--critical);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-search-input:disabled {
+  --tw-shadow: inset 0 0 0 1px var(--nav-text-secondary);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-2xl:disabled {
+  --tw-shadow: var(--elevation-2xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-base:disabled {
+  --tw-shadow: var(--elevation-base);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-inner-lg:disabled {
+  --tw-shadow: var(--elevation-inner-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-inner-md:disabled {
+  --tw-shadow: var(--elevation-inner-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-lg:disabled {
+  --tw-shadow: var(--elevation-lg);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-md:disabled {
+  --tw-shadow: var(--elevation-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-xl:disabled {
+  --tw-shadow: var(--elevation-xl);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.outline-none {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.outline-white {
+  outline: 2px dotted white;
+  outline-offset: 2px;
+}
+
+.outline-black {
+  outline: 2px dotted black;
+  outline-offset: 2px;
+}
+
+.focus\\\\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focus\\\\:outline-white:focus {
+  outline: 2px dotted white;
+  outline-offset: 2px;
+}
+
+.focus\\\\:outline-black:focus {
+  outline: 2px dotted black;
+  outline-offset: 2px;
+}
+
+*, ::before, ::after {
+  --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+}
+
+.ring-0 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-1 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-2 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-4 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-8 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-0:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-1:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-2:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-4:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring-8:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\\\\:ring:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-0:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-1:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-2:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-4:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring-8:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-visible\\\\:ring:focus-visible {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-0:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-1:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-2:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-4:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring-8:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\\\\:ring:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-inset {
+  --tw-ring-inset: inset;
+}
+
+.focus-within\\\\:ring-inset:focus-within {
+  --tw-ring-inset: inset;
+}
+
+.focus-visible\\\\:ring-inset:focus-visible {
+  --tw-ring-inset: inset;
+}
+
+.focus\\\\:ring-inset:focus {
+  --tw-ring-inset: inset;
+}
+
+.ring-current {
+  --tw-ring-color: currentColor;
+}
+
+.ring-transparent {
+  --tw-ring-color: transparent;
+}
+
+.ring-falcon {
+  --tw-ring-color: var(--falcon);
+}
+
+.ring-basement {
+  --tw-ring-color: var(--basement);
+}
+
+.ring-blue {
+  --tw-ring-color: var(--blue);
+}
+
+.ring-body-and-labels {
+  --tw-ring-color: var(--body-and-labels);
+}
+
+.ring-brand {
+  --tw-ring-color: var(--brand);
+}
+
+.ring-code-base-64 {
+  --tw-ring-color: var(--code-base-64);
+}
+
+.ring-code-bg {
+  --tw-ring-color: var(--code-bg);
+}
+
+.ring-code-outline {
+  --tw-ring-color: var(--code-outline);
+}
+
+.ring-code-text {
+  --tw-ring-color: var(--code-text);
+}
+
+.ring-critical {
+  --tw-ring-color: var(--critical);
+}
+
+.ring-destructive-hover {
+  --tw-ring-color: var(--destructive-hover);
+}
+
+.ring-destructive-idle {
+  --tw-ring-color: var(--destructive-idle);
+}
+
+.ring-destructive-pressed {
+  --tw-ring-color: var(--destructive-pressed);
+}
+
+.ring-disabled {
+  --tw-ring-color: var(--disabled);
+}
+
+.ring-disc-operations {
+  --tw-ring-color: var(--disc-operations);
+}
+
+.ring-dns-requests {
+  --tw-ring-color: var(--dns-requests);
+}
+
+.ring-focus {
+  --tw-ring-color: var(--focus);
+}
+
+.ring-graph-1 {
+  --tw-ring-color: var(--graph-1);
+}
+
+.ring-graph-10 {
+  --tw-ring-color: var(--graph-10);
+}
+
+.ring-graph-11 {
+  --tw-ring-color: var(--graph-11);
+}
+
+.ring-graph-2 {
+  --tw-ring-color: var(--graph-2);
+}
+
+.ring-graph-3 {
+  --tw-ring-color: var(--graph-3);
+}
+
+.ring-graph-4 {
+  --tw-ring-color: var(--graph-4);
+}
+
+.ring-graph-5 {
+  --tw-ring-color: var(--graph-5);
+}
+
+.ring-graph-6 {
+  --tw-ring-color: var(--graph-6);
+}
+
+.ring-graph-7 {
+  --tw-ring-color: var(--graph-7);
+}
+
+.ring-graph-8 {
+  --tw-ring-color: var(--graph-8);
+}
+
+.ring-graph-9 {
+  --tw-ring-color: var(--graph-9);
+}
+
+.ring-graph-disabled {
+  --tw-ring-color: var(--graph-disabled);
+}
+
+.ring-ground-floor {
+  --tw-ring-color: var(--ground-floor);
+}
+
+.ring-high {
+  --tw-ring-color: var(--high);
+}
+
+.ring-informational {
+  --tw-ring-color: var(--informational);
+}
+
+.ring-lines-dark {
+  --tw-ring-color: var(--lines-dark);
+}
+
+.ring-lines-light {
+  --tw-ring-color: var(--lines-light);
+}
+
+.ring-low {
+  --tw-ring-color: var(--low);
+}
+
+.ring-medium {
+  --tw-ring-color: var(--medium);
+}
+
+.ring-mezzanine {
+  --tw-ring-color: var(--mezzanine);
+}
+
+.ring-nav-text-and-icons {
+  --tw-ring-color: var(--nav-text-and-icons);
+}
+
+.ring-nav-text-secondary {
+  --tw-ring-color: var(--nav-text-secondary);
+}
+
+.ring-network-operations {
+  --tw-ring-color: var(--network-operations);
+}
+
+.ring-normal-hover {
+  --tw-ring-color: var(--normal-hover);
+}
+
+.ring-normal-idle {
+  --tw-ring-color: var(--normal-idle);
+}
+
+.ring-normal-pressed {
+  --tw-ring-color: var(--normal-pressed);
+}
+
+.ring-overlay-0\\\\.5 {
+  --tw-ring-color: var(--overlay-0\\\\.5);
+}
+
+.ring-overlay-1 {
+  --tw-ring-color: var(--overlay-1);
+}
+
+.ring-overlay-2 {
+  --tw-ring-color: var(--overlay-2);
+}
+
+.ring-positive {
+  --tw-ring-color: var(--positive);
+}
+
+.ring-primary-hover {
+  --tw-ring-color: var(--primary-hover);
+}
+
+.ring-primary-idle {
+  --tw-ring-color: var(--primary-idle);
+}
+
+.ring-primary-pressed {
+  --tw-ring-color: var(--primary-pressed);
+}
+
+.ring-process-operations {
+  --tw-ring-color: var(--process-operations);
+}
+
+.ring-purple {
+  --tw-ring-color: var(--purple);
+}
+
+.ring-registry-operations {
+  --tw-ring-color: var(--registry-operations);
+}
+
+.ring-selected {
+  --tw-ring-color: var(--selected);
+}
+
+.ring-surface-2xl {
+  --tw-ring-color: var(--surface-2xl);
+}
+
+.ring-surface-base {
+  --tw-ring-color: var(--surface-base);
+}
+
+.ring-surface-inner {
+  --tw-ring-color: var(--surface-inner);
+}
+
+.ring-surface-lg {
+  --tw-ring-color: var(--surface-lg);
+}
+
+.ring-surface-md {
+  --tw-ring-color: var(--surface-md);
+}
+
+.ring-surface-xl {
+  --tw-ring-color: var(--surface-xl);
+}
+
+.ring-text-and-icons {
+  --tw-ring-color: var(--text-and-icons);
+}
+
+.ring-titles-and-attributes {
+  --tw-ring-color: var(--titles-and-attributes);
+}
+
+.focus-within\\\\:ring-current:focus-within {
+  --tw-ring-color: currentColor;
+}
+
+.focus-within\\\\:ring-transparent:focus-within {
+  --tw-ring-color: transparent;
+}
+
+.focus-within\\\\:ring-falcon:focus-within {
+  --tw-ring-color: var(--falcon);
+}
+
+.focus-within\\\\:ring-basement:focus-within {
+  --tw-ring-color: var(--basement);
+}
+
+.focus-within\\\\:ring-blue:focus-within {
+  --tw-ring-color: var(--blue);
+}
+
+.focus-within\\\\:ring-body-and-labels:focus-within {
+  --tw-ring-color: var(--body-and-labels);
+}
+
+.focus-within\\\\:ring-brand:focus-within {
+  --tw-ring-color: var(--brand);
+}
+
+.focus-within\\\\:ring-code-base-64:focus-within {
+  --tw-ring-color: var(--code-base-64);
+}
+
+.focus-within\\\\:ring-code-bg:focus-within {
+  --tw-ring-color: var(--code-bg);
+}
+
+.focus-within\\\\:ring-code-outline:focus-within {
+  --tw-ring-color: var(--code-outline);
+}
+
+.focus-within\\\\:ring-code-text:focus-within {
+  --tw-ring-color: var(--code-text);
+}
+
+.focus-within\\\\:ring-critical:focus-within {
+  --tw-ring-color: var(--critical);
+}
+
+.focus-within\\\\:ring-destructive-hover:focus-within {
+  --tw-ring-color: var(--destructive-hover);
+}
+
+.focus-within\\\\:ring-destructive-idle:focus-within {
+  --tw-ring-color: var(--destructive-idle);
+}
+
+.focus-within\\\\:ring-destructive-pressed:focus-within {
+  --tw-ring-color: var(--destructive-pressed);
+}
+
+.focus-within\\\\:ring-disabled:focus-within {
+  --tw-ring-color: var(--disabled);
+}
+
+.focus-within\\\\:ring-disc-operations:focus-within {
+  --tw-ring-color: var(--disc-operations);
+}
+
+.focus-within\\\\:ring-dns-requests:focus-within {
+  --tw-ring-color: var(--dns-requests);
+}
+
+.focus-within\\\\:ring-focus:focus-within {
+  --tw-ring-color: var(--focus);
+}
+
+.focus-within\\\\:ring-graph-1:focus-within {
+  --tw-ring-color: var(--graph-1);
+}
+
+.focus-within\\\\:ring-graph-10:focus-within {
+  --tw-ring-color: var(--graph-10);
+}
+
+.focus-within\\\\:ring-graph-11:focus-within {
+  --tw-ring-color: var(--graph-11);
+}
+
+.focus-within\\\\:ring-graph-2:focus-within {
+  --tw-ring-color: var(--graph-2);
+}
+
+.focus-within\\\\:ring-graph-3:focus-within {
+  --tw-ring-color: var(--graph-3);
+}
+
+.focus-within\\\\:ring-graph-4:focus-within {
+  --tw-ring-color: var(--graph-4);
+}
+
+.focus-within\\\\:ring-graph-5:focus-within {
+  --tw-ring-color: var(--graph-5);
+}
+
+.focus-within\\\\:ring-graph-6:focus-within {
+  --tw-ring-color: var(--graph-6);
+}
+
+.focus-within\\\\:ring-graph-7:focus-within {
+  --tw-ring-color: var(--graph-7);
+}
+
+.focus-within\\\\:ring-graph-8:focus-within {
+  --tw-ring-color: var(--graph-8);
+}
+
+.focus-within\\\\:ring-graph-9:focus-within {
+  --tw-ring-color: var(--graph-9);
+}
+
+.focus-within\\\\:ring-graph-disabled:focus-within {
+  --tw-ring-color: var(--graph-disabled);
+}
+
+.focus-within\\\\:ring-ground-floor:focus-within {
+  --tw-ring-color: var(--ground-floor);
+}
+
+.focus-within\\\\:ring-high:focus-within {
+  --tw-ring-color: var(--high);
+}
+
+.focus-within\\\\:ring-informational:focus-within {
+  --tw-ring-color: var(--informational);
+}
+
+.focus-within\\\\:ring-lines-dark:focus-within {
+  --tw-ring-color: var(--lines-dark);
+}
+
+.focus-within\\\\:ring-lines-light:focus-within {
+  --tw-ring-color: var(--lines-light);
+}
+
+.focus-within\\\\:ring-low:focus-within {
+  --tw-ring-color: var(--low);
+}
+
+.focus-within\\\\:ring-medium:focus-within {
+  --tw-ring-color: var(--medium);
+}
+
+.focus-within\\\\:ring-mezzanine:focus-within {
+  --tw-ring-color: var(--mezzanine);
+}
+
+.focus-within\\\\:ring-nav-text-and-icons:focus-within {
+  --tw-ring-color: var(--nav-text-and-icons);
+}
+
+.focus-within\\\\:ring-nav-text-secondary:focus-within {
+  --tw-ring-color: var(--nav-text-secondary);
+}
+
+.focus-within\\\\:ring-network-operations:focus-within {
+  --tw-ring-color: var(--network-operations);
+}
+
+.focus-within\\\\:ring-normal-hover:focus-within {
+  --tw-ring-color: var(--normal-hover);
+}
+
+.focus-within\\\\:ring-normal-idle:focus-within {
+  --tw-ring-color: var(--normal-idle);
+}
+
+.focus-within\\\\:ring-normal-pressed:focus-within {
+  --tw-ring-color: var(--normal-pressed);
+}
+
+.focus-within\\\\:ring-overlay-0\\\\.5:focus-within {
+  --tw-ring-color: var(--overlay-0\\\\.5);
+}
+
+.focus-within\\\\:ring-overlay-1:focus-within {
+  --tw-ring-color: var(--overlay-1);
+}
+
+.focus-within\\\\:ring-overlay-2:focus-within {
+  --tw-ring-color: var(--overlay-2);
+}
+
+.focus-within\\\\:ring-positive:focus-within {
+  --tw-ring-color: var(--positive);
+}
+
+.focus-within\\\\:ring-primary-hover:focus-within {
+  --tw-ring-color: var(--primary-hover);
+}
+
+.focus-within\\\\:ring-primary-idle:focus-within {
+  --tw-ring-color: var(--primary-idle);
+}
+
+.focus-within\\\\:ring-primary-pressed:focus-within {
+  --tw-ring-color: var(--primary-pressed);
+}
+
+.focus-within\\\\:ring-process-operations:focus-within {
+  --tw-ring-color: var(--process-operations);
+}
+
+.focus-within\\\\:ring-purple:focus-within {
+  --tw-ring-color: var(--purple);
+}
+
+.focus-within\\\\:ring-registry-operations:focus-within {
+  --tw-ring-color: var(--registry-operations);
+}
+
+.focus-within\\\\:ring-selected:focus-within {
+  --tw-ring-color: var(--selected);
+}
+
+.focus-within\\\\:ring-surface-2xl:focus-within {
+  --tw-ring-color: var(--surface-2xl);
+}
+
+.focus-within\\\\:ring-surface-base:focus-within {
+  --tw-ring-color: var(--surface-base);
+}
+
+.focus-within\\\\:ring-surface-inner:focus-within {
+  --tw-ring-color: var(--surface-inner);
+}
+
+.focus-within\\\\:ring-surface-lg:focus-within {
+  --tw-ring-color: var(--surface-lg);
+}
+
+.focus-within\\\\:ring-surface-md:focus-within {
+  --tw-ring-color: var(--surface-md);
+}
+
+.focus-within\\\\:ring-surface-xl:focus-within {
+  --tw-ring-color: var(--surface-xl);
+}
+
+.focus-within\\\\:ring-text-and-icons:focus-within {
+  --tw-ring-color: var(--text-and-icons);
+}
+
+.focus-within\\\\:ring-titles-and-attributes:focus-within {
+  --tw-ring-color: var(--titles-and-attributes);
+}
+
+.focus\\\\:ring-current:focus {
+  --tw-ring-color: currentColor;
+}
+
+.focus\\\\:ring-transparent:focus {
+  --tw-ring-color: transparent;
+}
+
+.focus\\\\:ring-falcon:focus {
+  --tw-ring-color: var(--falcon);
+}
+
+.focus\\\\:ring-basement:focus {
+  --tw-ring-color: var(--basement);
+}
+
+.focus\\\\:ring-blue:focus {
+  --tw-ring-color: var(--blue);
+}
+
+.focus\\\\:ring-body-and-labels:focus {
+  --tw-ring-color: var(--body-and-labels);
+}
+
+.focus\\\\:ring-brand:focus {
+  --tw-ring-color: var(--brand);
+}
+
+.focus\\\\:ring-code-base-64:focus {
+  --tw-ring-color: var(--code-base-64);
+}
+
+.focus\\\\:ring-code-bg:focus {
+  --tw-ring-color: var(--code-bg);
+}
+
+.focus\\\\:ring-code-outline:focus {
+  --tw-ring-color: var(--code-outline);
+}
+
+.focus\\\\:ring-code-text:focus {
+  --tw-ring-color: var(--code-text);
+}
+
+.focus\\\\:ring-critical:focus {
+  --tw-ring-color: var(--critical);
+}
+
+.focus\\\\:ring-destructive-hover:focus {
+  --tw-ring-color: var(--destructive-hover);
+}
+
+.focus\\\\:ring-destructive-idle:focus {
+  --tw-ring-color: var(--destructive-idle);
+}
+
+.focus\\\\:ring-destructive-pressed:focus {
+  --tw-ring-color: var(--destructive-pressed);
+}
+
+.focus\\\\:ring-disabled:focus {
+  --tw-ring-color: var(--disabled);
+}
+
+.focus\\\\:ring-disc-operations:focus {
+  --tw-ring-color: var(--disc-operations);
+}
+
+.focus\\\\:ring-dns-requests:focus {
+  --tw-ring-color: var(--dns-requests);
+}
+
+.focus\\\\:ring-focus:focus {
+  --tw-ring-color: var(--focus);
+}
+
+.focus\\\\:ring-graph-1:focus {
+  --tw-ring-color: var(--graph-1);
+}
+
+.focus\\\\:ring-graph-10:focus {
+  --tw-ring-color: var(--graph-10);
+}
+
+.focus\\\\:ring-graph-11:focus {
+  --tw-ring-color: var(--graph-11);
+}
+
+.focus\\\\:ring-graph-2:focus {
+  --tw-ring-color: var(--graph-2);
+}
+
+.focus\\\\:ring-graph-3:focus {
+  --tw-ring-color: var(--graph-3);
+}
+
+.focus\\\\:ring-graph-4:focus {
+  --tw-ring-color: var(--graph-4);
+}
+
+.focus\\\\:ring-graph-5:focus {
+  --tw-ring-color: var(--graph-5);
+}
+
+.focus\\\\:ring-graph-6:focus {
+  --tw-ring-color: var(--graph-6);
+}
+
+.focus\\\\:ring-graph-7:focus {
+  --tw-ring-color: var(--graph-7);
+}
+
+.focus\\\\:ring-graph-8:focus {
+  --tw-ring-color: var(--graph-8);
+}
+
+.focus\\\\:ring-graph-9:focus {
+  --tw-ring-color: var(--graph-9);
+}
+
+.focus\\\\:ring-graph-disabled:focus {
+  --tw-ring-color: var(--graph-disabled);
+}
+
+.focus\\\\:ring-ground-floor:focus {
+  --tw-ring-color: var(--ground-floor);
+}
+
+.focus\\\\:ring-high:focus {
+  --tw-ring-color: var(--high);
+}
+
+.focus\\\\:ring-informational:focus {
+  --tw-ring-color: var(--informational);
+}
+
+.focus\\\\:ring-lines-dark:focus {
+  --tw-ring-color: var(--lines-dark);
+}
+
+.focus\\\\:ring-lines-light:focus {
+  --tw-ring-color: var(--lines-light);
+}
+
+.focus\\\\:ring-low:focus {
+  --tw-ring-color: var(--low);
+}
+
+.focus\\\\:ring-medium:focus {
+  --tw-ring-color: var(--medium);
+}
+
+.focus\\\\:ring-mezzanine:focus {
+  --tw-ring-color: var(--mezzanine);
+}
+
+.focus\\\\:ring-nav-text-and-icons:focus {
+  --tw-ring-color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:ring-nav-text-secondary:focus {
+  --tw-ring-color: var(--nav-text-secondary);
+}
+
+.focus\\\\:ring-network-operations:focus {
+  --tw-ring-color: var(--network-operations);
+}
+
+.focus\\\\:ring-normal-hover:focus {
+  --tw-ring-color: var(--normal-hover);
+}
+
+.focus\\\\:ring-normal-idle:focus {
+  --tw-ring-color: var(--normal-idle);
+}
+
+.focus\\\\:ring-normal-pressed:focus {
+  --tw-ring-color: var(--normal-pressed);
+}
+
+.focus\\\\:ring-overlay-0\\\\.5:focus {
+  --tw-ring-color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:ring-overlay-1:focus {
+  --tw-ring-color: var(--overlay-1);
+}
+
+.focus\\\\:ring-overlay-2:focus {
+  --tw-ring-color: var(--overlay-2);
+}
+
+.focus\\\\:ring-positive:focus {
+  --tw-ring-color: var(--positive);
+}
+
+.focus\\\\:ring-primary-hover:focus {
+  --tw-ring-color: var(--primary-hover);
+}
+
+.focus\\\\:ring-primary-idle:focus {
+  --tw-ring-color: var(--primary-idle);
+}
+
+.focus\\\\:ring-primary-pressed:focus {
+  --tw-ring-color: var(--primary-pressed);
+}
+
+.focus\\\\:ring-process-operations:focus {
+  --tw-ring-color: var(--process-operations);
+}
+
+.focus\\\\:ring-purple:focus {
+  --tw-ring-color: var(--purple);
+}
+
+.focus\\\\:ring-registry-operations:focus {
+  --tw-ring-color: var(--registry-operations);
+}
+
+.focus\\\\:ring-selected:focus {
+  --tw-ring-color: var(--selected);
+}
+
+.focus\\\\:ring-surface-2xl:focus {
+  --tw-ring-color: var(--surface-2xl);
+}
+
+.focus\\\\:ring-surface-base:focus {
+  --tw-ring-color: var(--surface-base);
+}
+
+.focus\\\\:ring-surface-inner:focus {
+  --tw-ring-color: var(--surface-inner);
+}
+
+.focus\\\\:ring-surface-lg:focus {
+  --tw-ring-color: var(--surface-lg);
+}
+
+.focus\\\\:ring-surface-md:focus {
+  --tw-ring-color: var(--surface-md);
+}
+
+.focus\\\\:ring-surface-xl:focus {
+  --tw-ring-color: var(--surface-xl);
+}
+
+.focus\\\\:ring-text-and-icons:focus {
+  --tw-ring-color: var(--text-and-icons);
+}
+
+.focus\\\\:ring-titles-and-attributes:focus {
+  --tw-ring-color: var(--titles-and-attributes);
+}
+
+.ring-opacity-0 {
+  --tw-ring-opacity: 0;
+}
+
+.ring-opacity-5 {
+  --tw-ring-opacity: 0.05;
+}
+
+.ring-opacity-10 {
+  --tw-ring-opacity: 0.1;
+}
+
+.ring-opacity-20 {
+  --tw-ring-opacity: 0.2;
+}
+
+.ring-opacity-25 {
+  --tw-ring-opacity: 0.25;
+}
+
+.ring-opacity-30 {
+  --tw-ring-opacity: 0.3;
+}
+
+.ring-opacity-40 {
+  --tw-ring-opacity: 0.4;
+}
+
+.ring-opacity-50 {
+  --tw-ring-opacity: 0.5;
+}
+
+.ring-opacity-60 {
+  --tw-ring-opacity: 0.6;
+}
+
+.ring-opacity-70 {
+  --tw-ring-opacity: 0.7;
+}
+
+.ring-opacity-75 {
+  --tw-ring-opacity: 0.75;
+}
+
+.ring-opacity-80 {
+  --tw-ring-opacity: 0.8;
+}
+
+.ring-opacity-90 {
+  --tw-ring-opacity: 0.9;
+}
+
+.ring-opacity-95 {
+  --tw-ring-opacity: 0.95;
+}
+
+.ring-opacity-100 {
+  --tw-ring-opacity: 1;
+}
+
+.focus-within\\\\:ring-opacity-0:focus-within {
+  --tw-ring-opacity: 0;
+}
+
+.focus-within\\\\:ring-opacity-5:focus-within {
+  --tw-ring-opacity: 0.05;
+}
+
+.focus-within\\\\:ring-opacity-10:focus-within {
+  --tw-ring-opacity: 0.1;
+}
+
+.focus-within\\\\:ring-opacity-20:focus-within {
+  --tw-ring-opacity: 0.2;
+}
+
+.focus-within\\\\:ring-opacity-25:focus-within {
+  --tw-ring-opacity: 0.25;
+}
+
+.focus-within\\\\:ring-opacity-30:focus-within {
+  --tw-ring-opacity: 0.3;
+}
+
+.focus-within\\\\:ring-opacity-40:focus-within {
+  --tw-ring-opacity: 0.4;
+}
+
+.focus-within\\\\:ring-opacity-50:focus-within {
+  --tw-ring-opacity: 0.5;
+}
+
+.focus-within\\\\:ring-opacity-60:focus-within {
+  --tw-ring-opacity: 0.6;
+}
+
+.focus-within\\\\:ring-opacity-70:focus-within {
+  --tw-ring-opacity: 0.7;
+}
+
+.focus-within\\\\:ring-opacity-75:focus-within {
+  --tw-ring-opacity: 0.75;
+}
+
+.focus-within\\\\:ring-opacity-80:focus-within {
+  --tw-ring-opacity: 0.8;
+}
+
+.focus-within\\\\:ring-opacity-90:focus-within {
+  --tw-ring-opacity: 0.9;
+}
+
+.focus-within\\\\:ring-opacity-95:focus-within {
+  --tw-ring-opacity: 0.95;
+}
+
+.focus-within\\\\:ring-opacity-100:focus-within {
+  --tw-ring-opacity: 1;
+}
+
+.focus\\\\:ring-opacity-0:focus {
+  --tw-ring-opacity: 0;
+}
+
+.focus\\\\:ring-opacity-5:focus {
+  --tw-ring-opacity: 0.05;
+}
+
+.focus\\\\:ring-opacity-10:focus {
+  --tw-ring-opacity: 0.1;
+}
+
+.focus\\\\:ring-opacity-20:focus {
+  --tw-ring-opacity: 0.2;
+}
+
+.focus\\\\:ring-opacity-25:focus {
+  --tw-ring-opacity: 0.25;
+}
+
+.focus\\\\:ring-opacity-30:focus {
+  --tw-ring-opacity: 0.3;
+}
+
+.focus\\\\:ring-opacity-40:focus {
+  --tw-ring-opacity: 0.4;
+}
+
+.focus\\\\:ring-opacity-50:focus {
+  --tw-ring-opacity: 0.5;
+}
+
+.focus\\\\:ring-opacity-60:focus {
+  --tw-ring-opacity: 0.6;
+}
+
+.focus\\\\:ring-opacity-70:focus {
+  --tw-ring-opacity: 0.7;
+}
+
+.focus\\\\:ring-opacity-75:focus {
+  --tw-ring-opacity: 0.75;
+}
+
+.focus\\\\:ring-opacity-80:focus {
+  --tw-ring-opacity: 0.8;
+}
+
+.focus\\\\:ring-opacity-90:focus {
+  --tw-ring-opacity: 0.9;
+}
+
+.focus\\\\:ring-opacity-95:focus {
+  --tw-ring-opacity: 0.95;
+}
+
+.focus\\\\:ring-opacity-100:focus {
+  --tw-ring-opacity: 1;
+}
+
+.ring-offset-0 {
+  --tw-ring-offset-width: 0px;
+}
+
+.ring-offset-1 {
+  --tw-ring-offset-width: 1px;
+}
+
+.ring-offset-2 {
+  --tw-ring-offset-width: 2px;
+}
+
+.ring-offset-4 {
+  --tw-ring-offset-width: 4px;
+}
+
+.ring-offset-8 {
+  --tw-ring-offset-width: 8px;
+}
+
+.focus-within\\\\:ring-offset-0:focus-within {
+  --tw-ring-offset-width: 0px;
+}
+
+.focus-within\\\\:ring-offset-1:focus-within {
+  --tw-ring-offset-width: 1px;
+}
+
+.focus-within\\\\:ring-offset-2:focus-within {
+  --tw-ring-offset-width: 2px;
+}
+
+.focus-within\\\\:ring-offset-4:focus-within {
+  --tw-ring-offset-width: 4px;
+}
+
+.focus-within\\\\:ring-offset-8:focus-within {
+  --tw-ring-offset-width: 8px;
+}
+
+.focus\\\\:ring-offset-0:focus {
+  --tw-ring-offset-width: 0px;
+}
+
+.focus\\\\:ring-offset-1:focus {
+  --tw-ring-offset-width: 1px;
+}
+
+.focus\\\\:ring-offset-2:focus {
+  --tw-ring-offset-width: 2px;
+}
+
+.focus\\\\:ring-offset-4:focus {
+  --tw-ring-offset-width: 4px;
+}
+
+.focus\\\\:ring-offset-8:focus {
+  --tw-ring-offset-width: 8px;
+}
+
+.ring-offset-current {
+  --tw-ring-offset-color: currentColor;
+}
+
+.ring-offset-transparent {
+  --tw-ring-offset-color: transparent;
+}
+
+.ring-offset-falcon {
+  --tw-ring-offset-color: var(--falcon);
+}
+
+.ring-offset-basement {
+  --tw-ring-offset-color: var(--basement);
+}
+
+.ring-offset-blue {
+  --tw-ring-offset-color: var(--blue);
+}
+
+.ring-offset-body-and-labels {
+  --tw-ring-offset-color: var(--body-and-labels);
+}
+
+.ring-offset-brand {
+  --tw-ring-offset-color: var(--brand);
+}
+
+.ring-offset-code-base-64 {
+  --tw-ring-offset-color: var(--code-base-64);
+}
+
+.ring-offset-code-bg {
+  --tw-ring-offset-color: var(--code-bg);
+}
+
+.ring-offset-code-outline {
+  --tw-ring-offset-color: var(--code-outline);
+}
+
+.ring-offset-code-text {
+  --tw-ring-offset-color: var(--code-text);
+}
+
+.ring-offset-critical {
+  --tw-ring-offset-color: var(--critical);
+}
+
+.ring-offset-destructive-hover {
+  --tw-ring-offset-color: var(--destructive-hover);
+}
+
+.ring-offset-destructive-idle {
+  --tw-ring-offset-color: var(--destructive-idle);
+}
+
+.ring-offset-destructive-pressed {
+  --tw-ring-offset-color: var(--destructive-pressed);
+}
+
+.ring-offset-disabled {
+  --tw-ring-offset-color: var(--disabled);
+}
+
+.ring-offset-disc-operations {
+  --tw-ring-offset-color: var(--disc-operations);
+}
+
+.ring-offset-dns-requests {
+  --tw-ring-offset-color: var(--dns-requests);
+}
+
+.ring-offset-focus {
+  --tw-ring-offset-color: var(--focus);
+}
+
+.ring-offset-graph-1 {
+  --tw-ring-offset-color: var(--graph-1);
+}
+
+.ring-offset-graph-10 {
+  --tw-ring-offset-color: var(--graph-10);
+}
+
+.ring-offset-graph-11 {
+  --tw-ring-offset-color: var(--graph-11);
+}
+
+.ring-offset-graph-2 {
+  --tw-ring-offset-color: var(--graph-2);
+}
+
+.ring-offset-graph-3 {
+  --tw-ring-offset-color: var(--graph-3);
+}
+
+.ring-offset-graph-4 {
+  --tw-ring-offset-color: var(--graph-4);
+}
+
+.ring-offset-graph-5 {
+  --tw-ring-offset-color: var(--graph-5);
+}
+
+.ring-offset-graph-6 {
+  --tw-ring-offset-color: var(--graph-6);
+}
+
+.ring-offset-graph-7 {
+  --tw-ring-offset-color: var(--graph-7);
+}
+
+.ring-offset-graph-8 {
+  --tw-ring-offset-color: var(--graph-8);
+}
+
+.ring-offset-graph-9 {
+  --tw-ring-offset-color: var(--graph-9);
+}
+
+.ring-offset-graph-disabled {
+  --tw-ring-offset-color: var(--graph-disabled);
+}
+
+.ring-offset-ground-floor {
+  --tw-ring-offset-color: var(--ground-floor);
+}
+
+.ring-offset-high {
+  --tw-ring-offset-color: var(--high);
+}
+
+.ring-offset-informational {
+  --tw-ring-offset-color: var(--informational);
+}
+
+.ring-offset-lines-dark {
+  --tw-ring-offset-color: var(--lines-dark);
+}
+
+.ring-offset-lines-light {
+  --tw-ring-offset-color: var(--lines-light);
+}
+
+.ring-offset-low {
+  --tw-ring-offset-color: var(--low);
+}
+
+.ring-offset-medium {
+  --tw-ring-offset-color: var(--medium);
+}
+
+.ring-offset-mezzanine {
+  --tw-ring-offset-color: var(--mezzanine);
+}
+
+.ring-offset-nav-text-and-icons {
+  --tw-ring-offset-color: var(--nav-text-and-icons);
+}
+
+.ring-offset-nav-text-secondary {
+  --tw-ring-offset-color: var(--nav-text-secondary);
+}
+
+.ring-offset-network-operations {
+  --tw-ring-offset-color: var(--network-operations);
+}
+
+.ring-offset-normal-hover {
+  --tw-ring-offset-color: var(--normal-hover);
+}
+
+.ring-offset-normal-idle {
+  --tw-ring-offset-color: var(--normal-idle);
+}
+
+.ring-offset-normal-pressed {
+  --tw-ring-offset-color: var(--normal-pressed);
+}
+
+.ring-offset-overlay-0\\\\.5 {
+  --tw-ring-offset-color: var(--overlay-0\\\\.5);
+}
+
+.ring-offset-overlay-1 {
+  --tw-ring-offset-color: var(--overlay-1);
+}
+
+.ring-offset-overlay-2 {
+  --tw-ring-offset-color: var(--overlay-2);
+}
+
+.ring-offset-positive {
+  --tw-ring-offset-color: var(--positive);
+}
+
+.ring-offset-primary-hover {
+  --tw-ring-offset-color: var(--primary-hover);
+}
+
+.ring-offset-primary-idle {
+  --tw-ring-offset-color: var(--primary-idle);
+}
+
+.ring-offset-primary-pressed {
+  --tw-ring-offset-color: var(--primary-pressed);
+}
+
+.ring-offset-process-operations {
+  --tw-ring-offset-color: var(--process-operations);
+}
+
+.ring-offset-purple {
+  --tw-ring-offset-color: var(--purple);
+}
+
+.ring-offset-registry-operations {
+  --tw-ring-offset-color: var(--registry-operations);
+}
+
+.ring-offset-selected {
+  --tw-ring-offset-color: var(--selected);
+}
+
+.ring-offset-surface-2xl {
+  --tw-ring-offset-color: var(--surface-2xl);
+}
+
+.ring-offset-surface-base {
+  --tw-ring-offset-color: var(--surface-base);
+}
+
+.ring-offset-surface-inner {
+  --tw-ring-offset-color: var(--surface-inner);
+}
+
+.ring-offset-surface-lg {
+  --tw-ring-offset-color: var(--surface-lg);
+}
+
+.ring-offset-surface-md {
+  --tw-ring-offset-color: var(--surface-md);
+}
+
+.ring-offset-surface-xl {
+  --tw-ring-offset-color: var(--surface-xl);
+}
+
+.ring-offset-text-and-icons {
+  --tw-ring-offset-color: var(--text-and-icons);
+}
+
+.ring-offset-titles-and-attributes {
+  --tw-ring-offset-color: var(--titles-and-attributes);
+}
+
+.focus-within\\\\:ring-offset-current:focus-within {
+  --tw-ring-offset-color: currentColor;
+}
+
+.focus-within\\\\:ring-offset-transparent:focus-within {
+  --tw-ring-offset-color: transparent;
+}
+
+.focus-within\\\\:ring-offset-falcon:focus-within {
+  --tw-ring-offset-color: var(--falcon);
+}
+
+.focus-within\\\\:ring-offset-basement:focus-within {
+  --tw-ring-offset-color: var(--basement);
+}
+
+.focus-within\\\\:ring-offset-blue:focus-within {
+  --tw-ring-offset-color: var(--blue);
+}
+
+.focus-within\\\\:ring-offset-body-and-labels:focus-within {
+  --tw-ring-offset-color: var(--body-and-labels);
+}
+
+.focus-within\\\\:ring-offset-brand:focus-within {
+  --tw-ring-offset-color: var(--brand);
+}
+
+.focus-within\\\\:ring-offset-code-base-64:focus-within {
+  --tw-ring-offset-color: var(--code-base-64);
+}
+
+.focus-within\\\\:ring-offset-code-bg:focus-within {
+  --tw-ring-offset-color: var(--code-bg);
+}
+
+.focus-within\\\\:ring-offset-code-outline:focus-within {
+  --tw-ring-offset-color: var(--code-outline);
+}
+
+.focus-within\\\\:ring-offset-code-text:focus-within {
+  --tw-ring-offset-color: var(--code-text);
+}
+
+.focus-within\\\\:ring-offset-critical:focus-within {
+  --tw-ring-offset-color: var(--critical);
+}
+
+.focus-within\\\\:ring-offset-destructive-hover:focus-within {
+  --tw-ring-offset-color: var(--destructive-hover);
+}
+
+.focus-within\\\\:ring-offset-destructive-idle:focus-within {
+  --tw-ring-offset-color: var(--destructive-idle);
+}
+
+.focus-within\\\\:ring-offset-destructive-pressed:focus-within {
+  --tw-ring-offset-color: var(--destructive-pressed);
+}
+
+.focus-within\\\\:ring-offset-disabled:focus-within {
+  --tw-ring-offset-color: var(--disabled);
+}
+
+.focus-within\\\\:ring-offset-disc-operations:focus-within {
+  --tw-ring-offset-color: var(--disc-operations);
+}
+
+.focus-within\\\\:ring-offset-dns-requests:focus-within {
+  --tw-ring-offset-color: var(--dns-requests);
+}
+
+.focus-within\\\\:ring-offset-focus:focus-within {
+  --tw-ring-offset-color: var(--focus);
+}
+
+.focus-within\\\\:ring-offset-graph-1:focus-within {
+  --tw-ring-offset-color: var(--graph-1);
+}
+
+.focus-within\\\\:ring-offset-graph-10:focus-within {
+  --tw-ring-offset-color: var(--graph-10);
+}
+
+.focus-within\\\\:ring-offset-graph-11:focus-within {
+  --tw-ring-offset-color: var(--graph-11);
+}
+
+.focus-within\\\\:ring-offset-graph-2:focus-within {
+  --tw-ring-offset-color: var(--graph-2);
+}
+
+.focus-within\\\\:ring-offset-graph-3:focus-within {
+  --tw-ring-offset-color: var(--graph-3);
+}
+
+.focus-within\\\\:ring-offset-graph-4:focus-within {
+  --tw-ring-offset-color: var(--graph-4);
+}
+
+.focus-within\\\\:ring-offset-graph-5:focus-within {
+  --tw-ring-offset-color: var(--graph-5);
+}
+
+.focus-within\\\\:ring-offset-graph-6:focus-within {
+  --tw-ring-offset-color: var(--graph-6);
+}
+
+.focus-within\\\\:ring-offset-graph-7:focus-within {
+  --tw-ring-offset-color: var(--graph-7);
+}
+
+.focus-within\\\\:ring-offset-graph-8:focus-within {
+  --tw-ring-offset-color: var(--graph-8);
+}
+
+.focus-within\\\\:ring-offset-graph-9:focus-within {
+  --tw-ring-offset-color: var(--graph-9);
+}
+
+.focus-within\\\\:ring-offset-graph-disabled:focus-within {
+  --tw-ring-offset-color: var(--graph-disabled);
+}
+
+.focus-within\\\\:ring-offset-ground-floor:focus-within {
+  --tw-ring-offset-color: var(--ground-floor);
+}
+
+.focus-within\\\\:ring-offset-high:focus-within {
+  --tw-ring-offset-color: var(--high);
+}
+
+.focus-within\\\\:ring-offset-informational:focus-within {
+  --tw-ring-offset-color: var(--informational);
+}
+
+.focus-within\\\\:ring-offset-lines-dark:focus-within {
+  --tw-ring-offset-color: var(--lines-dark);
+}
+
+.focus-within\\\\:ring-offset-lines-light:focus-within {
+  --tw-ring-offset-color: var(--lines-light);
+}
+
+.focus-within\\\\:ring-offset-low:focus-within {
+  --tw-ring-offset-color: var(--low);
+}
+
+.focus-within\\\\:ring-offset-medium:focus-within {
+  --tw-ring-offset-color: var(--medium);
+}
+
+.focus-within\\\\:ring-offset-mezzanine:focus-within {
+  --tw-ring-offset-color: var(--mezzanine);
+}
+
+.focus-within\\\\:ring-offset-nav-text-and-icons:focus-within {
+  --tw-ring-offset-color: var(--nav-text-and-icons);
+}
+
+.focus-within\\\\:ring-offset-nav-text-secondary:focus-within {
+  --tw-ring-offset-color: var(--nav-text-secondary);
+}
+
+.focus-within\\\\:ring-offset-network-operations:focus-within {
+  --tw-ring-offset-color: var(--network-operations);
+}
+
+.focus-within\\\\:ring-offset-normal-hover:focus-within {
+  --tw-ring-offset-color: var(--normal-hover);
+}
+
+.focus-within\\\\:ring-offset-normal-idle:focus-within {
+  --tw-ring-offset-color: var(--normal-idle);
+}
+
+.focus-within\\\\:ring-offset-normal-pressed:focus-within {
+  --tw-ring-offset-color: var(--normal-pressed);
+}
+
+.focus-within\\\\:ring-offset-overlay-0\\\\.5:focus-within {
+  --tw-ring-offset-color: var(--overlay-0\\\\.5);
+}
+
+.focus-within\\\\:ring-offset-overlay-1:focus-within {
+  --tw-ring-offset-color: var(--overlay-1);
+}
+
+.focus-within\\\\:ring-offset-overlay-2:focus-within {
+  --tw-ring-offset-color: var(--overlay-2);
+}
+
+.focus-within\\\\:ring-offset-positive:focus-within {
+  --tw-ring-offset-color: var(--positive);
+}
+
+.focus-within\\\\:ring-offset-primary-hover:focus-within {
+  --tw-ring-offset-color: var(--primary-hover);
+}
+
+.focus-within\\\\:ring-offset-primary-idle:focus-within {
+  --tw-ring-offset-color: var(--primary-idle);
+}
+
+.focus-within\\\\:ring-offset-primary-pressed:focus-within {
+  --tw-ring-offset-color: var(--primary-pressed);
+}
+
+.focus-within\\\\:ring-offset-process-operations:focus-within {
+  --tw-ring-offset-color: var(--process-operations);
+}
+
+.focus-within\\\\:ring-offset-purple:focus-within {
+  --tw-ring-offset-color: var(--purple);
+}
+
+.focus-within\\\\:ring-offset-registry-operations:focus-within {
+  --tw-ring-offset-color: var(--registry-operations);
+}
+
+.focus-within\\\\:ring-offset-selected:focus-within {
+  --tw-ring-offset-color: var(--selected);
+}
+
+.focus-within\\\\:ring-offset-surface-2xl:focus-within {
+  --tw-ring-offset-color: var(--surface-2xl);
+}
+
+.focus-within\\\\:ring-offset-surface-base:focus-within {
+  --tw-ring-offset-color: var(--surface-base);
+}
+
+.focus-within\\\\:ring-offset-surface-inner:focus-within {
+  --tw-ring-offset-color: var(--surface-inner);
+}
+
+.focus-within\\\\:ring-offset-surface-lg:focus-within {
+  --tw-ring-offset-color: var(--surface-lg);
+}
+
+.focus-within\\\\:ring-offset-surface-md:focus-within {
+  --tw-ring-offset-color: var(--surface-md);
+}
+
+.focus-within\\\\:ring-offset-surface-xl:focus-within {
+  --tw-ring-offset-color: var(--surface-xl);
+}
+
+.focus-within\\\\:ring-offset-text-and-icons:focus-within {
+  --tw-ring-offset-color: var(--text-and-icons);
+}
+
+.focus-within\\\\:ring-offset-titles-and-attributes:focus-within {
+  --tw-ring-offset-color: var(--titles-and-attributes);
+}
+
+.focus\\\\:ring-offset-current:focus {
+  --tw-ring-offset-color: currentColor;
+}
+
+.focus\\\\:ring-offset-transparent:focus {
+  --tw-ring-offset-color: transparent;
+}
+
+.focus\\\\:ring-offset-falcon:focus {
+  --tw-ring-offset-color: var(--falcon);
+}
+
+.focus\\\\:ring-offset-basement:focus {
+  --tw-ring-offset-color: var(--basement);
+}
+
+.focus\\\\:ring-offset-blue:focus {
+  --tw-ring-offset-color: var(--blue);
+}
+
+.focus\\\\:ring-offset-body-and-labels:focus {
+  --tw-ring-offset-color: var(--body-and-labels);
+}
+
+.focus\\\\:ring-offset-brand:focus {
+  --tw-ring-offset-color: var(--brand);
+}
+
+.focus\\\\:ring-offset-code-base-64:focus {
+  --tw-ring-offset-color: var(--code-base-64);
+}
+
+.focus\\\\:ring-offset-code-bg:focus {
+  --tw-ring-offset-color: var(--code-bg);
+}
+
+.focus\\\\:ring-offset-code-outline:focus {
+  --tw-ring-offset-color: var(--code-outline);
+}
+
+.focus\\\\:ring-offset-code-text:focus {
+  --tw-ring-offset-color: var(--code-text);
+}
+
+.focus\\\\:ring-offset-critical:focus {
+  --tw-ring-offset-color: var(--critical);
+}
+
+.focus\\\\:ring-offset-destructive-hover:focus {
+  --tw-ring-offset-color: var(--destructive-hover);
+}
+
+.focus\\\\:ring-offset-destructive-idle:focus {
+  --tw-ring-offset-color: var(--destructive-idle);
+}
+
+.focus\\\\:ring-offset-destructive-pressed:focus {
+  --tw-ring-offset-color: var(--destructive-pressed);
+}
+
+.focus\\\\:ring-offset-disabled:focus {
+  --tw-ring-offset-color: var(--disabled);
+}
+
+.focus\\\\:ring-offset-disc-operations:focus {
+  --tw-ring-offset-color: var(--disc-operations);
+}
+
+.focus\\\\:ring-offset-dns-requests:focus {
+  --tw-ring-offset-color: var(--dns-requests);
+}
+
+.focus\\\\:ring-offset-focus:focus {
+  --tw-ring-offset-color: var(--focus);
+}
+
+.focus\\\\:ring-offset-graph-1:focus {
+  --tw-ring-offset-color: var(--graph-1);
+}
+
+.focus\\\\:ring-offset-graph-10:focus {
+  --tw-ring-offset-color: var(--graph-10);
+}
+
+.focus\\\\:ring-offset-graph-11:focus {
+  --tw-ring-offset-color: var(--graph-11);
+}
+
+.focus\\\\:ring-offset-graph-2:focus {
+  --tw-ring-offset-color: var(--graph-2);
+}
+
+.focus\\\\:ring-offset-graph-3:focus {
+  --tw-ring-offset-color: var(--graph-3);
+}
+
+.focus\\\\:ring-offset-graph-4:focus {
+  --tw-ring-offset-color: var(--graph-4);
+}
+
+.focus\\\\:ring-offset-graph-5:focus {
+  --tw-ring-offset-color: var(--graph-5);
+}
+
+.focus\\\\:ring-offset-graph-6:focus {
+  --tw-ring-offset-color: var(--graph-6);
+}
+
+.focus\\\\:ring-offset-graph-7:focus {
+  --tw-ring-offset-color: var(--graph-7);
+}
+
+.focus\\\\:ring-offset-graph-8:focus {
+  --tw-ring-offset-color: var(--graph-8);
+}
+
+.focus\\\\:ring-offset-graph-9:focus {
+  --tw-ring-offset-color: var(--graph-9);
+}
+
+.focus\\\\:ring-offset-graph-disabled:focus {
+  --tw-ring-offset-color: var(--graph-disabled);
+}
+
+.focus\\\\:ring-offset-ground-floor:focus {
+  --tw-ring-offset-color: var(--ground-floor);
+}
+
+.focus\\\\:ring-offset-high:focus {
+  --tw-ring-offset-color: var(--high);
+}
+
+.focus\\\\:ring-offset-informational:focus {
+  --tw-ring-offset-color: var(--informational);
+}
+
+.focus\\\\:ring-offset-lines-dark:focus {
+  --tw-ring-offset-color: var(--lines-dark);
+}
+
+.focus\\\\:ring-offset-lines-light:focus {
+  --tw-ring-offset-color: var(--lines-light);
+}
+
+.focus\\\\:ring-offset-low:focus {
+  --tw-ring-offset-color: var(--low);
+}
+
+.focus\\\\:ring-offset-medium:focus {
+  --tw-ring-offset-color: var(--medium);
+}
+
+.focus\\\\:ring-offset-mezzanine:focus {
+  --tw-ring-offset-color: var(--mezzanine);
+}
+
+.focus\\\\:ring-offset-nav-text-and-icons:focus {
+  --tw-ring-offset-color: var(--nav-text-and-icons);
+}
+
+.focus\\\\:ring-offset-nav-text-secondary:focus {
+  --tw-ring-offset-color: var(--nav-text-secondary);
+}
+
+.focus\\\\:ring-offset-network-operations:focus {
+  --tw-ring-offset-color: var(--network-operations);
+}
+
+.focus\\\\:ring-offset-normal-hover:focus {
+  --tw-ring-offset-color: var(--normal-hover);
+}
+
+.focus\\\\:ring-offset-normal-idle:focus {
+  --tw-ring-offset-color: var(--normal-idle);
+}
+
+.focus\\\\:ring-offset-normal-pressed:focus {
+  --tw-ring-offset-color: var(--normal-pressed);
+}
+
+.focus\\\\:ring-offset-overlay-0\\\\.5:focus {
+  --tw-ring-offset-color: var(--overlay-0\\\\.5);
+}
+
+.focus\\\\:ring-offset-overlay-1:focus {
+  --tw-ring-offset-color: var(--overlay-1);
+}
+
+.focus\\\\:ring-offset-overlay-2:focus {
+  --tw-ring-offset-color: var(--overlay-2);
+}
+
+.focus\\\\:ring-offset-positive:focus {
+  --tw-ring-offset-color: var(--positive);
+}
+
+.focus\\\\:ring-offset-primary-hover:focus {
+  --tw-ring-offset-color: var(--primary-hover);
+}
+
+.focus\\\\:ring-offset-primary-idle:focus {
+  --tw-ring-offset-color: var(--primary-idle);
+}
+
+.focus\\\\:ring-offset-primary-pressed:focus {
+  --tw-ring-offset-color: var(--primary-pressed);
+}
+
+.focus\\\\:ring-offset-process-operations:focus {
+  --tw-ring-offset-color: var(--process-operations);
+}
+
+.focus\\\\:ring-offset-purple:focus {
+  --tw-ring-offset-color: var(--purple);
+}
+
+.focus\\\\:ring-offset-registry-operations:focus {
+  --tw-ring-offset-color: var(--registry-operations);
+}
+
+.focus\\\\:ring-offset-selected:focus {
+  --tw-ring-offset-color: var(--selected);
+}
+
+.focus\\\\:ring-offset-surface-2xl:focus {
+  --tw-ring-offset-color: var(--surface-2xl);
+}
+
+.focus\\\\:ring-offset-surface-base:focus {
+  --tw-ring-offset-color: var(--surface-base);
+}
+
+.focus\\\\:ring-offset-surface-inner:focus {
+  --tw-ring-offset-color: var(--surface-inner);
+}
+
+.focus\\\\:ring-offset-surface-lg:focus {
+  --tw-ring-offset-color: var(--surface-lg);
+}
+
+.focus\\\\:ring-offset-surface-md:focus {
+  --tw-ring-offset-color: var(--surface-md);
+}
+
+.focus\\\\:ring-offset-surface-xl:focus {
+  --tw-ring-offset-color: var(--surface-xl);
+}
+
+.focus\\\\:ring-offset-text-and-icons:focus {
+  --tw-ring-offset-color: var(--text-and-icons);
+}
+
+.focus\\\\:ring-offset-titles-and-attributes:focus {
+  --tw-ring-offset-color: var(--titles-and-attributes);
+}
+
+.filter {
+  --tw-blur: var(--tw-empty,/*!*/ /*!*/);
+  --tw-brightness: var(--tw-empty,/*!*/ /*!*/);
+  --tw-contrast: var(--tw-empty,/*!*/ /*!*/);
+  --tw-grayscale: var(--tw-empty,/*!*/ /*!*/);
+  --tw-hue-rotate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-invert: var(--tw-empty,/*!*/ /*!*/);
+  --tw-saturate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-sepia: var(--tw-empty,/*!*/ /*!*/);
+  --tw-drop-shadow: var(--tw-empty,/*!*/ /*!*/);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.filter-none {
+  filter: none;
+}
+
+.blur-0 {
+  --tw-blur: blur(0);
+}
+
+.blur-none {
+  --tw-blur: blur(0);
+}
+
+.blur-sm {
+  --tw-blur: blur(4px);
+}
+
+.blur {
+  --tw-blur: blur(8px);
+}
+
+.blur-md {
+  --tw-blur: blur(12px);
+}
+
+.blur-lg {
+  --tw-blur: blur(16px);
+}
+
+.blur-xl {
+  --tw-blur: blur(24px);
+}
+
+.blur-2xl {
+  --tw-blur: blur(40px);
+}
+
+.blur-3xl {
+  --tw-blur: blur(64px);
+}
+
+.brightness-0 {
+  --tw-brightness: brightness(0);
+}
+
+.brightness-50 {
+  --tw-brightness: brightness(.5);
+}
+
+.brightness-75 {
+  --tw-brightness: brightness(.75);
+}
+
+.brightness-90 {
+  --tw-brightness: brightness(.9);
+}
+
+.brightness-95 {
+  --tw-brightness: brightness(.95);
+}
+
+.brightness-100 {
+  --tw-brightness: brightness(1);
+}
+
+.brightness-105 {
+  --tw-brightness: brightness(1.05);
+}
+
+.brightness-110 {
+  --tw-brightness: brightness(1.1);
+}
+
+.brightness-125 {
+  --tw-brightness: brightness(1.25);
+}
+
+.brightness-150 {
+  --tw-brightness: brightness(1.5);
+}
+
+.brightness-200 {
+  --tw-brightness: brightness(2);
+}
+
+.contrast-0 {
+  --tw-contrast: contrast(0);
+}
+
+.contrast-50 {
+  --tw-contrast: contrast(.5);
+}
+
+.contrast-75 {
+  --tw-contrast: contrast(.75);
+}
+
+.contrast-100 {
+  --tw-contrast: contrast(1);
+}
+
+.contrast-125 {
+  --tw-contrast: contrast(1.25);
+}
+
+.contrast-150 {
+  --tw-contrast: contrast(1.5);
+}
+
+.contrast-200 {
+  --tw-contrast: contrast(2);
+}
+
+.drop-shadow-sm {
+  --tw-drop-shadow: drop-shadow(0 1px 1px rgba(0,0,0,0.05));
+}
+
+.drop-shadow {
+  --tw-drop-shadow: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.06));
+}
+
+.drop-shadow-md {
+  --tw-drop-shadow: drop-shadow(0 4px 3px rgba(0, 0, 0, 0.07)) drop-shadow(0 2px 2px rgba(0, 0, 0, 0.06));
+}
+
+.drop-shadow-lg {
+  --tw-drop-shadow: drop-shadow(0 10px 8px rgba(0, 0, 0, 0.04)) drop-shadow(0 4px 3px rgba(0, 0, 0, 0.1));
+}
+
+.drop-shadow-xl {
+  --tw-drop-shadow: drop-shadow(0 20px 13px rgba(0, 0, 0, 0.03)) drop-shadow(0 8px 5px rgba(0, 0, 0, 0.08));
+}
+
+.drop-shadow-2xl {
+  --tw-drop-shadow: drop-shadow(0 25px 25px rgba(0, 0, 0, 0.15));
+}
+
+.drop-shadow-none {
+  --tw-drop-shadow: drop-shadow(0 0 #0000);
+}
+
+.grayscale-0 {
+  --tw-grayscale: grayscale(0);
+}
+
+.grayscale {
+  --tw-grayscale: grayscale(100%);
+}
+
+.hue-rotate-0 {
+  --tw-hue-rotate: hue-rotate(0deg);
+}
+
+.hue-rotate-15 {
+  --tw-hue-rotate: hue-rotate(15deg);
+}
+
+.hue-rotate-30 {
+  --tw-hue-rotate: hue-rotate(30deg);
+}
+
+.hue-rotate-60 {
+  --tw-hue-rotate: hue-rotate(60deg);
+}
+
+.hue-rotate-90 {
+  --tw-hue-rotate: hue-rotate(90deg);
+}
+
+.hue-rotate-180 {
+  --tw-hue-rotate: hue-rotate(180deg);
+}
+
+.-hue-rotate-180 {
+  --tw-hue-rotate: hue-rotate(-180deg);
+}
+
+.-hue-rotate-90 {
+  --tw-hue-rotate: hue-rotate(-90deg);
+}
+
+.-hue-rotate-60 {
+  --tw-hue-rotate: hue-rotate(-60deg);
+}
+
+.-hue-rotate-30 {
+  --tw-hue-rotate: hue-rotate(-30deg);
+}
+
+.-hue-rotate-15 {
+  --tw-hue-rotate: hue-rotate(-15deg);
+}
+
+.invert-0 {
+  --tw-invert: invert(0);
+}
+
+.invert {
+  --tw-invert: invert(100%);
+}
+
+.saturate-0 {
+  --tw-saturate: saturate(0);
+}
+
+.saturate-50 {
+  --tw-saturate: saturate(.5);
+}
+
+.saturate-100 {
+  --tw-saturate: saturate(1);
+}
+
+.saturate-150 {
+  --tw-saturate: saturate(1.5);
+}
+
+.saturate-200 {
+  --tw-saturate: saturate(2);
+}
+
+.sepia-0 {
+  --tw-sepia: sepia(0);
+}
+
+.sepia {
+  --tw-sepia: sepia(100%);
+}
+
+.backdrop-filter {
+  --tw-backdrop-blur: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-brightness: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-contrast: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-grayscale: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-hue-rotate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-invert: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-opacity: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-saturate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-backdrop-sepia: var(--tw-empty,/*!*/ /*!*/);
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+          backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
+.backdrop-filter-none {
+  -webkit-backdrop-filter: none;
+          backdrop-filter: none;
+}
+
+.backdrop-blur-0 {
+  --tw-backdrop-blur: blur(0);
+}
+
+.backdrop-blur-none {
+  --tw-backdrop-blur: blur(0);
+}
+
+.backdrop-blur-sm {
+  --tw-backdrop-blur: blur(4px);
+}
+
+.backdrop-blur {
+  --tw-backdrop-blur: blur(8px);
+}
+
+.backdrop-blur-md {
+  --tw-backdrop-blur: blur(12px);
+}
+
+.backdrop-blur-lg {
+  --tw-backdrop-blur: blur(16px);
+}
+
+.backdrop-blur-xl {
+  --tw-backdrop-blur: blur(24px);
+}
+
+.backdrop-blur-2xl {
+  --tw-backdrop-blur: blur(40px);
+}
+
+.backdrop-blur-3xl {
+  --tw-backdrop-blur: blur(64px);
+}
+
+.backdrop-brightness-0 {
+  --tw-backdrop-brightness: brightness(0);
+}
+
+.backdrop-brightness-50 {
+  --tw-backdrop-brightness: brightness(.5);
+}
+
+.backdrop-brightness-75 {
+  --tw-backdrop-brightness: brightness(.75);
+}
+
+.backdrop-brightness-90 {
+  --tw-backdrop-brightness: brightness(.9);
+}
+
+.backdrop-brightness-95 {
+  --tw-backdrop-brightness: brightness(.95);
+}
+
+.backdrop-brightness-100 {
+  --tw-backdrop-brightness: brightness(1);
+}
+
+.backdrop-brightness-105 {
+  --tw-backdrop-brightness: brightness(1.05);
+}
+
+.backdrop-brightness-110 {
+  --tw-backdrop-brightness: brightness(1.1);
+}
+
+.backdrop-brightness-125 {
+  --tw-backdrop-brightness: brightness(1.25);
+}
+
+.backdrop-brightness-150 {
+  --tw-backdrop-brightness: brightness(1.5);
+}
+
+.backdrop-brightness-200 {
+  --tw-backdrop-brightness: brightness(2);
+}
+
+.backdrop-contrast-0 {
+  --tw-backdrop-contrast: contrast(0);
+}
+
+.backdrop-contrast-50 {
+  --tw-backdrop-contrast: contrast(.5);
+}
+
+.backdrop-contrast-75 {
+  --tw-backdrop-contrast: contrast(.75);
+}
+
+.backdrop-contrast-100 {
+  --tw-backdrop-contrast: contrast(1);
+}
+
+.backdrop-contrast-125 {
+  --tw-backdrop-contrast: contrast(1.25);
+}
+
+.backdrop-contrast-150 {
+  --tw-backdrop-contrast: contrast(1.5);
+}
+
+.backdrop-contrast-200 {
+  --tw-backdrop-contrast: contrast(2);
+}
+
+.backdrop-grayscale-0 {
+  --tw-backdrop-grayscale: grayscale(0);
+}
+
+.backdrop-grayscale {
+  --tw-backdrop-grayscale: grayscale(100%);
+}
+
+.backdrop-hue-rotate-0 {
+  --tw-backdrop-hue-rotate: hue-rotate(0deg);
+}
+
+.backdrop-hue-rotate-15 {
+  --tw-backdrop-hue-rotate: hue-rotate(15deg);
+}
+
+.backdrop-hue-rotate-30 {
+  --tw-backdrop-hue-rotate: hue-rotate(30deg);
+}
+
+.backdrop-hue-rotate-60 {
+  --tw-backdrop-hue-rotate: hue-rotate(60deg);
+}
+
+.backdrop-hue-rotate-90 {
+  --tw-backdrop-hue-rotate: hue-rotate(90deg);
+}
+
+.backdrop-hue-rotate-180 {
+  --tw-backdrop-hue-rotate: hue-rotate(180deg);
+}
+
+.-backdrop-hue-rotate-180 {
+  --tw-backdrop-hue-rotate: hue-rotate(-180deg);
+}
+
+.-backdrop-hue-rotate-90 {
+  --tw-backdrop-hue-rotate: hue-rotate(-90deg);
+}
+
+.-backdrop-hue-rotate-60 {
+  --tw-backdrop-hue-rotate: hue-rotate(-60deg);
+}
+
+.-backdrop-hue-rotate-30 {
+  --tw-backdrop-hue-rotate: hue-rotate(-30deg);
+}
+
+.-backdrop-hue-rotate-15 {
+  --tw-backdrop-hue-rotate: hue-rotate(-15deg);
+}
+
+.backdrop-invert-0 {
+  --tw-backdrop-invert: invert(0);
+}
+
+.backdrop-invert {
+  --tw-backdrop-invert: invert(100%);
+}
+
+.backdrop-opacity-0 {
+  --tw-backdrop-opacity: opacity(0);
+}
+
+.backdrop-opacity-5 {
+  --tw-backdrop-opacity: opacity(0.05);
+}
+
+.backdrop-opacity-10 {
+  --tw-backdrop-opacity: opacity(0.1);
+}
+
+.backdrop-opacity-20 {
+  --tw-backdrop-opacity: opacity(0.2);
+}
+
+.backdrop-opacity-25 {
+  --tw-backdrop-opacity: opacity(0.25);
+}
+
+.backdrop-opacity-30 {
+  --tw-backdrop-opacity: opacity(0.3);
+}
+
+.backdrop-opacity-40 {
+  --tw-backdrop-opacity: opacity(0.4);
+}
+
+.backdrop-opacity-50 {
+  --tw-backdrop-opacity: opacity(0.5);
+}
+
+.backdrop-opacity-60 {
+  --tw-backdrop-opacity: opacity(0.6);
+}
+
+.backdrop-opacity-70 {
+  --tw-backdrop-opacity: opacity(0.7);
+}
+
+.backdrop-opacity-75 {
+  --tw-backdrop-opacity: opacity(0.75);
+}
+
+.backdrop-opacity-80 {
+  --tw-backdrop-opacity: opacity(0.8);
+}
+
+.backdrop-opacity-90 {
+  --tw-backdrop-opacity: opacity(0.9);
+}
+
+.backdrop-opacity-95 {
+  --tw-backdrop-opacity: opacity(0.95);
+}
+
+.backdrop-opacity-100 {
+  --tw-backdrop-opacity: opacity(1);
+}
+
+.backdrop-saturate-0 {
+  --tw-backdrop-saturate: saturate(0);
+}
+
+.backdrop-saturate-50 {
+  --tw-backdrop-saturate: saturate(.5);
+}
+
+.backdrop-saturate-100 {
+  --tw-backdrop-saturate: saturate(1);
+}
+
+.backdrop-saturate-150 {
+  --tw-backdrop-saturate: saturate(1.5);
+}
+
+.backdrop-saturate-200 {
+  --tw-backdrop-saturate: saturate(2);
+}
+
+.backdrop-sepia-0 {
+  --tw-backdrop-sepia: sepia(0);
+}
+
+.backdrop-sepia {
+  --tw-backdrop-sepia: sepia(100%);
+}
+
+.transition-none {
+  transition-property: none;
+}
+
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition {
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-colors {
+  transition-property: background-color, border-color, color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-opacity {
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-shadow {
+  transition-property: box-shadow;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-width {
+  transition-property: width;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-none:active {
+  transition-property: none;
+}
+
+.active\\\\:transition-all:active {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition:active {
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-colors:active {
+  transition-property: background-color, border-color, color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-opacity:active {
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-shadow:active {
+  transition-property: box-shadow;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-transform:active {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.active\\\\:transition-width:active {
+  transition-property: width;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.delay-75 {
+  transition-delay: 75ms;
+}
+
+.delay-100 {
+  transition-delay: 100ms;
+}
+
+.delay-150 {
+  transition-delay: 150ms;
+}
+
+.delay-200 {
+  transition-delay: 200ms;
+}
+
+.delay-300 {
+  transition-delay: 300ms;
+}
+
+.delay-500 {
+  transition-delay: 500ms;
+}
+
+.delay-700 {
+  transition-delay: 700ms;
+}
+
+.delay-1000 {
+  transition-delay: 1000ms;
+}
+
+.duration-75 {
+  transition-duration: 75ms;
+}
+
+.duration-100 {
+  transition-duration: 100ms;
+}
+
+.duration-150 {
+  transition-duration: 150ms;
+}
+
+.duration-200 {
+  transition-duration: 200ms;
+}
+
+.duration-300 {
+  transition-duration: 300ms;
+}
+
+.duration-500 {
+  transition-duration: 500ms;
+}
+
+.duration-700 {
+  transition-duration: 700ms;
+}
+
+.duration-1000 {
+  transition-duration: 1000ms;
+}
+
+.ease-linear {
+  transition-timing-function: linear;
+}
+
+.ease-in {
+  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+}
+
+.ease-out {
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+
+.ease-in-out {
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.content-none {
+  content: none;
+}
+
+.clamp-1 {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-4 {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-5 {
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-6 {
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-7 {
+  display: -webkit-box;
+  -webkit-line-clamp: 7;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-8 {
+  display: -webkit-box;
+  -webkit-line-clamp: 8;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-9 {
+  display: -webkit-box;
+  -webkit-line-clamp: 9;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-10 {
+  display: -webkit-box;
+  -webkit-line-clamp: 10;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+@media print {
+  .print\\\\:block {
+    display: block;
+  }
+
+  .print\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .print\\\\:inline {
+    display: inline;
+  }
+
+  .print\\\\:flex {
+    display: flex;
+  }
+
+  .print\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .print\\\\:table {
+    display: table;
+  }
+
+  .print\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .print\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .print\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .print\\\\:table-column {
+    display: table-column;
+  }
+
+  .print\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .print\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .print\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .print\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .print\\\\:table-row {
+    display: table-row;
+  }
+
+  .print\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .print\\\\:grid {
+    display: grid;
+  }
+
+  .print\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .print\\\\:contents {
+    display: contents;
+  }
+
+  .print\\\\:list-item {
+    display: list-item;
+  }
+
+  .print\\\\:hidden {
+    display: none;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:block {
+    display: block;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline {
+    display: inline;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:flex {
+    display: flex;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table {
+    display: table;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-column {
+    display: table-column;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:table-row {
+    display: table-row;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:grid {
+    display: grid;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:contents {
+    display: contents;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:list-item {
+    display: list-item;
+  }
+
+  .group:hover .print\\\\:group-hover\\\\:hidden {
+    display: none;
+  }
+
+  .print\\\\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-8 {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-9 {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-10 {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-11 {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+
+  .print\\\\:grid-cols-none {
+    grid-template-columns: none;
+  }
+
+  .print\\\\:grid-cols-centered-2\\\\/3 {
+    grid-template-columns: 2fr 8fr 2fr;
+  }
+
+  .print\\\\:grid-cols-auto-2 {
+    grid-template-columns: auto auto;
+  }
+
+  .print\\\\:grid-cols-max-content-4 {
+    grid-template-columns: repeat(4, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(4, minmax(max-content, 1fr));
+  }
+
+  .print\\\\:grid-cols-max-content-6 {
+    grid-template-columns: repeat(6, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(6, minmax(max-content, 1fr));
+  }
+
+  .print\\\\:bg-origin-border {
+    background-origin: border-box;
+  }
+
+  .print\\\\:bg-origin-padding {
+    background-origin: padding-box;
+  }
+
+  .print\\\\:bg-origin-content {
+    background-origin: content-box;
+  }
+
+  .print\\\\:backdrop-opacity-0 {
+    --tw-backdrop-opacity: opacity(0);
+  }
+
+  .print\\\\:backdrop-opacity-5 {
+    --tw-backdrop-opacity: opacity(0.05);
+  }
+
+  .print\\\\:backdrop-opacity-10 {
+    --tw-backdrop-opacity: opacity(0.1);
+  }
+
+  .print\\\\:backdrop-opacity-20 {
+    --tw-backdrop-opacity: opacity(0.2);
+  }
+
+  .print\\\\:backdrop-opacity-25 {
+    --tw-backdrop-opacity: opacity(0.25);
+  }
+
+  .print\\\\:backdrop-opacity-30 {
+    --tw-backdrop-opacity: opacity(0.3);
+  }
+
+  .print\\\\:backdrop-opacity-40 {
+    --tw-backdrop-opacity: opacity(0.4);
+  }
+
+  .print\\\\:backdrop-opacity-50 {
+    --tw-backdrop-opacity: opacity(0.5);
+  }
+
+  .print\\\\:backdrop-opacity-60 {
+    --tw-backdrop-opacity: opacity(0.6);
+  }
+
+  .print\\\\:backdrop-opacity-70 {
+    --tw-backdrop-opacity: opacity(0.7);
+  }
+
+  .print\\\\:backdrop-opacity-75 {
+    --tw-backdrop-opacity: opacity(0.75);
+  }
+
+  .print\\\\:backdrop-opacity-80 {
+    --tw-backdrop-opacity: opacity(0.8);
+  }
+
+  .print\\\\:backdrop-opacity-90 {
+    --tw-backdrop-opacity: opacity(0.9);
+  }
+
+  .print\\\\:backdrop-opacity-95 {
+    --tw-backdrop-opacity: opacity(0.95);
+  }
+
+  .print\\\\:backdrop-opacity-100 {
+    --tw-backdrop-opacity: opacity(1);
+  }
+}
+
+@media (min-width: 1120px) {
+  .lg\\\\:block {
+    display: block;
+  }
+
+  .lg\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .lg\\\\:inline {
+    display: inline;
+  }
+
+  .lg\\\\:flex {
+    display: flex;
+  }
+
+  .lg\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .lg\\\\:table {
+    display: table;
+  }
+
+  .lg\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .lg\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .lg\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .lg\\\\:table-column {
+    display: table-column;
+  }
+
+  .lg\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .lg\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .lg\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .lg\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .lg\\\\:table-row {
+    display: table-row;
+  }
+
+  .lg\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .lg\\\\:grid {
+    display: grid;
+  }
+
+  .lg\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .lg\\\\:contents {
+    display: contents;
+  }
+
+  .lg\\\\:list-item {
+    display: list-item;
+  }
+
+  .lg\\\\:hidden {
+    display: none;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:block {
+    display: block;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline {
+    display: inline;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:flex {
+    display: flex;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table {
+    display: table;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-column {
+    display: table-column;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:table-row {
+    display: table-row;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:grid {
+    display: grid;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:contents {
+    display: contents;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:list-item {
+    display: list-item;
+  }
+
+  .group:hover .lg\\\\:group-hover\\\\:hidden {
+    display: none;
+  }
+
+  .lg\\\\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-8 {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-9 {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-10 {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-11 {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+
+  .lg\\\\:grid-cols-none {
+    grid-template-columns: none;
+  }
+
+  .lg\\\\:grid-cols-centered-2\\\\/3 {
+    grid-template-columns: 2fr 8fr 2fr;
+  }
+
+  .lg\\\\:grid-cols-auto-2 {
+    grid-template-columns: auto auto;
+  }
+
+  .lg\\\\:grid-cols-max-content-4 {
+    grid-template-columns: repeat(4, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(4, minmax(max-content, 1fr));
+  }
+
+  .lg\\\\:grid-cols-max-content-6 {
+    grid-template-columns: repeat(6, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(6, minmax(max-content, 1fr));
+  }
+
+  .lg\\\\:bg-origin-border {
+    background-origin: border-box;
+  }
+
+  .lg\\\\:bg-origin-padding {
+    background-origin: padding-box;
+  }
+
+  .lg\\\\:bg-origin-content {
+    background-origin: content-box;
+  }
+
+  .lg\\\\:backdrop-opacity-0 {
+    --tw-backdrop-opacity: opacity(0);
+  }
+
+  .lg\\\\:backdrop-opacity-5 {
+    --tw-backdrop-opacity: opacity(0.05);
+  }
+
+  .lg\\\\:backdrop-opacity-10 {
+    --tw-backdrop-opacity: opacity(0.1);
+  }
+
+  .lg\\\\:backdrop-opacity-20 {
+    --tw-backdrop-opacity: opacity(0.2);
+  }
+
+  .lg\\\\:backdrop-opacity-25 {
+    --tw-backdrop-opacity: opacity(0.25);
+  }
+
+  .lg\\\\:backdrop-opacity-30 {
+    --tw-backdrop-opacity: opacity(0.3);
+  }
+
+  .lg\\\\:backdrop-opacity-40 {
+    --tw-backdrop-opacity: opacity(0.4);
+  }
+
+  .lg\\\\:backdrop-opacity-50 {
+    --tw-backdrop-opacity: opacity(0.5);
+  }
+
+  .lg\\\\:backdrop-opacity-60 {
+    --tw-backdrop-opacity: opacity(0.6);
+  }
+
+  .lg\\\\:backdrop-opacity-70 {
+    --tw-backdrop-opacity: opacity(0.7);
+  }
+
+  .lg\\\\:backdrop-opacity-75 {
+    --tw-backdrop-opacity: opacity(0.75);
+  }
+
+  .lg\\\\:backdrop-opacity-80 {
+    --tw-backdrop-opacity: opacity(0.8);
+  }
+
+  .lg\\\\:backdrop-opacity-90 {
+    --tw-backdrop-opacity: opacity(0.9);
+  }
+
+  .lg\\\\:backdrop-opacity-95 {
+    --tw-backdrop-opacity: opacity(0.95);
+  }
+
+  .lg\\\\:backdrop-opacity-100 {
+    --tw-backdrop-opacity: opacity(1);
+  }
+}
+
+@media (min-width: 1536px) {
+  .\\\\32xl\\\\:block {
+    display: block;
+  }
+
+  .\\\\32xl\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .\\\\32xl\\\\:inline {
+    display: inline;
+  }
+
+  .\\\\32xl\\\\:flex {
+    display: flex;
+  }
+
+  .\\\\32xl\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .\\\\32xl\\\\:table {
+    display: table;
+  }
+
+  .\\\\32xl\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .\\\\32xl\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .\\\\32xl\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .\\\\32xl\\\\:table-column {
+    display: table-column;
+  }
+
+  .\\\\32xl\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .\\\\32xl\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .\\\\32xl\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .\\\\32xl\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .\\\\32xl\\\\:table-row {
+    display: table-row;
+  }
+
+  .\\\\32xl\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .\\\\32xl\\\\:grid {
+    display: grid;
+  }
+
+  .\\\\32xl\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .\\\\32xl\\\\:contents {
+    display: contents;
+  }
+
+  .\\\\32xl\\\\:list-item {
+    display: list-item;
+  }
+
+  .\\\\32xl\\\\:hidden {
+    display: none;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:block {
+    display: block;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline-block {
+    display: inline-block;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline {
+    display: inline;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:flex {
+    display: flex;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline-flex {
+    display: inline-flex;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table {
+    display: table;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline-table {
+    display: inline-table;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-caption {
+    display: table-caption;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-cell {
+    display: table-cell;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-column {
+    display: table-column;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-column-group {
+    display: table-column-group;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-footer-group {
+    display: table-footer-group;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-header-group {
+    display: table-header-group;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-row-group {
+    display: table-row-group;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:table-row {
+    display: table-row;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:flow-root {
+    display: flow-root;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:grid {
+    display: grid;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:inline-grid {
+    display: inline-grid;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:contents {
+    display: contents;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:list-item {
+    display: list-item;
+  }
+
+  .group:hover .\\\\32xl\\\\:group-hover\\\\:hidden {
+    display: none;
+  }
+
+  .\\\\32xl\\\\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-8 {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-9 {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-10 {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-11 {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-none {
+    grid-template-columns: none;
+  }
+
+  .\\\\32xl\\\\:grid-cols-centered-2\\\\/3 {
+    grid-template-columns: 2fr 8fr 2fr;
+  }
+
+  .\\\\32xl\\\\:grid-cols-auto-2 {
+    grid-template-columns: auto auto;
+  }
+
+  .\\\\32xl\\\\:grid-cols-max-content-4 {
+    grid-template-columns: repeat(4, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(4, minmax(max-content, 1fr));
+  }
+
+  .\\\\32xl\\\\:grid-cols-max-content-6 {
+    grid-template-columns: repeat(6, minmax(-webkit-max-content, 1fr));
+    grid-template-columns: repeat(6, minmax(max-content, 1fr));
+  }
+
+  .\\\\32xl\\\\:bg-origin-border {
+    background-origin: border-box;
+  }
+
+  .\\\\32xl\\\\:bg-origin-padding {
+    background-origin: padding-box;
+  }
+
+  .\\\\32xl\\\\:bg-origin-content {
+    background-origin: content-box;
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-0 {
+    --tw-backdrop-opacity: opacity(0);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-5 {
+    --tw-backdrop-opacity: opacity(0.05);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-10 {
+    --tw-backdrop-opacity: opacity(0.1);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-20 {
+    --tw-backdrop-opacity: opacity(0.2);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-25 {
+    --tw-backdrop-opacity: opacity(0.25);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-30 {
+    --tw-backdrop-opacity: opacity(0.3);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-40 {
+    --tw-backdrop-opacity: opacity(0.4);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-50 {
+    --tw-backdrop-opacity: opacity(0.5);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-60 {
+    --tw-backdrop-opacity: opacity(0.6);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-70 {
+    --tw-backdrop-opacity: opacity(0.7);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-75 {
+    --tw-backdrop-opacity: opacity(0.75);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-80 {
+    --tw-backdrop-opacity: opacity(0.8);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-90 {
+    --tw-backdrop-opacity: opacity(0.9);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-95 {
+    --tw-backdrop-opacity: opacity(0.95);
+  }
+
+  .\\\\32xl\\\\:backdrop-opacity-100 {
+    --tw-backdrop-opacity: opacity(1);
+  }
+}
+"
+`;

--- a/tests/cdn.test.ts
+++ b/tests/cdn.test.ts
@@ -1,0 +1,18 @@
+import fse from 'fs-extra';
+import path from 'path';
+import { describe, expect, test } from 'vitest';
+
+const root = process.cwd();
+const cdn = path.join(root, 'toucan.css');
+
+describe('CDN', () => {
+  test('file exists', async () => {
+    expect(await fse.pathExists(cdn)).toBe(true);
+  });
+
+  test('does not change unexpectedly', async () => {
+    let buffer = await fse.readFile(cdn);
+
+    expect(buffer.toString()).toMatchSnapshot();
+  });
+});

--- a/tests/css-import.test.ts
+++ b/tests/css-import.test.ts
@@ -1,0 +1,18 @@
+import fse from 'fs-extra';
+import path from 'path';
+import { describe, expect, test } from 'vitest';
+
+const root = process.cwd();
+const cssImport = path.join(root, 'index.css');
+
+describe('CSS @import', () => {
+  test('file exists', async () => {
+    expect(await fse.pathExists(cssImport)).toBe(true);
+  });
+
+  test('does not change unexpectedly', async () => {
+    let buffer = await fse.readFile(cssImport);
+
+    expect(buffer.toString()).toMatchSnapshot();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globalSetup: ['tests/-setup.ts'],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,79 +9,57 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.7":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
   integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
   dependencies:
     "@babel/highlight" "^7.16.7"
 
-"@babel/code-frame@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
-  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
+"@babel/generator@^7.17.10":
+  version "7.17.10"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz#c281fa35b0c349bbe9d02916f4ae08fc85ed7189"
+  integrity sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==
   dependencies:
-    "@babel/highlight" "^7.14.5"
-
-"@babel/generator@^7.15.4":
-  version "7.15.4"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz#85acb159a267ca6324f9793986991ee2022a05b0"
-  integrity sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==
-  dependencies:
-    "@babel/types" "^7.15.4"
+    "@babel/types" "^7.17.10"
+    "@jridgewell/gen-mapping" "^0.1.0"
     jsesc "^2.5.1"
-    source-map "^0.5.0"
 
-"@babel/helper-function-name@^7.15.4":
-  version "7.15.4"
-  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz#845744dafc4381a4a5fb6afa6c3d36f98a787ebc"
-  integrity sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==
+"@babel/helper-environment-visitor@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
+  integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.15.4"
-    "@babel/template" "^7.15.4"
-    "@babel/types" "^7.15.4"
+    "@babel/types" "^7.16.7"
 
-"@babel/helper-get-function-arity@^7.15.4":
-  version "7.15.4"
-  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz#098818934a137fce78b536a3e015864be1e2879b"
-  integrity sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==
+"@babel/helper-function-name@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz#136fcd54bc1da82fcb47565cf16fd8e444b1ff12"
+  integrity sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==
   dependencies:
-    "@babel/types" "^7.15.4"
+    "@babel/template" "^7.16.7"
+    "@babel/types" "^7.17.0"
 
-"@babel/helper-hoist-variables@^7.15.4":
-  version "7.15.4"
-  resolved "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz#09993a3259c0e918f99d104261dfdfc033f178df"
-  integrity sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==
+"@babel/helper-hoist-variables@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
+  integrity sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
   dependencies:
-    "@babel/types" "^7.15.4"
+    "@babel/types" "^7.16.7"
 
-"@babel/helper-split-export-declaration@^7.15.4":
-  version "7.15.4"
-  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz#aecab92dcdbef6a10aa3b62ab204b085f776e257"
-  integrity sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==
+"@babel/helper-split-export-declaration@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b"
+  integrity sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
   dependencies:
-    "@babel/types" "^7.15.4"
+    "@babel/types" "^7.16.7"
 
-"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.16.7":
+"@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
-"@babel/helper-validator-identifier@^7.14.9":
-  version "7.14.9"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
-  integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
-
-"@babel/highlight@^7.10.4":
-  version "7.14.5"
-  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
-  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.14.5"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.14.5", "@babel/highlight@^7.16.7":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
   version "7.17.9"
   resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz#61b2ee7f32ea0454612def4fccdae0de232b73e3"
   integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
@@ -90,42 +68,53 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.15.4", "@babel/parser@^7.7.0":
-  version "7.15.6"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz#043b9aa3c303c0722e5377fef9197f4cf1796549"
-  integrity sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==
+"@babel/parser@^7.16.7", "@babel/parser@^7.17.10", "@babel/parser@^7.7.0":
+  version "7.17.10"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz#873b16db82a8909e0fbd7f115772f4b739f6ce78"
+  integrity sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==
 
-"@babel/template@^7.15.4":
-  version "7.15.4"
-  resolved "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
-  integrity sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
+"@babel/template@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
+  integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
   dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/parser" "^7.15.4"
-    "@babel/types" "^7.15.4"
+    "@babel/code-frame" "^7.16.7"
+    "@babel/parser" "^7.16.7"
+    "@babel/types" "^7.16.7"
 
 "@babel/traverse@^7.7.0":
-  version "7.15.4"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz#ff8510367a144bfbff552d9e18e28f3e2889c22d"
-  integrity sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==
+  version "7.17.10"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz#1ee1a5ac39f4eac844e6cf855b35520e5eb6f8b5"
+  integrity sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==
   dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.15.4"
-    "@babel/helper-function-name" "^7.15.4"
-    "@babel/helper-hoist-variables" "^7.15.4"
-    "@babel/helper-split-export-declaration" "^7.15.4"
-    "@babel/parser" "^7.15.4"
-    "@babel/types" "^7.15.4"
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.10"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.17.9"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.10"
+    "@babel/types" "^7.17.10"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.15.4", "@babel/types@^7.7.0":
-  version "7.15.6"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz#99abdc48218b2881c058dd0a7ab05b99c9be758f"
-  integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
+"@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.17.10", "@babel/types@^7.7.0":
+  version "7.17.10"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz#d35d7b4467e439fcf06d195f8100e0fea7fc82c4"
+  integrity sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.14.9"
+    "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
@@ -161,26 +150,26 @@
     ora "~5.4.1"
 
 "@figma-export/core@^3.3.1":
-  version "3.4.0"
-  resolved "https://registry.npmjs.org/@figma-export/core/-/core-3.4.0.tgz#50426717ab405607096ebb5effb165d6f59c883a"
-  integrity sha512-Y1P0NvQH6vKtZJHoBI4vp5lQyowSYNyIEJXla7ip59ZfVHyg0/fyn/oFhcuPdbyX31qwDkb04CMVxbzHv/45kg==
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/@figma-export/core/-/core-3.5.0.tgz#ae23abf50af0899d0156477ba26f82d924ac5595"
+  integrity sha512-XCvBYwqFnvESyfSWSWoRUERID0HD3CuQQ6924Z+6v+aJtaxznfVbdDRbaOAI+XcinU3DRf+4tSZMFVm45vLOPA==
   dependencies:
-    "@figma-export/types" "^3.4.0"
+    "@figma-export/types" "^3.5.0"
     axios "~0.21.4"
     figma-js "~1.14.0"
     p-limit "^3.1.0"
 
-"@figma-export/types@^3.3.1", "@figma-export/types@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.npmjs.org/@figma-export/types/-/types-3.4.0.tgz#ea60914390d0efab11e1a87c2d87ec828503930b"
-  integrity sha512-GoH/u2Oje5nwAxAWrBD9d/mCpitZJi6xj5BD2XSjMKYfE0eKTJkHoYviqpk36hIRrwUBnBv+1zd+vWqzBDX36g==
+"@figma-export/types@^3.3.1", "@figma-export/types@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/@figma-export/types/-/types-3.5.0.tgz#cc6147ca4e93f7a09a9c1f776d806583b609cca1"
+  integrity sha512-Lxe10lVWbDqt8H0oXiVNn10asxwyQ+Ibf2OVv8SJBBQgWMTP+jx0WB2jjIcLIxo2E+n0Qob/4LecjBWICLBhNQ==
   dependencies:
     figma-js "~1.14.0"
 
 "@gar/promisify@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
-  integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
+  integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -192,9 +181,50 @@
     minimatch "^3.0.4"
 
 "@humanwhocodes/object-schema@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
-  integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@isaacs/string-locale-compare@^1.0.1", "@isaacs/string-locale-compare@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz#291c227e93fd407a96ecd59879a35809120e432b"
+  integrity sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==
+
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
+  integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
+
+"@jridgewell/gen-mapping@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
+  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.0"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.0.7"
+  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz#30cd49820a962aff48c8fffc5cd760151fca61fe"
+  integrity sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==
+
+"@jridgewell/set-array@^1.0.0":
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz#36a6acc93987adcf0ba50c66908bd0b70de8afea"
+  integrity sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.13"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
+  integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
+
+"@jridgewell/trace-mapping@^0.3.7":
+  version "0.3.13"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz#dcfe3e95f224c8fe97a87a5235defec999aa92ea"
+  integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@koa/router@^9.0.1":
   version "9.4.0"
@@ -228,11 +258,12 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@npmcli/arborist@^2.3.0", "@npmcli/arborist@^2.5.0", "@npmcli/arborist@^2.8.3":
-  version "2.8.3"
-  resolved "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.8.3.tgz#5569e7d2038f6893abc81f9c879f497b506e6980"
-  integrity sha512-miFcxbZjmQqeFTeRSLLh+lc/gxIKDO5L4PVCp+dp+kmcwJmYsEJmF7YvHR2yi3jF+fxgvLf3CCFzboPIXAuabg==
+"@npmcli/arborist@^2.3.0", "@npmcli/arborist@^2.5.0", "@npmcli/arborist@^2.9.0":
+  version "2.10.0"
+  resolved "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.10.0.tgz#424c2d73a7ae59c960b0cc7f74fed043e4316c2c"
+  integrity sha512-CLnD+zXG9oijEEzViimz8fbOoFVb7hoypiaf7p6giJhvYtrxLAyY3cZAMPIFQvsG731+02eMDp3LqVBNo7BaZA==
   dependencies:
+    "@isaacs/string-locale-compare" "^1.0.1"
     "@npmcli/installed-package-contents" "^1.0.7"
     "@npmcli/map-workspaces" "^1.0.2"
     "@npmcli/metavuln-calculator" "^1.1.0"
@@ -266,14 +297,14 @@
     walk-up-path "^1.0.0"
 
 "@npmcli/ci-detect@^1.2.0", "@npmcli/ci-detect@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-1.3.0.tgz#6c1d2c625fb6ef1b9dea85ad0a5afcbef85ef22a"
-  integrity sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-1.4.0.tgz#18478bbaa900c37bfbd8a2006a6262c62e8b0fe1"
+  integrity sha512-3BGrt6FLjqM6br5AhWRKTr3u5GIVkjRYeAFrMp3HjnfICrg4xOrVRwFavKT6tsp++bq5dluL5t8ME/Nha/6c1Q==
 
 "@npmcli/config@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/@npmcli/config/-/config-2.3.0.tgz#364fbe942037e562a832a113206e14ccb651f7bc"
-  integrity sha512-yjiC1xv7KTmUTqfRwN2ZL7BHV160ctGF0fLXmKkkMXj40UOvBe45Apwvt5JsFRtXSoHkUYy1ouzscziuWNzklg==
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/@npmcli/config/-/config-2.4.0.tgz#1447b0274f9502871dabd3ab1d8302472d515b1f"
+  integrity sha512-fwxu/zaZnvBJohXM3igzqa3P1IVYWi5N343XcKvKkJbAx+rTqegS5tAul4NLiMPQh6WoS5a4er6oo/ieUx1f4g==
   dependencies:
     ini "^2.0.0"
     mkdirp-infer-owner "^2.0.0"
@@ -289,9 +320,9 @@
     ansi-styles "^4.3.0"
 
 "@npmcli/fs@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz#589612cfad3a6ea0feafcb901d29c63fd52db09f"
-  integrity sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
+  integrity sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==
   dependencies:
     "@gar/promisify" "^1.0.1"
     semver "^7.3.5"
@@ -351,9 +382,9 @@
   integrity sha512-qq3oEfcLFwNfEYOQ8HLimRGKlD8WSeGEdtUa7hmzpR8Sa7haL1KVQrvgO6wqMjhWFFVjgtrh1gIxDz+P8sjUaA==
 
 "@npmcli/node-gyp@^1.0.1", "@npmcli/node-gyp@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.2.tgz#3cdc1f30e9736dbc417373ed803b42b1a0a29ede"
-  integrity sha512-yrJUe6reVMpktcvagumoqD9r08fH1iRo01gn1u0zoCApa9lnZGEigVKUd2hzsCId4gdtkZZIVscLhNxMECKgRg==
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.3.tgz#a912e637418ffc5f2db375e93b85837691a43a33"
+  integrity sha512-fnkhw+fmX65kiLqk6E3BFLXNC26rUhK90zVwe2yncPliVT/Qos3xjhTLE59Df8KnPlcwIERXKVlU1bXoUQ+liA==
 
 "@npmcli/package-json@^1.0.1":
   version "1.0.1"
@@ -399,22 +430,22 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "2.6.2"
 
-"@oclif/command@^1.5.20", "@oclif/command@~1.8.0":
-  version "1.8.0"
-  resolved "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz#c1a499b10d26e9d1a611190a81005589accbb339"
-  integrity sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==
+"@oclif/command@^1.8.15", "@oclif/command@~1.8.0":
+  version "1.8.16"
+  resolved "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz#bea46f81b2061b47e1cda318a0b923e62ca4cc0c"
+  integrity sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==
   dependencies:
-    "@oclif/config" "^1.15.1"
-    "@oclif/errors" "^1.3.3"
-    "@oclif/parser" "^3.8.3"
-    "@oclif/plugin-help" "^3"
+    "@oclif/config" "^1.18.2"
+    "@oclif/errors" "^1.3.5"
+    "@oclif/help" "^1.0.1"
+    "@oclif/parser" "^3.8.6"
     debug "^4.1.1"
     semver "^7.3.2"
 
-"@oclif/config@^1.15.1", "@oclif/config@~1.17.0":
-  version "1.17.0"
-  resolved "https://registry.npmjs.org/@oclif/config/-/config-1.17.0.tgz#ba8639118633102a7e481760c50054623d09fcab"
-  integrity sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==
+"@oclif/config@1.18.2":
+  version "1.18.2"
+  resolved "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz#5bfe74a9ba6a8ca3dceb314a81bd9ce2e15ebbfe"
+  integrity sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==
   dependencies:
     "@oclif/errors" "^1.3.3"
     "@oclif/parser" "^3.8.0"
@@ -423,7 +454,31 @@
     is-wsl "^2.1.1"
     tslib "^2.0.0"
 
-"@oclif/errors@^1.2.2", "@oclif/errors@^1.3.3", "@oclif/errors@~1.3.4":
+"@oclif/config@^1.18.2":
+  version "1.18.3"
+  resolved "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz#ddfc144fdab66b1658c2f1b3478fa7fbfd317e79"
+  integrity sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==
+  dependencies:
+    "@oclif/errors" "^1.3.5"
+    "@oclif/parser" "^3.8.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-wsl "^2.1.1"
+    tslib "^2.3.1"
+
+"@oclif/config@~1.17.0":
+  version "1.17.1"
+  resolved "https://registry.npmjs.org/@oclif/config/-/config-1.17.1.tgz#383515f6715b91d8df5db8108214e93bb46e86ca"
+  integrity sha512-UqV5qsN2np96TNlJspSNlRl7CpFmxYSrB0iLe3XV9NDkbFEE5prGP++h6w6xOR/FL3QV7BoqrbwGuJdJdFbidw==
+  dependencies:
+    "@oclif/errors" "^1.3.3"
+    "@oclif/parser" "^3.8.6"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-wsl "^2.1.1"
+    tslib "^2.0.0"
+
+"@oclif/errors@1.3.5", "@oclif/errors@^1.3.3", "@oclif/errors@^1.3.5", "@oclif/errors@~1.3.4":
   version "1.3.5"
   resolved "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz#a1e9694dbeccab10fe2fe15acb7113991bed636c"
   integrity sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==
@@ -434,52 +489,68 @@
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+"@oclif/help@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@oclif/help/-/help-1.0.1.tgz#fd96a3dd9fb2314479e6c8584c91b63754a7dff5"
+  integrity sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==
+  dependencies:
+    "@oclif/config" "1.18.2"
+    "@oclif/errors" "1.3.5"
+    chalk "^4.1.2"
+    indent-string "^4.0.0"
+    lodash "^4.17.21"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    widest-line "^3.1.0"
+    wrap-ansi "^6.2.0"
+
 "@oclif/linewrap@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
-"@oclif/parser@^3.8.0", "@oclif/parser@^3.8.3":
-  version "3.8.5"
-  resolved "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.5.tgz#c5161766a1efca7343e1f25d769efbefe09f639b"
-  integrity sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==
+"@oclif/parser@^3.8.0", "@oclif/parser@^3.8.6":
+  version "3.8.7"
+  resolved "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz#236d48db05d0b00157d3b42d31f9dac7550d2a7c"
+  integrity sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==
   dependencies:
-    "@oclif/errors" "^1.2.2"
+    "@oclif/errors" "^1.3.5"
     "@oclif/linewrap" "^1.0.0"
-    chalk "^2.4.2"
-    tslib "^1.9.3"
-
-"@oclif/plugin-help@^3", "@oclif/plugin-help@~3.2.2":
-  version "3.2.3"
-  resolved "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.3.tgz#cd24010e7eb326782843d3aa6d6b5a4affebb2c3"
-  integrity sha512-l2Pd0lbOMq4u/7xsl9hqISFqyR9gWEz/8+05xmrXFr67jXyS6EUCQB+mFBa0wepltrmJu0sAFg9AvA2mLaMMqQ==
-  dependencies:
-    "@oclif/command" "^1.5.20"
-    "@oclif/config" "^1.15.1"
-    "@oclif/errors" "^1.2.2"
     chalk "^4.1.0"
+    tslib "^2.3.1"
+
+"@oclif/plugin-help@~3.2.2":
+  version "3.2.20"
+  resolved "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.20.tgz#441c706f863df29b05da29716537454ce22f82e4"
+  integrity sha512-3DhmxopYMHblO9peXulsVkb1ueEg0/5dAdQ3ddy+/S2Vi/lytrkA3WsJUTp+QNdJJc5w2y1+1BR8T8KS2nOmow==
+  dependencies:
+    "@oclif/command" "^1.8.15"
+    "@oclif/config" "1.18.2"
+    "@oclif/errors" "1.3.5"
+    "@oclif/help" "^1.0.1"
+    chalk "^4.1.2"
     indent-string "^4.0.0"
-    lodash.template "^4.4.0"
+    lodash "^4.17.21"
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     widest-line "^3.1.0"
-    wrap-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 "@octokit/auth-token@^2.4.4":
-  version "2.4.5"
-  resolved "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
-  integrity sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz#27c37ea26c205f28443402477ffd261311f21e36"
+  integrity sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==
   dependencies:
     "@octokit/types" "^6.0.3"
 
 "@octokit/core@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz#8601ceeb1ec0e1b1b8217b960a413ed8e947809b"
-  integrity sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==
+  version "3.6.0"
+  resolved "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz#3376cb9f3008d9b3d110370d90e0a1fcd5fe6085"
+  integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
   dependencies:
     "@octokit/auth-token" "^2.4.4"
     "@octokit/graphql" "^4.5.8"
-    "@octokit/request" "^5.6.0"
+    "@octokit/request" "^5.6.3"
     "@octokit/request-error" "^2.0.5"
     "@octokit/types" "^6.0.3"
     before-after-hook "^2.2.0"
@@ -503,29 +574,29 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^10.2.2":
-  version "10.2.2"
-  resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.2.2.tgz#6c1c839d7d169feabaf1d2a69c79439c75d979cd"
-  integrity sha512-EVcXQ+ZrC04cg17AMg1ofocWMxHDn17cB66ZHgYc0eUwjFtxS0oBzkyw2VqIrHBwVgtfoYrq1WMQfQmMjUwthw==
+"@octokit/openapi-types@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
+  integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
 
-"@octokit/plugin-paginate-rest@^2.16.0":
-  version "2.16.3"
-  resolved "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.3.tgz#6dbf74a12a53e04da6ca731d4c93f20c0b5c6fe9"
-  integrity sha512-kdc65UEsqze/9fCISq6BxLzeB9qf0vKvKojIfzgwf4tEF+Wy6c9dXnPFE6vgpoDFB1Z5Jek5WFVU6vL1w22+Iw==
+"@octokit/plugin-paginate-rest@^2.16.8":
+  version "2.17.0"
+  resolved "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz#32e9c7cab2a374421d3d0de239102287d791bce7"
+  integrity sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==
   dependencies:
-    "@octokit/types" "^6.28.1"
+    "@octokit/types" "^6.34.0"
 
 "@octokit/plugin-request-log@^1.0.4":
   version "1.0.4"
   resolved "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
   integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
 
-"@octokit/plugin-rest-endpoint-methods@^5.9.0":
-  version "5.10.4"
-  resolved "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.10.4.tgz#97e85eb7375e30b9bf193894670f9da205e79408"
-  integrity sha512-Dh+EAMCYR9RUHwQChH94Skl0lM8Fh99auT8ggck/xTzjJrwVzvsd0YH68oRPqp/HxICzmUjLfaQ9sy1o1sfIiA==
+"@octokit/plugin-rest-endpoint-methods@^5.12.0":
+  version "5.13.0"
+  resolved "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz#8c46109021a3412233f6f50d28786f8e552427ba"
+  integrity sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==
   dependencies:
-    "@octokit/types" "^6.28.1"
+    "@octokit/types" "^6.34.0"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
@@ -537,34 +608,34 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^5.6.0":
-  version "5.6.1"
-  resolved "https://registry.npmjs.org/@octokit/request/-/request-5.6.1.tgz#f97aff075c37ab1d427c49082fefeef0dba2d8ce"
-  integrity sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==
+"@octokit/request@^5.6.0", "@octokit/request@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
+  integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
   dependencies:
     "@octokit/endpoint" "^6.0.1"
     "@octokit/request-error" "^2.1.0"
     "@octokit/types" "^6.16.1"
     is-plain-object "^5.0.0"
-    node-fetch "^2.6.1"
+    node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^18.0.0":
-  version "18.10.0"
-  resolved "https://registry.npmjs.org/@octokit/rest/-/rest-18.10.0.tgz#8a0add9611253e0e31d3ed5b4bc941a3795a7648"
-  integrity sha512-esHR5OKy38bccL/sajHqZudZCvmv4yjovMJzyXlphaUo7xykmtOdILGJ3aAm0mFHmMLmPFmDMJXf39cAjNJsrw==
+  version "18.12.0"
+  resolved "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
+  integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
   dependencies:
     "@octokit/core" "^3.5.1"
-    "@octokit/plugin-paginate-rest" "^2.16.0"
+    "@octokit/plugin-paginate-rest" "^2.16.8"
     "@octokit/plugin-request-log" "^1.0.4"
-    "@octokit/plugin-rest-endpoint-methods" "^5.9.0"
+    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
 
-"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.28.1":
-  version "6.28.1"
-  resolved "https://registry.npmjs.org/@octokit/types/-/types-6.28.1.tgz#ab990d1fe952226055e81c7650480e6bacfb877c"
-  integrity sha512-XlxDoQLFO5JnFZgKVQTYTvXRsQFfr/GwDUU108NJ9R5yFPkA2qXhTJjYuul3vE4eLXP40FA2nysOu2zd6boE+w==
+"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.34.0":
+  version "6.34.0"
+  resolved "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz#c6021333334d1ecfb5d370a8798162ddf1ae8218"
+  integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
   dependencies:
-    "@octokit/openapi-types" "^10.2.2"
+    "@octokit/openapi-types" "^11.2.0"
 
 "@semantic-release/changelog@^5.0.1":
   version "5.0.1"
@@ -670,6 +741,30 @@
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/chai-subset@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
+  integrity sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
+  integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
+
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
+  dependencies:
+    "@types/node" "*"
+
+"@types/istanbul-lib-coverage@^2.0.1":
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
+  integrity sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -685,6 +780,11 @@
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/node@*":
+  version "17.0.32"
+  resolved "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz#51d59d7a90ef2d0ae961791e0900cad2393a0149"
+  integrity sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -695,10 +795,10 @@
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/retry@^0.12.0":
-  version "0.12.1"
-  resolved "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
-  integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@typescript-eslint/eslint-plugin@5.22.0":
   version "5.22.0"
@@ -794,12 +894,12 @@ abbrev@1, abbrev@~1.1.1:
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
 accepts@^1.3.5:
-  version "1.3.7"
-  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
-  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
+  version "1.3.8"
+  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
   dependencies:
-    mime-types "~2.1.24"
-    negotiator "0.6.2"
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
 
 acorn-jsx@^5.3.1:
   version "5.3.2"
@@ -833,9 +933,9 @@ agent-base@6, agent-base@^6.0.2:
     debug "4"
 
 agentkeepalive@^4.1.3:
-  version "4.1.4"
-  resolved "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz#d928028a4862cb11718e55227872e842a44c945b"
-  integrity sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
+  integrity sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==
   dependencies:
     debug "^4.1.0"
     depd "^1.1.2"
@@ -860,9 +960,9 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.6.3"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
-  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
+  version "8.11.0"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -887,16 +987,16 @@ ansi-regex@^2.0.0:
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
-ansi-regex@^5.0.0:
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -919,11 +1019,6 @@ ansistyles@~0.1.3:
   version "0.1.3"
   resolved "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
   integrity sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=
-
-any-promise@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
-  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
 anymatch@~3.1.2:
   version "3.1.2"
@@ -1023,9 +1118,9 @@ asap@^2.0.0:
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
 asn1@~0.2.3:
-  version "0.2.4"
-  resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
-  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
+  version "0.2.6"
+  resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
   dependencies:
     safer-buffer "~2.1.0"
 
@@ -1034,15 +1129,20 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.npmjs.org/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  version "2.6.4"
+  resolved "https://registry.npmjs.org/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
   dependencies:
     lodash "^4.17.14"
 
@@ -1120,12 +1220,12 @@ before-after-hook@^2.2.0:
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
 bin-links@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/bin-links/-/bin-links-2.2.1.tgz#347d9dbb48f7d60e6c11fe68b77a424bee14d61b"
-  integrity sha512-wFzVTqavpgCCYAh8SVBdnZdiQMxTkGR+T3b14CNpBXIBe2neJWaMGAZ55XWWHELJJ89dscuq0VCBqcVaIOgCMg==
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/bin-links/-/bin-links-2.3.0.tgz#1ff241c86d2c29b24ae52f49544db5d78a4eb967"
+  integrity sha512-JzrOLHLwX2zMqKdyYZjkDgQGT+kHDkIhv2/IK2lJ00qLxV4TmFoHi8drDBb6H5Zrz1YfgHkai4e2MGPqnoUhqA==
   dependencies:
     cmd-shim "^4.0.1"
-    mkdirp "^1.0.3"
+    mkdirp-infer-owner "^2.0.0"
     npm-normalize-package-bin "^1.0.0"
     read-cmd-shim "^2.0.0"
     rimraf "^3.0.0"
@@ -1158,7 +1258,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1193,6 +1293,24 @@ bytes@^3.0.0:
   version "3.1.2"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+c8@^7.11.2:
+  version "7.11.2"
+  resolved "https://registry.npmjs.org/c8/-/c8-7.11.2.tgz#2f2103e39079899041e612999a16b31d7ea6d463"
+  integrity sha512-6ahJSrhS6TqSghHm+HnWt/8Y2+z0hM/FQyB1ybKhAR30+NYL9CTQ1uwHxuWw6U7BHlHv6wvhgOrH81I+lfCkxg==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@istanbuljs/schema" "^0.1.3"
+    find-up "^5.0.0"
+    foreground-child "^2.0.0"
+    istanbul-lib-coverage "^3.2.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-reports "^3.1.4"
+    rimraf "^3.0.2"
+    test-exclude "^6.0.0"
+    v8-to-istanbul "^9.0.0"
+    yargs "^16.2.0"
+    yargs-parser "^20.2.9"
 
 cacache@^15.0.3, cacache@^15.0.5, cacache@^15.2.0, cacache@^15.3.0:
   version "15.3.0"
@@ -1259,9 +1377,9 @@ camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001335:
-  version "1.0.30001338"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz#b5dd7a7941a51a16480bdf6ff82bded1628eec0d"
-  integrity sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==
+  version "1.0.30001340"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001340.tgz#029a2f8bfc025d4820fafbfaa6259fd7778340c7"
+  integrity sha512-jUNz+a9blQTQVu4uFcn17uAD8IDizPzQkIKh3LCJfg9BkyIqExYYdyc/ZSlWUSKb8iYiXxKsxbv4zYSvkqjrxw==
 
 cardinal@^2.1.1:
   version "2.1.1"
@@ -1276,7 +1394,20 @@ caseless@~0.12.0:
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
+chai@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
+  integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
+chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1292,6 +1423,11 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chokidar@^3.5.2:
   version "3.5.3"
@@ -1348,19 +1484,18 @@ cli-cursor@^3.1.0:
     restore-cursor "^3.1.0"
 
 cli-spinners@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz#36c7dc98fb6a9a76bd6238ec3f77e2425627e939"
-  integrity sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==
+  version "2.6.1"
+  resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
+  integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
 
 cli-table3@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz#b7b1bc65ca8e7b5cef9124e13dc2b21e2ce4faee"
-  integrity sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
+  integrity sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==
   dependencies:
-    object-assign "^4.1.0"
     string-width "^4.2.0"
   optionalDependencies:
-    colors "^1.1.2"
+    "@colors/colors" "1.5.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -1438,11 +1573,6 @@ color@^4.0.1:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
-colors@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 columnify@~1.5.4:
   version "1.5.4"
   resolved "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -1497,11 +1627,11 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0, console-control-
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 content-disposition@~0.5.2:
-  version "0.5.3"
-  resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
-  integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
+  version "0.5.4"
+  resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
   dependencies:
-    safe-buffer "5.1.2"
+    safe-buffer "5.2.1"
 
 content-type@^1.0.4:
   version "1.0.4"
@@ -1541,9 +1671,9 @@ conventional-commits-filter@^2.0.0, conventional-commits-filter@^2.0.7:
     modify-values "^1.0.0"
 
 conventional-commits-parser@^3.0.0, conventional-commits-parser@^3.0.7:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.2.tgz#190fb9900c6e02be0c0bca9b03d57e24982639fd"
-  integrity sha512-Jr9KAKgqAkwXMRHjxDwO/zOCDKod1XdAESHAGuJX38iZ7ZzVti/tvVoysO0suMsdAObp9NQ2rHSsSbnAqZ5f5g==
+  version "3.2.4"
+  resolved "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz#a7d3b77758a202a9b2293d2112a8d8052c740972"
+  integrity sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==
   dependencies:
     JSONStream "^1.0.4"
     is-text-path "^1.0.1"
@@ -1551,6 +1681,13 @@ conventional-commits-parser@^3.0.0, conventional-commits-parser@^3.0.7:
     meow "^8.0.0"
     split2 "^3.0.0"
     through2 "^4.0.0"
+
+convert-source-map@^1.6.0:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
+  integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
+  dependencies:
+    safe-buffer "~5.1.1"
 
 cookies@~0.8.0:
   version "0.8.0"
@@ -1641,10 +1778,10 @@ dateformat@^3.0.0:
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
-  version "4.3.2"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3:
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -1661,20 +1798,6 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.3.2:
-  version "4.3.4"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -1693,6 +1816,13 @@ decamelize@^1.1.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-equal@~1.0.1:
   version "1.0.1"
@@ -1716,14 +1846,7 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-define-properties@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
-  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
-  dependencies:
-    object-keys "^1.0.12"
-
-define-properties@^1.1.4:
+define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
   integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
@@ -1776,9 +1899,9 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 destroy@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
-  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
 detective@^5.2.0:
   version "5.2.0"
@@ -1790,9 +1913,9 @@ detective@^5.2.0:
     minimist "^1.1.1"
 
 dezalgo@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
-  integrity sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
+  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
   dependencies:
     asap "^2.0.0"
     wrappy "1"
@@ -1895,13 +2018,6 @@ encoding@^0.1.12:
   dependencies:
     iconv-lite "^0.6.2"
 
-end-of-stream@^1.1.0:
-  version "1.4.4"
-  resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
-
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -1910,11 +2026,12 @@ enquirer@^2.3.5:
     ansi-colors "^4.1.1"
 
 env-ci@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz#48b6687f8af8cdf5e31b8fcf2987553d085249d9"
-  integrity sha512-Xc41mKvjouTXD3Oy9AqySz1IeyvJvHZ20Twf5ZLYbNpPPIuCnL/qHCmNlD01LoNy0JTunw9HPYVptD19Ac7Mbw==
+  version "5.5.0"
+  resolved "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz#43364e3554d261a586dec707bc32be81112b545f"
+  integrity sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==
   dependencies:
-    execa "^4.0.0"
+    execa "^5.0.0"
+    fromentries "^1.3.2"
     java-properties "^1.0.0"
 
 env-paths@^2.2.0:
@@ -1933,30 +2050,6 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-es-abstract@^1.18.0-next.2:
-  version "1.18.6"
-  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz#2c44e3ea7a6255039164d26559777a6d978cb456"
-  integrity sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==
-  dependencies:
-    call-bind "^1.0.2"
-    es-to-primitive "^1.2.1"
-    function-bind "^1.1.1"
-    get-intrinsic "^1.1.1"
-    get-symbol-description "^1.0.0"
-    has "^1.0.3"
-    has-symbols "^1.0.2"
-    internal-slot "^1.0.3"
-    is-callable "^1.2.4"
-    is-negative-zero "^2.0.1"
-    is-regex "^1.1.4"
-    is-string "^1.0.7"
-    object-inspect "^1.11.0"
-    object-keys "^1.1.1"
-    object.assign "^4.1.2"
-    string.prototype.trimend "^1.0.4"
-    string.prototype.trimstart "^1.0.4"
-    unbox-primitive "^1.0.1"
 
 es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
   version "1.20.0"
@@ -2002,6 +2095,132 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+esbuild-android-64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz#09f12a372eed9743fd77ff6d889ac14f7b340c21"
+  integrity sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==
+
+esbuild-android-arm64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz#f608d00ea03fe26f3b1ab92a30f99220390f3071"
+  integrity sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==
+
+esbuild-darwin-64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz#31528daa75b4c9317721ede344195163fae3e041"
+  integrity sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==
+
+esbuild-darwin-arm64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz#247f770d86d90a215fa194f24f90e30a0bd97245"
+  integrity sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==
+
+esbuild-freebsd-64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz#479414d294905055eb396ebe455ed42213284ee0"
+  integrity sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==
+
+esbuild-freebsd-arm64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz#cedeb10357c88533615921ae767a67dc870a474c"
+  integrity sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==
+
+esbuild-linux-32@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz#d9f008c4322d771f3958f59c1eee5a05cdf92485"
+  integrity sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==
+
+esbuild-linux-64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz#ba58d7f66858913aeb1ab5c6bde1bbd824731795"
+  integrity sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==
+
+esbuild-linux-arm64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz#708785a30072702b5b1c16b65cf9c25c51202529"
+  integrity sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==
+
+esbuild-linux-arm@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz#4e8b5deaa7ab60d0d28fab131244ef82b40684f4"
+  integrity sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==
+
+esbuild-linux-mips64le@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz#6f3bf3023f711084e5a1e8190487d2020f39f0f7"
+  integrity sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==
+
+esbuild-linux-ppc64le@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz#900e718a4ea3f6aedde8424828eeefdd4b48d4b9"
+  integrity sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==
+
+esbuild-linux-riscv64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz#dcbff622fa37047a75d2ff7a1d8d2949d80277e4"
+  integrity sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==
+
+esbuild-linux-s390x@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz#3f725a7945b419406c99d93744b28552561dcdfd"
+  integrity sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==
+
+esbuild-netbsd-64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz#e10e40b6a765798b90d4eb85901cc85c8b7ff85e"
+  integrity sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==
+
+esbuild-openbsd-64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz#935ec143f75ce10bd9cdb1c87fee00287eb0edbc"
+  integrity sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==
+
+esbuild-sunos-64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz#0e7aa82b022a2e6d55b0646738b2582c2d72c3c0"
+  integrity sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==
+
+esbuild-windows-32@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz#3f1538241f31b538545f4b5841b248cac260fa35"
+  integrity sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==
+
+esbuild-windows-64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz#b100c59f96d3c2da2e796e42fee4900d755d3e03"
+  integrity sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==
+
+esbuild-windows-arm64@0.14.39:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz#00268517e665b33c89778d61f144e4256b39f631"
+  integrity sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==
+
+esbuild@^0.14.27:
+  version "0.14.39"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz#c926b2259fe6f6d3a94f528fb42e103c5a6d909a"
+  integrity sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==
+  optionalDependencies:
+    esbuild-android-64 "0.14.39"
+    esbuild-android-arm64 "0.14.39"
+    esbuild-darwin-64 "0.14.39"
+    esbuild-darwin-arm64 "0.14.39"
+    esbuild-freebsd-64 "0.14.39"
+    esbuild-freebsd-arm64 "0.14.39"
+    esbuild-linux-32 "0.14.39"
+    esbuild-linux-64 "0.14.39"
+    esbuild-linux-arm "0.14.39"
+    esbuild-linux-arm64 "0.14.39"
+    esbuild-linux-mips64le "0.14.39"
+    esbuild-linux-ppc64le "0.14.39"
+    esbuild-linux-riscv64 "0.14.39"
+    esbuild-linux-s390x "0.14.39"
+    esbuild-netbsd-64 "0.14.39"
+    esbuild-openbsd-64 "0.14.39"
+    esbuild-sunos-64 "0.14.39"
+    esbuild-windows-32 "0.14.39"
+    esbuild-windows-64 "0.14.39"
+    esbuild-windows-arm64 "0.14.39"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -2251,31 +2470,16 @@ estraverse@^4.1.1:
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0, estraverse@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
-  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-execa@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
-  integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
-  dependencies:
-    cross-spawn "^7.0.0"
-    get-stream "^5.0.0"
-    human-signals "^1.1.1"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.0"
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
-    strip-final-newline "^2.0.0"
-
-execa@^5.0.0, execa@^5.1.1:
+execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -2290,6 +2494,21 @@ execa@^5.0.0, execa@^5.1.1:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+execa@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz#cea16dee211ff011246556388effa0818394fb20"
+  integrity sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.1"
+    human-signals "^3.0.1"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^3.0.7"
+    strip-final-newline "^3.0.0"
+
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -2301,9 +2520,9 @@ extsprintf@1.3.0:
   integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
 
 extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -2314,17 +2533,6 @@ fast-diff@^1.1.2:
   version "1.2.0"
   resolved "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
-
-fast-glob@^3.1.1:
-  version "3.2.7"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
-  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
 
 fast-glob@^3.2.7, fast-glob@^3.2.9:
   version "3.2.11"
@@ -2409,6 +2617,14 @@ find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 find-versions@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz#3c57e573bf97769b8cb8df16934b627915da4965"
@@ -2425,14 +2641,22 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.1.0:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
-  integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
+  version "3.2.5"
+  resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
+  integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
 follow-redirects@^1.14.0:
-  version "1.14.4"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
-  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+  version "1.15.0"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
+  integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
+
+foreground-child@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"
+  integrity sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^3.0.2"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -2465,6 +2689,11 @@ from2@^2.3.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fromentries@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
+  integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
 
 fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
@@ -2537,9 +2766,9 @@ functions-have-names@^1.2.2:
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
 gauge@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz#4bea07bcde3782f06dced8950e51307aa0f4a346"
-  integrity sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
+  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
   dependencies:
     aproba "^1.0.3 || ^2.0.0"
     color-support "^1.1.2"
@@ -2547,8 +2776,8 @@ gauge@^3.0.0:
     has-unicode "^2.0.1"
     object-assign "^4.1.1"
     signal-exit "^3.0.0"
-    string-width "^1.0.1 || ^2.0.0"
-    strip-ansi "^3.0.1 || ^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
     wide-align "^1.1.2"
 
 gauge@~2.7.3:
@@ -2570,6 +2799,11 @@ get-caller-file@^2.0.5:
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
@@ -2579,14 +2813,7 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
-get-stream@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
-  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
-  dependencies:
-    pump "^3.0.0"
-
-get-stream@^6.0.0:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -2632,19 +2859,7 @@ glob-parent@^6.0.1:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^7.1.1, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
-  version "7.1.7"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.3:
+glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -2662,25 +2877,13 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.6.0, globals@^13.9.0:
-  version "13.11.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz#40ef678da117fe7bd2e28f1fab24951bd0255be7"
-  integrity sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==
+  version "13.15.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz#38113218c907d2f7e98658af246cef8b77e90bac"
+  integrity sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.0, globby@^11.0.1:
-  version "11.0.4"
-  resolved "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
-  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
-    slash "^3.0.0"
-
-globby@^11.0.4:
+globby@^11.0.0, globby@^11.0.1, globby@^11.0.4:
   version "11.1.0"
   resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -2692,12 +2895,7 @@ globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.8:
-  version "4.2.8"
-  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
-  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
-
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.8:
   version "4.2.10"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -2732,12 +2930,7 @@ hard-rejection@^2.1.0:
   resolved "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
-has-bigints@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
-  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
-
-has-bigints@^1.0.2:
+has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
@@ -2759,12 +2952,7 @@ has-property-descriptors@^1.0.0:
   dependencies:
     get-intrinsic "^1.1.1"
 
-has-symbols@^1.0.1, has-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
-  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
-
-has-symbols@^1.0.3:
+has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
@@ -2804,9 +2992,9 @@ hosted-git-info@^2.1.4:
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hosted-git-info@^4.0.0, hosted-git-info@^4.0.1, hosted-git-info@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz#5e425507eede4fea846b7262f0838456c4209961"
-  integrity sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
+  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -2819,6 +3007,11 @@ hsla-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 html-tags@^3.1.0:
   version "3.2.0"
@@ -2839,15 +3032,15 @@ http-cache-semantics@^4.1.0:
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
 http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
-  version "1.8.0"
-  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz#75d1bbe497e1044f51e4ee9e704a62f28d336507"
-  integrity sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==
+  version "1.8.1"
+  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
   dependencies:
     depd "~1.1.2"
     inherits "2.0.4"
     setprototypeof "1.2.0"
     statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
+    toidentifier "1.0.1"
 
 http-errors@~1.6.2:
   version "1.6.3"
@@ -2878,22 +3071,22 @@ http-signature@~1.2.0:
     sshpk "^1.7.0"
 
 https-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
-  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
     debug "4"
-
-human-signals@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
-  integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+human-signals@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
+  integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
 
 humanize-ms@^1.2.1:
   version "1.2.1"
@@ -2926,12 +3119,7 @@ ignore@^4.0.6:
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4:
-  version "5.1.8"
-  resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
-  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
-
-ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.1.1, ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -2994,7 +3182,7 @@ ini@~1.3.0:
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-init-package-json@^2.0.4:
+init-package-json@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/init-package-json/-/init-package-json-2.0.5.tgz#78b85f3c36014db42d8f32117252504f68022646"
   integrity sha512-u1uGAtEFu3VA6HNl/yUWw57jmKEMx8SKOxHhxjGnOFUiIlFnohKDFg4ZrPpv9wWqk44nDxGJAtqjdQFm+9XXQA==
@@ -3030,9 +3218,9 @@ ip-regex@^4.1.0:
   integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
 ip@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+  version "1.1.8"
+  resolved "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
+  integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -3090,17 +3278,10 @@ is-color-stop@^1.1.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.2.0, is-core-module@^2.8.1:
+is-core-module@^2.5.0, is-core-module@^2.8.1:
   version "2.9.0"
   resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
-  dependencies:
-    has "^1.0.3"
-
-is-core-module@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz#d7553b2526fe59b92ba3e40c8df757ec8a709e19"
-  integrity sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==
   dependencies:
     has "^1.0.3"
 
@@ -3145,14 +3326,7 @@ is-generator-function@^1.0.7:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-glob@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
-  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
-  dependencies:
-    is-extglob "^2.1.1"
-
-is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -3169,20 +3343,15 @@ is-lambda@^1.0.1:
   resolved "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
   integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
 
-is-negative-zero@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
-  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
-
 is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
 is-number-object@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz#6a7aaf838c7f0686a50b4553f7e54a96494e89f0"
-  integrity sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==
+  version "1.0.7"
+  resolved "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
+  integrity sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==
   dependencies:
     has-tostringtag "^1.0.0"
 
@@ -3235,6 +3404,11 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
@@ -3307,6 +3481,28 @@ issue-parser@^6.0.0:
     lodash.isstring "^4.0.1"
     lodash.uniqby "^4.7.0"
 
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz#189e7909d0a39fa5a3dfad5b03f71947770191d3"
+  integrity sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==
+
+istanbul-lib-report@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
+  integrity sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^3.0.0"
+    supports-color "^7.1.0"
+
+istanbul-reports@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz#1b6f068ecbc6c331040aab5741991273e609e40c"
+  integrity sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 java-properties@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz#ccd1fa73907438a5b5c38982269d0e771fe78211"
@@ -3355,10 +3551,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -3409,19 +3605,19 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsprim@^1.2.2:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
-  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+  version "1.4.2"
+  resolved "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
+  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
   dependencies:
     assert-plus "1.0.0"
     extsprintf "1.3.0"
-    json-schema "0.2.3"
+    json-schema "0.4.0"
     verror "1.10.0"
 
 just-diff-apply@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-3.0.0.tgz#a77348d24f0694e378b57293dceb65bdf5a91c4f"
-  integrity sha512-K2MLc+ZC2DVxX4V61bIKPeMUUfj1YYZ3h0myhchDXOW1cKoPZMnjIoNCqv9bF2n5Oob1PFxuR2gVJxkxz4e58w==
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-3.1.2.tgz#710d8cda00c65dc4e692df50dbe9bac5581c2193"
+  integrity sha512-TCa7ZdxCeq6q3Rgms2JCRHTCfWAETPZ8SzYUbkYF6KR3I03sN29DaOIC+xyWboIcMvjAsD5iG2u/RWzHD8XpgQ==
 
 just-diff@^3.0.1:
   version "3.1.1"
@@ -3440,25 +3636,18 @@ kind-of@^6.0.3:
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-koa-compose@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz#a85ccb40b7d986d8e5a345b3a1ace8eabcf54de7"
-  integrity sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=
-  dependencies:
-    any-promise "^1.1.0"
-
 koa-compose@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
   integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
 
-koa-convert@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz#da40875df49de0539098d1700b50820cebcd21d0"
-  integrity sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=
+koa-convert@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz#86a0c44d81d40551bae22fee6709904573eea4f5"
+  integrity sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==
   dependencies:
     co "^4.6.0"
-    koa-compose "^3.0.0"
+    koa-compose "^4.1.0"
 
 koa-send@^5.0.0:
   version "5.0.1"
@@ -3478,16 +3667,16 @@ koa-static@^5.0.0:
     koa-send "^5.0.0"
 
 koa@^2.12.0:
-  version "2.13.1"
-  resolved "https://registry.npmjs.org/koa/-/koa-2.13.1.tgz#6275172875b27bcfe1d454356a5b6b9f5a9b1051"
-  integrity sha512-Lb2Dloc72auj5vK4X4qqL7B5jyDPQaZucc9sR/71byg7ryoD1NCaCm63CShk9ID9quQvDEi1bGR/iGjCG7As3w==
+  version "2.13.4"
+  resolved "https://registry.npmjs.org/koa/-/koa-2.13.4.tgz#ee5b0cb39e0b8069c38d115139c774833d32462e"
+  integrity sha512-43zkIKubNbnrULWlHdN5h1g3SEKXOEzoAlRsHOTFpnlDu8JlAOZSMJBLULusuXRequboiwJcj5vtYXKB3k7+2g==
   dependencies:
     accepts "^1.3.5"
     cache-content-type "^1.0.0"
     content-disposition "~0.5.2"
     content-type "^1.0.4"
     cookies "~0.8.0"
-    debug "~3.1.0"
+    debug "^4.3.2"
     delegates "^1.0.0"
     depd "^2.0.0"
     destroy "^1.0.4"
@@ -3498,7 +3687,7 @@ koa@^2.12.0:
     http-errors "^1.6.3"
     is-generator-function "^1.0.7"
     koa-compose "^4.1.0"
-    koa-convert "^1.2.0"
+    koa-convert "^2.0.0"
     on-finished "^2.3.0"
     only "~0.0.2"
     parseurl "^1.3.2"
@@ -3644,6 +3833,11 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
+local-pkg@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.1.tgz#e7b0d7aa0b9c498a1110a5ac5b00ba66ef38cfff"
+  integrity sha512-lL87ytIGP2FU5PWwNDo0w3WhIo2gopIAxPg9RxDYF7m4rr5ahuZxP22xnJHIvaLTe4Z9P6uKKY2UHiwyB4pcrw==
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -3659,20 +3853,17 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash._reinterpolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
 
 lodash.capitalize@^4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
   integrity sha1-+CbJtOKoUR2E46yinbBeGk87cqk=
-
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"
@@ -3704,21 +3895,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.template@^4.4.0:
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-
 lodash.topath@^4.5.2:
   version "4.5.2"
   resolved "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
@@ -3747,6 +3923,13 @@ log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
+loupe@^2.3.1:
+  version "2.3.4"
+  resolved "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
+  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
+  dependencies:
+    get-func-name "^2.0.0"
+
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -3760,6 +3943,13 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+make-dir@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
 
 make-fetch-happen@^9.0.1, make-fetch-happen@^9.1.0:
   version "9.1.0"
@@ -3789,9 +3979,9 @@ map-obj@^1.0.0:
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
 
 map-obj@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz#e4ea399dbc979ae735c83c863dd31bdf364277b7"
-  integrity sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
+  integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
 marked-terminal@^4.1.1:
   version "4.2.0"
@@ -3857,15 +4047,7 @@ methods@^1.1.2:
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-micromatch@^4.0.0, micromatch@^4.0.2:
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
-  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.2.3"
-
-micromatch@^4.0.4:
+micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -3873,27 +4055,32 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-mime-db@1.49.0:
-  version "1.49.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
-  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.32"
-  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz#1d00e89e7de7fe02008db61001d9e02852670fd5"
-  integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
-    mime-db "1.49.0"
+    mime-db "1.52.0"
 
 mime@^2.4.3:
-  version "2.5.2"
-  resolved "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
-  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
 min-indent@^1.0.0:
   version "1.0.1"
@@ -3916,15 +4103,10 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.1, minimist@^1.2.6:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
-
-minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minipass-collect@^1.0.2:
   version "1.0.2"
@@ -3974,9 +4156,9 @@ minipass-sized@^1.0.3:
     minipass "^3.0.0"
 
 minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz#71f6251b0a33a49c01b3cf97ff77eda030dff732"
-  integrity sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==
+  version "3.1.6"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
+  integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
   dependencies:
     yallist "^4.0.0"
 
@@ -3998,11 +4180,11 @@ mkdirp-infer-owner@^2.0.0:
     mkdirp "^1.0.3"
 
 mkdirp@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
-  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  version "0.5.6"
+  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
-    minimist "^1.2.5"
+    minimist "^1.2.6"
 
 mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
@@ -4049,10 +4231,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-negotiator@0.6.2, negotiator@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
-  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+negotiator@0.6.3, negotiator@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.6.0:
   version "2.6.2"
@@ -4084,10 +4266,12 @@ node-emoji@^1.10.0, node-emoji@^1.11.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz#986996818b73785e47b1965cc34eb093a1d464d0"
-  integrity sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp@^7.1.0, node-gyp@^7.1.2:
   version "7.1.2"
@@ -4241,12 +4425,19 @@ npm-run-all@^4.1.5:
     shell-quote "^1.6.1"
     string.prototype.padend "^3.0.0"
 
-npm-run-path@^4.0.0, npm-run-path@^4.0.1:
+npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+npm-run-path@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz#bc62f7f3f6952d9894bd08944ba011a6ee7b7e00"
+  integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
+  dependencies:
+    path-key "^4.0.0"
 
 npm-user-validate@^1.0.1:
   version "1.0.1"
@@ -4254,11 +4445,12 @@ npm-user-validate@^1.0.1:
   integrity sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==
 
 npm@^7.0.0:
-  version "7.23.0"
-  resolved "https://registry.npmjs.org/npm/-/npm-7.23.0.tgz#aeafaafe847fdd7c496d8e4d4bcbb5201aa1930c"
-  integrity sha512-m7WFTwGfiBX+jL4ObX7rIDkug/hG/Jn8vZUjKw4WS8CqMjVydHiWTARLDIll7LtHu5i7ZHBnqXZbL2S73U5p6A==
+  version "7.24.2"
+  resolved "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz#861117af8241bea592289f22407230e5300e59ca"
+  integrity sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==
   dependencies:
-    "@npmcli/arborist" "^2.8.3"
+    "@isaacs/string-locale-compare" "^1.1.0"
+    "@npmcli/arborist" "^2.9.0"
     "@npmcli/ci-detect" "^1.2.0"
     "@npmcli/config" "^2.3.0"
     "@npmcli/map-workspaces" "^1.0.4"
@@ -4275,11 +4467,11 @@ npm@^7.0.0:
     cli-table3 "^0.6.0"
     columnify "~1.5.4"
     fastest-levenshtein "^1.0.12"
-    glob "^7.1.7"
+    glob "^7.2.0"
     graceful-fs "^4.2.8"
     hosted-git-info "^4.0.2"
     ini "^2.0.0"
-    init-package-json "^2.0.4"
+    init-package-json "^2.0.5"
     is-cidr "^4.0.2"
     json-parse-even-better-errors "^2.3.1"
     libnpmaccess "^4.0.2"
@@ -4368,17 +4560,12 @@ object-hash@^2.2.0:
   resolved "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
   integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
-object-inspect@^1.11.0, object-inspect@^1.9.0:
-  version "1.11.0"
-  resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
-  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
-
-object-inspect@^1.12.0:
+object-inspect@^1.12.0, object-inspect@^1.9.0:
   version "1.12.0"
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -4403,13 +4590,13 @@ object.values@^1.1.5:
     es-abstract "^1.19.1"
 
 on-finished@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
-  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -4422,6 +4609,13 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
 
 only@~0.0.2:
   version "0.0.2"
@@ -4499,7 +4693,7 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.1.0:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -4520,6 +4714,13 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
 p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
@@ -4538,11 +4739,11 @@ p-reduce@^2.0.0:
   integrity sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==
 
 p-retry@^4.0.0:
-  version "4.6.1"
-  resolved "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz#8fcddd5cdf7a67a0911a9cf2ef0e5df7f602316c"
-  integrity sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==
+  version "4.6.2"
+  resolved "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
   dependencies:
-    "@types/retry" "^0.12.0"
+    "@types/retry" "0.12.0"
     retry "^0.13.1"
 
 p-try@^1.0.0:
@@ -4644,15 +4845,20 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6, path-parse@^1.0.7:
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
+
+path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-to-regexp@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
-  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
+  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -4666,6 +4872,11 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -4676,7 +4887,7 @@ picocolors@^1.0.0:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -4749,7 +4960,7 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.1.6, postcss@^8.3.5, postcss@^8.3.6:
+postcss@^8.1.6, postcss@^8.3.5, postcss@^8.3.6, postcss@^8.4.13:
   version "8.4.13"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz#7c87bc268e79f7f86524235821dfdf9f73e5d575"
   integrity sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==
@@ -4830,14 +5041,6 @@ psl@^1.1.28:
   resolved "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
-  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -4864,9 +5067,9 @@ qrcode-terminal@^0.12.0:
   integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
 
 qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+  version "6.5.3"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -4907,9 +5110,9 @@ read-package-json-fast@^2.0.1, read-package-json-fast@^2.0.2, read-package-json-
     npm-normalize-package-bin "^1.0.1"
 
 read-package-json@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.1.tgz#153be72fce801578c1c86b8ef2b21188df1b9eea"
-  integrity sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.2.tgz#b444d047de7c75d4a160cb056d00c0693c1df703"
+  integrity sha512-Dqer4pqzamDE2O4M55xp1qZMuLPqi4ldk2ya648FOMHRjwMzFhuxVrG04wd0c38IsvkVdr3vgHI6z+QTPdAjrQ==
   dependencies:
     glob "^7.1.1"
     json-parse-even-better-errors "^2.3.0"
@@ -5035,13 +5238,13 @@ registry-auth-token@^4.0.0:
     rc "^1.2.8"
 
 replace-in-file@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.2.0.tgz#9c0e381b0e02f27f83d5ba500bb4046f63d18566"
-  integrity sha512-Im2AF9G/qgkYneOc9QwWwUS/efyyonTUBvzXS2VXuxPawE5yQIjT/e6x4CTijO0Quq48lfAujuo+S89RR2TP2Q==
+  version "6.3.2"
+  resolved "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.3.2.tgz#0f19835137177c89932f45df319f3539a019484f"
+  integrity sha512-Dbt5pXKvFVPL3WAaEB3ZX+95yP0CeAtIPJDwYzHbPP5EAHn+0UoegH/Wg3HKflU9dYBH8UnBC2NvY3P+9EZtTg==
   dependencies:
-    chalk "^4.1.0"
-    glob "^7.1.6"
-    yargs "^16.2.0"
+    chalk "^4.1.2"
+    glob "^7.2.0"
+    yargs "^17.2.1"
 
 request@^2.88.2:
   version "2.88.2"
@@ -5102,15 +5305,7 @@ resolve-path@^1.4.0:
     http-errors "~1.6.2"
     path-is-absolute "1.0.1"
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0:
-  version "1.20.0"
-  resolved "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
-  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
-  dependencies:
-    is-core-module "^2.2.0"
-    path-parse "^1.0.6"
-
-resolve@^1.20.0, resolve@^1.22.0:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -5159,6 +5354,13 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup@^2.59.0:
+  version "2.72.1"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-2.72.1.tgz#861c94790537b10008f0ca0fbc60e631aabdd045"
+  integrity sha512-NTc5UGy/NWFGpSqF1lFY8z9Adri6uhyMLI6LvPAXdBKoPRFhIIiBUpt+Qg2awixqO3xvzSijjhnb4+QEZwJmxA==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -5166,15 +5368,15 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
@@ -5238,9 +5440,9 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.3.0:
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  version "7.3.7"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -5284,9 +5486,9 @@ shebang-regex@^3.0.0:
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.6.1:
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
-  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+  version "1.7.3"
+  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
+  integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -5297,15 +5499,10 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.3:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz#366a4684d175b9cab2081e3681fda3747b6c51d7"
-  integrity sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==
-
-signal-exit@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
-  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 signale@^1.2.1:
   version "1.4.0"
@@ -5337,7 +5534,7 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-smart-buffer@^4.1.0:
+smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
@@ -5351,31 +5548,26 @@ snake-case@^3.0.3:
     tslib "^2.0.3"
 
 socks-proxy-agent@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz#869cf2d7bd10fea96c7ad3111e81726855e285c3"
-  integrity sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.0.tgz#f6b5229cc0cbd6f2f202d9695f09d871e951c85e"
+  integrity sha512-wWqJhjb32Q6GsrUqzuFkukxb/zzide5quXYcMVpIjxalDBBYy2nqKCFQ/9+Ie4dvOYSQdOk3hUlZSdzZOd3zMQ==
   dependencies:
     agent-base "^6.0.2"
-    debug "^4.3.1"
-    socks "^2.6.1"
+    debug "^4.3.3"
+    socks "^2.6.2"
 
-socks@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
-  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
+socks@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
+  integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
   dependencies:
     ip "^1.1.5"
-    smart-buffer "^4.1.0"
+    smart-buffer "^4.2.0"
 
 source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
-
-source-map@^0.5.0:
-  version "0.5.7"
-  resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 source-map@^0.6.1:
   version "0.6.1"
@@ -5409,9 +5601,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.10"
-  resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
-  integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
+  version "3.0.11"
+  resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
+  integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
 split2@^3.0.0:
   version "3.2.2"
@@ -5440,9 +5632,9 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sshpk@^1.7.0:
-  version "1.16.1"
-  resolved "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
-  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
+  version "1.17.0"
+  resolved "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
+  integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -5483,7 +5675,16 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.1 || ^2.0.0", "string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -5491,31 +5692,14 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.2"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
-  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
-
 string.prototype.padend@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz#6858ca4f35c5268ebd5e8615e1327d55f59ee311"
-  integrity sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz#997a6de12c92c7cb34dc8a201a6c53d9bd88a5f1"
+  integrity sha512-jNIIeokznm8SD/TZISQsZKYu7RJyheFNt84DUPrh482GC8RVp2MKqm2O5oBRdGxbDQoXrhhWtPIWQOiy20svUg==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.2"
-
-string.prototype.trimend@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
-  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
 
 string.prototype.trimend@^1.0.5:
   version "1.0.5"
@@ -5525,14 +5709,6 @@ string.prototype.trimend@^1.0.5:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
-
-string.prototype.trimstart@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
-  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
 
 string.prototype.trimstart@^1.0.5:
   version "1.0.5"
@@ -5569,19 +5745,19 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-"strip-ansi@^3.0.1 || ^4.0.0", strip-ansi@^4.0.0:
+strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
-    ansi-regex "^5.0.0"
+    ansi-regex "^5.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -5592,6 +5768,11 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
 strip-indent@^3.0.0:
   version "3.0.0"
@@ -5638,16 +5819,15 @@ supports-preserve-symlinks-flag@^1.0.0:
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 table@^6.0.9:
-  version "6.7.1"
-  resolved "https://registry.npmjs.org/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
-  integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==
+  version "6.8.0"
+  resolved "https://registry.npmjs.org/table/-/table-6.8.0.tgz#87e28f14fa4321c3377ba286f07b79b281a3b3ca"
+  integrity sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==
   dependencies:
     ajv "^8.0.1"
-    lodash.clonedeep "^4.5.0"
     lodash.truncate "^4.4.2"
     slice-ansi "^4.0.0"
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tailwind-config-viewer@^1.7.0:
   version "1.7.0"
@@ -5729,6 +5909,15 @@ tempy@^1.0.0:
     type-fest "^0.16.0"
     unique-string "^2.0.0"
 
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
+    minimatch "^3.0.4"
+
 text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
@@ -5764,6 +5953,16 @@ tiny-relative-date@^1.3.0:
   resolved "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz#fa08aad501ed730f31cc043181d995c39a935e07"
   integrity sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==
 
+tinypool@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/tinypool/-/tinypool-0.1.3.tgz#b5570b364a1775fd403de5e7660b325308fee26b"
+  integrity sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==
+
+tinyspy@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/tinyspy/-/tinyspy-0.3.2.tgz#2f95cb14c38089ca690385f339781cd35faae566"
+  integrity sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==
+
 tmp@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
@@ -5783,10 +5982,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-toidentifier@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
-  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 tough-cookie@~2.5.0:
   version "2.5.0"
@@ -5795,6 +5994,11 @@ tough-cookie@~2.5.0:
   dependencies:
     psl "^1.1.28"
     punycode "^2.1.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
 traverse@~0.6.6:
   version "0.6.6"
@@ -5821,15 +6025,15 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.3:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsscmp@1.0.6:
   version "1.0.6"
@@ -5861,6 +6065,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.16.0:
   version "0.16.0"
@@ -5907,20 +6116,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-uglify-js@^3.1.4:
-  version "3.14.2"
-  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz#d7dd6a46ca57214f54a2d0a43cad0f35db82ac99"
-  integrity sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==
+typescript@^4.6.4:
+  version "4.6.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
-unbox-primitive@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
-  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
-  dependencies:
-    function-bind "^1.1.1"
-    has-bigints "^1.0.1"
-    has-symbols "^1.0.2"
-    which-boxed-primitive "^1.0.2"
+uglify-js@^3.1.4:
+  version "3.15.5"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz#2b10f9e0bfb3f5c15a8e8404393b6361eaeb33b3"
+  integrity sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -5995,6 +6199,15 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
+v8-to-istanbul@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.0.tgz#be0dae58719fc53cb97e5c7ac1d7e6d4f5b19511"
+  integrity sha512-HcvgY/xaRm7isYmyx+lFKA4uQmfUbN0J4M0nNItvzTvH/iQ9kW5j/t4YSR+Ge323/lrgDAWJoF46tzGQHwBHFw==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.7"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^1.6.0"
+
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -6024,36 +6237,61 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vite@^2.9.8:
+  version "2.9.9"
+  resolved "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz#8b558987db5e60fedec2f4b003b73164cb081c5e"
+  integrity sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==
+  dependencies:
+    esbuild "^0.14.27"
+    postcss "^8.4.13"
+    resolve "^1.22.0"
+    rollup "^2.59.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+vitest@0.12.4:
+  version "0.12.4"
+  resolved "https://registry.npmjs.org/vitest/-/vitest-0.12.4.tgz#de1e3180bd9af97e87564482d347dd7ac714ca8d"
+  integrity sha512-EDxdhlAt6vcu6y4VouAI60z78iCAVFnfBL4VlSQVQnGmOk5altOtIKvp3xfZ+cfo4iVHgqq1QNyf5qOFiL4leg==
+  dependencies:
+    "@types/chai" "^4.3.1"
+    "@types/chai-subset" "^1.3.3"
+    chai "^4.3.6"
+    local-pkg "^0.4.1"
+    tinypool "^0.1.3"
+    tinyspy "^0.3.2"
+    vite "^2.9.8"
+
 vscode-json-languageservice@^4.1.6:
-  version "4.1.7"
-  resolved "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.7.tgz#18244d62b115a5818c7526ef4339438b7175dfaa"
-  integrity sha512-cwG5TwZyHYthsk2aS3W1dVgVP6Vwn3o+zscwN58uMgZt/nKuyxd9vdEB1F58Ix+S5kSKAnkUCP6hvulcoImQQQ==
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz#94b6f471ece193bf4a1ef37f6ab5cce86d50a8b4"
+  integrity sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA==
   dependencies:
     jsonc-parser "^3.0.0"
-    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-textdocument "^1.0.3"
     vscode-languageserver-types "^3.16.0"
     vscode-nls "^5.0.0"
-    vscode-uri "^3.0.2"
+    vscode-uri "^3.0.3"
 
-vscode-languageserver-textdocument@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
-  integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
+vscode-languageserver-textdocument@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz#3cd56dd14cec1d09e86c4bb04b09a246cb3df157"
+  integrity sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ==
 
 vscode-languageserver-types@^3.16.0:
-  version "3.16.0"
-  resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
-  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
+  version "3.17.1"
+  resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz#c2d87fa7784f8cac389deb3ff1e2d9a7bef07e16"
+  integrity sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==
 
 vscode-nls@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
-  integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.1.tgz#ba23fc4d4420d25e7f886c8e83cbdcec47aa48b2"
+  integrity sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A==
 
-vscode-uri@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
-  integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
+vscode-uri@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz#a95c1ce2e6f41b7549f86279d19f47951e4f4d84"
+  integrity sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==
 
 walk-up-path@^1.0.0:
   version "1.0.0"
@@ -6066,6 +6304,19 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
@@ -6093,11 +6344,11 @@ which@^2.0.1, which@^2.0.2:
     isexe "^2.0.0"
 
 wide-align@^1.1.0, wide-align@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
+  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
   dependencies:
-    string-width "^1.0.2 || 2"
+    string-width "^1.0.2 || 2 || 3 || 4"
 
 widest-line@^3.1.0:
   version "3.1.0"
@@ -6116,14 +6367,14 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-wrap-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz#b3570d7c70156159a2d42be5cc942e957f7b1131"
-  integrity sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
   dependencies:
-    ansi-styles "^3.2.0"
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -6169,10 +6420,15 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.3:
+yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^21.0.0:
+  version "21.0.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
+  integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
 yargs@^16.2.0:
   version "16.2.0"
@@ -6187,10 +6443,23 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yargs@^17.2.1:
+  version "17.5.0"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.5.0.tgz#2706c5431f8c119002a2b106fc9f58b9bb9097a3"
+  integrity sha512-3sLxVhbAB5OC8qvVRebCLWuouhwh/rswsiDYx3WGxajUk/l4G20SKfrKKFeNIHboUFt2JFgv2yfn+5cgOr/t5A==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
+
 ylru@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/ylru/-/ylru-1.2.1.tgz#f576b63341547989c1de7ba288760923b27fe84f"
-  integrity sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/ylru/-/ylru-1.3.2.tgz#0de48017473275a4cbdfc83a1eaf67c01af8a785"
+  integrity sha512-RXRJzMiK6U2ye0BlGGZnmpwJDPgakn6aNQ0A7gHRbD4I0uvK4TW6UqkK1V0pp9jskjJBAXd3dRrbzWkqJ+6cxA==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Required: https://github.com/CrowdStrike/tailwind-toucan-base/pull/1

These tests will allow us to use renovate safely. Any PR that results in changes of the CSS will fail the CI checks.

Note however, that because the Tailwind Preview PR is implemented, all PRs will get a "Cloudflare Pages" check, which will fail until every PR is rebased on top of the Tailwind Preview PR

The settings that help out with this protection:
![image](https://user-images.githubusercontent.com/199018/167262453-3f853df7-aab6-4c71-aec6-1ea7e9207e02.png)
