### PR TITLE
chore(internal): add manual demo and link for manual testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ pnpm run build:preview
 npx http-server ./dist
 ```
 
+Note that changes to config or build scripts will require re-running `pnpm start`.
+
+## Previewing manual tests locally
+
+```bash
+pnpm build
+```
+
+then, open the `manual-test.html`
+```bash
+firefox ./manual-test.html
+```
+
+Or, along with the tailwind-preview
+```bash
+pnpm start
+```
+
+and visit `http://localhost:8080/manual`
+
 ## Importing colors and shadows from Figma
 
 This addon provides the ability to pull our palette information directly from Figma files and store them in

--- a/lib/build-preview.mjs
+++ b/lib/build-preview.mjs
@@ -68,6 +68,11 @@ async function main() {
     await execa('cp', ['./toucan.css', './dist/css/toucan.css'], { cwd: root });
   }
 
+  // Setup our manual test page(s)
+  await fse.mkdirp(path.join(root, './dist/manual'));
+  await execa('cp', ['./manual-test.html', './dist/manual/index.html'], { cwd: root });
+  await execa('cp', ['./toucan.css', './dist/manual/toucan.css'], { cwd: root });
+
   // Apply the same fingerprint to toucan as exists on the default CSS
   let fingerprint = cssFiles[0].split('.')[1];
   let newName = `toucan.${fingerprint}.css`;
