### PR TITLE
Add Loose Type Utils

### DIFF
--- a/build/theme-json/figma-export.js
+++ b/build/theme-json/figma-export.js
@@ -15,6 +15,8 @@ module.exports = ({ folderPrefix, output, theme }) => {
 
     let colors = grabColors({ folderPrefix, styles });
 
+    themesJson.themes ||= {};
+    themesJson.themes[theme] ||= {};
     themesJson.themes[theme].colors = prepareColorsForJson(colors);
     themesJson.themes[theme].shadows = grabShadows({ folderPrefix, styles });
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   },
   "typesVersions": {
     "*": {
+      "types": [
+        "./src/types.d.ts"
+      ],
       "theme-data": [
         "./src/theme-data.d.ts"
       ]

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,48 @@
+/**
+ * Generic loosley typed version of the strict types provided by
+ * ```ts
+ * import type ThemeData from '@crowdstrike/tailwind-toucan-base/theme-data';
+ * ```
+ */
+export interface ColorInfo {
+  category: string[];
+  hasAlpha: boolean;
+  rgbFill: string;
+  fill: {
+    r: number;
+    g: number;
+    b: number;
+    a: number;
+  };
+  name: string;
+  value: string;
+}
+
+/**
+ * Generic loosley typed version of the strict types provided by
+ * ```ts
+ * import type ThemeData from '@crowdstrike/tailwind-toucan-base/theme-data';
+ * ```
+ */
+export interface Theme {
+  colors: ColorInfo[];
+  cssSelector: string;
+  shadows: Array<{
+    name: string;
+    effects: string[];
+  }>;
+}
+
+/**
+ * Generic loosley typed version of the strict types provided by
+ * ```ts
+ * import type ThemeData from '@crowdstrike/tailwind-toucan-base/theme-data';
+ * ```
+ */
+export interface ThemeData {
+  aliases: { name: string; value: string }[];
+  themes: {
+    dark: Theme;
+    light: Theme;
+  };
+}


### PR DESCRIPTION
Previously, these type utilities were bundled with https://github.com/crowdstrike/ember-toucan-styles

but since "theme-data" now lives in tailwind-toucan-base, the loose types should live here as well.

**Test Plan**

Green