### PR TITLE
fix(#182): remove darkMode from config

### DIFF
--- a/build/preview/tailwind.config.js
+++ b/build/preview/tailwind.config.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   presets: [require('../../src/tailwind.config')],
-  darkMode: false,
 
   theme: {
     configViewer: {


### PR DESCRIPTION
- For tailwind-3.x the config of darkMode [should not be used](https://tailwindcss.com/docs/upgrade-guide)
- It's only annoyance, but when using [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) I get tons of:
> warn - The `darkMode` option in your Tailwind CSS configuration is set to `false`, which now behaves the same as `media`.
> warn - Change `darkMode` to `media` or remove it entirely.
> warn - https://tailwindcss.com/docs/upgrade-guide#remove-dark-mode-configuration
- This PR should ... hopefully fix that