@@ -133,6 +138,10 @@ async function main() {
         -->
       </head>
       <body class="theme-light">
+        <div class="p-2">
+          <a class="underline interactive-link" href="/manual">View Manual Tests</a>
+        </div>
+
         <noscript><strong>We're sorry but tailwind-config-viewer doesn't work properly without JavaScript enabled. Please enable it to continue.</strong></noscript>
         <div id=app></div>
 

--- a/manual-test.html
+++ b/manual-test.html
@@ -1,0 +1,42 @@
+  <!DOCTYPE html>
+  <html lang=en>
+    <head>
+      <meta charset=utf-8>
+      <meta http-equiv=X-UA-Compatible content="IE=edge">
+      <meta name=viewport content="width=device-width,initial-scale=1">
+      <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAELklEQVR4Ac2XA5T0SBSFe23bVlfSaxsdrG3btm3btm3btvn/+28H3WNnv9vT2ZP1eCbn3JNKTabqvvvue5XODfuV5HJjDT+J43NjDzupZJNNxhkWEkExv3q9v+h0GierrDJusklunL8oM7hX6Fibha65Llln8Yn1/NsqZtLYWWileJVFptTzJ5uY8QdfBc+6GRJPhv68k6ekIs+clqqRQGJQUzKK6APXPAuJT+I1F5pDc5FnXRi61h2pMndCRj4ZcCLPkfeSu9BMZacwFyQeAg2/OXm/SsI1V0LqlcAzS2Z9ITIQGXvAyMSetUroWcc3+YVZifrset9KSMMF5bXsqUI3fxAkvo1c65TUF1kyShP3/pMJHHM0ET9Qcc28ENqQTSPwJRuvFRXtNRm/B36IXWu/eqcw/T81NFLU+zRJznQcO9ZxbPIxBtyiUlxovkjmdEwbc1f9toZZgfTc0rV2IYHod7xzJioVpdI/kklLurdNSJuz0VcyYOgXlokde30IvCFEjrW2UtUBiQQw1xq41jvczwcbjfGtebT5Xz2mFPVKCSKbrRq9Z75RpFHRLE8qjlSpBqQHgqc3rWknZc9KWteyExHSWCnivdu571zyCgv81S89OpiyagSuvQZkHmHBN0nFAZDauiq9Z2/C/fn2tVDBs5r4eydpSZoh1QmZRt8WmR/5n6t5b4XM+j3rrMpf9lnSR+Qfo17CwvujwgbM7cE4qXRH3gG6QHvk4pkaGfmFcYMMrmbWYyX+7cUAP7DBRfhj0+4SNXdrk5pRkxQpGdAsRTRXopoywfXsCukL6pLZuZ9XX3Ca2LV3UE+I/fyiLF5WtBBryZKIgEjUFKqPUgIo0eOPlDqMFDlmz8DJL63nRjrmmNWtGbILhfSFFgg0qHl1y9+VQZt8ogr6yp93guz6Pe4VsWsWZoHzJD33E8jnMzonVCn6e2ndBSYjBSfFnknaqAhFXGasZykhYlTNmNDJH8d9qV+dwiTp2sf/lymzDL9D7sjL78aCj4JKst4ikjgAhwVefnVIrYYx94XIW/q7KkNgvkk+AFSGVTUkxF8DO/W8LEH21FQ6VAngYfrEF+BqKuJUortO5wgbX0Bzui9GdpUic2WIxYzDAJ8oXWpgJcds3mMz/ltL1QlKNDsi97oiwcJ1IGaj37g3gi6ZUVCjEiDcVDPmqLhoFunV1/Od6cn3D7mrozrUPSV1nWelVZDoZK1FXQ+eBCcqnRB5Qn2lz5/y4I+juFbfE0LgCJUeiohAK6XXAd5hfHLJsRfPrqGvL971BuR3RZqiaI3Fp8AjF8j5yTqFajfUBw3YJfLNOjSyBdMmN2if9TKq/KDTlI2/AJXAM9thymNQ6BARTjuixoP620LfCxC4Xf5ITZtGr82H5KeeZBeG9EePOtxfDx1Fnna+IbvS0s2N5Ot396LRwiTPgrkAAAAASUVORK5CYII=" sizes="32x32">
+      <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABt0lEQVR4AaVTA8ydMRTtbMez0X6zzbaP/2O0cGY427YXbXGyxVowb/Fsh/OH2Vt37rxn3KTuOT0XZWSGscpolaixcs0sY5WLAtiq82h3dK8Gplevas8HdaxHeyeGD6/6Q00hijxpDXUVn2Mr3teVPPRqVKcmf9QkWZVDaKQqq3ve8O4NHcUXO5pvcbWYTY3IMrlmkskqy1iKi7TpqS4VjuRbANwDgh225AehaifGkY9CvWqzFEtTQ1lwlQgAtA5K9gO4FqqOoH3B/nmMmz3Nwy8Vb5xG8i+bI0Xz57LLWIAWoE0B4UVT0d189FsGBAZE10E+jVT9l/ZUSS9k19Z4rZ0zRkiA3E8Bi8BfTLibgZuvHV/XZgx219euxn8EXgQB1dYAW4uYLbvMfO7v1IECjPbRUeLLLxWPXCmCLFtgKCsvJE/g4gG0rY4W4xHgw3j5Flx6hr1PGA32zjqqC89dZKNF52djeHfEY7VD0rV4h/EN1FwF4QkbscpYytRSiQB8QDFAlo5R8VH6H/k7t8z+J6gCJ/WqRhdpTfGAgmXIwjxPd2rFCraULL0IWI2I1NB/wSMFE2S7/B0dkODci9GKYgAAAABJRU5ErkJggg==" sizes="16x16">
+
+      <title>CrowdStrike Toucan | Manual Testing</title>
+
+      <link rel="stylesheet" href="./toucan.css">
+
+    </head>
+    <body class="theme-light bg-ground-floor text-body-and-labels p-4">
+      <label id='theme-switcher'>
+        Dark Mode?
+        <input type="checkbox">
+      </label>
+      <hr class="my-4">
+
+      <fieldset>
+        <legend>.textbox</legend>
+        <input class="textbox" placeholder="Placeholder text">
+      </fieldset>
+
+
+      <script type="module">
+        document.querySelector('#theme-switcher').addEventListener('change', (e) => {
+          let isDark = e.target.checked;
+
+          if (isDark) {
+            document.body.classList.remove('theme-light');
+            document.body.classList.add('theme-dark');
+          } else {
+            document.body.classList.add('theme-light');
+            document.body.classList.remove('theme-dark');
+          }
+        })
+      </script>
+    </body>
+  </html>


### PR DESCRIPTION
This allows testing colors, contrast, interaction, etc

**Why**

We need an easy demo page for manually testing accessibility of our colors / styles.

Someone "needing to test something real quick" can add / edit the `manual-test.html` to set up their scenario and observe how it looks in both light and dark mode.

**Test Plan**

(at least until I get preview URLs working from forks, see exploration here: https://github.com/CrowdStrike/tailwind-toucan-base/pull/62)

1. `git clone https://github.com/NullVoxPopuli/tailwind-toucan-base.git`
2. `cd tailwind-toucan-base`
3. `git checkout add-manual-demo-page`
4. `pnpm install`
5. `pnpm start`
6. visit http://localhost:8080
7. see link at the top: ![image](https://user-images.githubusercontent.com/199018/176259935-fecca32d-83b0-45ef-9a92-9e5ae09c8cf2.png) 
8. see page: ![image](https://user-images.githubusercontent.com/199018/176260003-f1a9515c-47ef-4d33-96ad-b5fccbba5d17.png) 
    this may also be directly visited via `http://localhost:8080/manual`
    
When deployed, this'll be at https://tailwind-toucan-base.pages.dev/manual
