### PR TITLE
feat: Add new read-only-outline shadow

### DIFF
--- a/.changeset/wet-items-brush.md
+++ b/.changeset/wet-items-brush.md
@@ -1,0 +1,5 @@
+---
+"@crowdstrike/tailwind-toucan-base": minor
+---
+
+Added a new "read-only-outline" box-shadow to help build read-only form elements.

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -39,6 +39,7 @@ module.exports = {
       'search-input': 'inset 0 0 0 1px var(--nav-text-secondary)',
       'error-focus-outline':
         'inset 0 0 0 2px var(--critical), 0 0 0 2px var(--surface-base), 0 0 0 4px var(--focus)',
+      'read-only-outline': 'inset 0 0 0 1px var(--disabled)',
       ...boxShadow,
     },
 

--- a/tests/__snapshots__/cdn.test.ts.snap
+++ b/tests/__snapshots__/cdn.test.ts.snap
@@ -34123,6 +34123,11 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.shadow-read-only-outline {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .shadow-2xl {
   --tw-shadow: var(--elevation-2xl);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -34185,6 +34190,11 @@ video {
 
 .hover\\\\:shadow-error-focus-outline:hover {
   --tw-shadow: inset 0 0 0 2px var(--critical), 0 0 0 2px var(--surface-base), 0 0 0 4px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-read-only-outline:hover {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -34253,6 +34263,11 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.group:hover .group-hover\\\\:shadow-read-only-outline {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .group:hover .group-hover\\\\:shadow-2xl {
   --tw-shadow: var(--elevation-2xl);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -34315,6 +34330,11 @@ video {
 
 .focus\\\\:shadow-error-focus-outline:focus {
   --tw-shadow: inset 0 0 0 2px var(--critical), 0 0 0 2px var(--surface-base), 0 0 0 4px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-read-only-outline:focus {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -34383,6 +34403,11 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.focus-within\\\\:shadow-read-only-outline:focus-within {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .focus-within\\\\:shadow-2xl:focus-within {
   --tw-shadow: var(--elevation-2xl);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -34445,6 +34470,11 @@ video {
 
 .focus-visible\\\\:shadow-error-focus-outline:focus-visible {
   --tw-shadow: inset 0 0 0 2px var(--critical), 0 0 0 2px var(--surface-base), 0 0 0 4px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-read-only-outline:focus-visible {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -34513,6 +34543,11 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.active\\\\:shadow-read-only-outline:active {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .active\\\\:shadow-2xl:active {
   --tw-shadow: var(--elevation-2xl);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -34575,6 +34610,11 @@ video {
 
 .disabled\\\\:shadow-error-focus-outline:disabled {
   --tw-shadow: inset 0 0 0 2px var(--critical), 0 0 0 2px var(--surface-base), 0 0 0 4px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-read-only-outline:disabled {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 

--- a/tests/__snapshots__/css-import.test.ts.snap
+++ b/tests/__snapshots__/css-import.test.ts.snap
@@ -34123,6 +34123,11 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.shadow-read-only-outline {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .shadow-2xl {
   --tw-shadow: var(--elevation-2xl);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -34185,6 +34190,11 @@ video {
 
 .hover\\\\:shadow-error-focus-outline:hover {
   --tw-shadow: inset 0 0 0 2px var(--critical), 0 0 0 2px var(--surface-base), 0 0 0 4px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\\\\:shadow-read-only-outline:hover {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -34253,6 +34263,11 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.group:hover .group-hover\\\\:shadow-read-only-outline {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .group:hover .group-hover\\\\:shadow-2xl {
   --tw-shadow: var(--elevation-2xl);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -34315,6 +34330,11 @@ video {
 
 .focus\\\\:shadow-error-focus-outline:focus {
   --tw-shadow: inset 0 0 0 2px var(--critical), 0 0 0 2px var(--surface-base), 0 0 0 4px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\\\\:shadow-read-only-outline:focus {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -34383,6 +34403,11 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.focus-within\\\\:shadow-read-only-outline:focus-within {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .focus-within\\\\:shadow-2xl:focus-within {
   --tw-shadow: var(--elevation-2xl);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -34445,6 +34470,11 @@ video {
 
 .focus-visible\\\\:shadow-error-focus-outline:focus-visible {
   --tw-shadow: inset 0 0 0 2px var(--critical), 0 0 0 2px var(--surface-base), 0 0 0 4px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-visible\\\\:shadow-read-only-outline:focus-visible {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -34513,6 +34543,11 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.active\\\\:shadow-read-only-outline:active {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .active\\\\:shadow-2xl:active {
   --tw-shadow: var(--elevation-2xl);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -34575,6 +34610,11 @@ video {
 
 .disabled\\\\:shadow-error-focus-outline:disabled {
   --tw-shadow: inset 0 0 0 2px var(--critical), 0 0 0 2px var(--surface-base), 0 0 0 4px var(--focus);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.disabled\\\\:shadow-read-only-outline:disabled {
+  --tw-shadow: inset 0 0 0 1px var(--disabled);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 


### PR DESCRIPTION
## 🚀 Description
This PR addes a new `read-only-outline` shadow for our Form read only states.  Here is what this will end up looking like:

<img width="394" alt="Screenshot 2023-04-17 at 8 54 58 AM" src="https://user-images.githubusercontent.com/8069555/232490384-ad0e2969-271f-4e06-8698-28285e635520.png">

## Test Plan

- Visit https://add-readonly-styles.tailwind-toucan-base.pages.dev/#Shadows
- View and verify `shadow-read-only-outline` exists